### PR TITLE
ci: fixing deploy workflow

### DIFF
--- a/.github/workflows/merged.yml
+++ b/.github/workflows/merged.yml
@@ -12,16 +12,114 @@ on:
         type: choice
         options:
         - Debug
-        
+
 permissions:
   id-token: write
   contents: read
 
 jobs:
-  build:
-    name: Build app, run Configuration and UI tests then deploy to TestFlight
+  test_staging_config:
+    name: Run Staging Configuration Tests
     runs-on: macos-13
-    
+    steps:
+      - name: Add Path Globally
+        run: echo "/usr/local/bin" >> $GITHUB_PATH
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          lfs: 'true'
+          fetch-depth: 0
+
+      - name: Lint
+        run: swiftlint --strict
+
+      - name: Run Staging Configuration Tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LC_ALL: "en_US.UTF-8"
+          LANG: "en_US.UTF-8"
+        run: |
+          export GEM_HOME=$HOME/.gem
+          export GEM_PATH=$HOME/.gem
+
+          # Fixes issue with bundle install
+          eval "$(rbenv init - zsh)"
+          bundle install
+
+          bundle exec fastlane testWithoutCoverage scheme:"OneLoginStaging" \
+            testplan:OneLoginStaging
+  
+  test_build_config:
+    name: Run Build Configuration Tests
+    runs-on: macos-13
+    steps:
+      - name: Add Path Globally
+        run: echo "/usr/local/bin" >> $GITHUB_PATH
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          lfs: 'true'
+          fetch-depth: 0
+
+      - name: Lint
+        run: swiftlint --strict
+
+      - name: Run Build Configuration Tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LC_ALL: "en_US.UTF-8"
+          LANG: "en_US.UTF-8"
+        run: |
+          export GEM_HOME=$HOME/.gem
+          export GEM_PATH=$HOME/.gem
+
+          # Fixes issue with bundle install
+          eval "$(rbenv init - zsh)"
+          bundle install
+
+          bundle exec fastlane testWithoutCoverage scheme:"OneLoginBuild" \
+            testplan:OneLoginBuild
+
+  test_ui:
+    name: Run UI Tests
+    runs-on: macos-13
+    steps:
+      - name: Add Path Globally
+        run: echo "/usr/local/bin" >> $GITHUB_PATH
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          lfs: 'true'
+          fetch-depth: 0
+
+      - name: Lint
+        run: swiftlint --strict
+
+      - name: Run UI Tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LC_ALL: "en_US.UTF-8"
+          LANG: "en_US.UTF-8"
+        run: |
+          export GEM_HOME=$HOME/.gem
+          export GEM_PATH=$HOME/.gem
+
+          # Fixes issue with bundle install
+          eval "$(rbenv init - zsh)"
+          bundle install
+
+          bundle exec fastlane testWithoutCoverageForUITests scheme:"OneLoginBuild" \
+            testplan:OneLoginUI
+
+  deploy_apps:
+    if: github.event_name != 'workflow_dispatch'
+    needs: [test_staging_config, test_build_config, test_ui]
+    name: Deploy Staging and Build Apps
+    runs-on: macos-13
+
     steps:
       - name: Add path globally
         run: echo "/usr/local/bin" >> $GITHUB_PATH
@@ -30,13 +128,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           lfs: 'true'
-          
+
       - name: Check Dependencies
         uses: GetSidetrack/action-xcodeproj-spm-update@main
         with:
           workspace: "OneLogin.xcworkspace"
           scheme: "OneLogin"
-          
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
@@ -44,7 +142,7 @@ jobs:
           role-to-assume: ${{ secrets.GITHUBRUNNER_EC2_ACTIONS_ROLE_ARN }}
           role-duration-seconds: 1200
           role-skip-session-tagging: true
-          
+
       - name: Store ENV from AWS SecretManager
         id: secrets
         uses: say8425/aws-secrets-manager-actions@v2.2.1
@@ -52,29 +150,20 @@ jobs:
           AWS_DEFAULT_REGION: "eu-west-2"
           SECRET_NAME: "di-ipv-dca-mob-ios/github-actions-v2"
 
-      - name: Configuration and UITests then Deploy to App Store Connect
-        if: github.event_name != 'workflow_dispatch'
+      - name: Deploy to App Store Connect
         env:
           LC_ALL: "en_US.UTF-8"
           LANG: "en_US.UTF-8"
         run: |
           gitbranch=$(echo ${GITHUB_REF:-dev} | sed s/refs\\/heads\\///g)
           echo Pushed to branch: $gitbranch
-          
+
           export GEM_HOME=$HOME/.gem
           export GEM_PATH=$HOME/.gem
-          
+
           # Fixes issue with bundle install
           eval "$(rbenv init - zsh)"
           bundle install
-          
-          # Testing Staging configuration
-          bundle exec fastlane testWithoutCoverage scheme:"OneLoginStaging" \
-            testplan:OneLoginStaging
-        
-          # Testing Build configuration and UITests
-          bundle exec fastlane testWithoutCoverage scheme:"OneLoginBuild" \
-            testplan:OneLoginBuild
 
           # create variables
           CERTIFICATE_PATH=$RUNNER_TEMP/distribution.p12
@@ -84,50 +173,77 @@ jobs:
           # import certificates from secrets
           echo -n "${{env.AWS_SECRET_DISTRIBUTION_P12_ENCODED}}" | base64 --decode -o $CERTIFICATE_PATH
           echo -n "${{env.AWS_SECRET_AUTH_KEY_P8_ENCODED}}" | base64 --decode -o $APIKEY_PATH
-          
+
           bundle exec fastlane prerelease configuration:"Staging" \
             certificate_path:$CERTIFICATE_PATH \
             certificate_password:$CERTIFICATE_PASSWORD \
             apikey_path:$APIKEY_PATH --verbose
-            
+
           bundle exec fastlane prerelease configuration:"Build" \
             certificate_path:$CERTIFICATE_PATH \
             certificate_password:$CERTIFICATE_PASSWORD \
             apikey_path:$APIKEY_PATH --verbose
-          
+
+  manual_deploy_app:
+    if: github.event_name == 'workflow_dispatch'
+    needs: [test_${{ inputs.build_configuration }}_config, test_ui]
+    name: Manually Deploy App
+    runs-on: macos-13
+
+    steps:
+      - name: Add path globally
+        run: echo "/usr/local/bin" >> $GITHUB_PATH
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          lfs: 'true'
+
+      - name: Check Dependencies
+        uses: GetSidetrack/action-xcodeproj-spm-update@main
+        with:
+          workspace: "OneLogin.xcworkspace"
+          scheme: "OneLogin"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-region: eu-west-2
+          role-to-assume: ${{ secrets.GITHUBRUNNER_EC2_ACTIONS_ROLE_ARN }}
+          role-duration-seconds: 1200
+          role-skip-session-tagging: true
+
+      - name: Store ENV from AWS SecretManager
+        id: secrets
+        uses: say8425/aws-secrets-manager-actions@v2.2.1
+        with:
+          AWS_DEFAULT_REGION: "eu-west-2"
+          SECRET_NAME: "di-ipv-dca-mob-ios/github-actions-v2"
+
       - name: Configuration and UITests then Manual Deploy to App Store Connect
-        if: github.event_name == 'workflow_dispatch'
         env:
           LC_ALL: "en_US.UTF-8"
           LANG: "en_US.UTF-8"
         run: |
           gitbranch=$(echo ${GITHUB_REF:-dev} | sed s/refs\\/heads\\///g)
           echo Pushed to branch: $gitbranch
-            
+
           export GEM_HOME=$HOME/.gem
           export GEM_PATH=$HOME/.gem
-            
+
           # Fixes issue with bundle install
           eval "$(rbenv init - zsh)"
           bundle install
-          
-          # Testing Staging configuration
-          bundle exec fastlane testWithoutCoverage scheme:"OneLoginStaging" \
-            testplan:OneLoginStaging
-        
-          # Testing Build configuration and UITests
-          bundle exec fastlane testWithoutCoverage scheme:"OneLoginBuild" \
-            testplan:OneLoginBuild
-          
+
           # create variables
           CERTIFICATE_PATH=$RUNNER_TEMP/distribution.p12
           CERTIFICATE_PASSWORD="${{env.AWS_SECRET_SIGNING_KEY_PASSWORD}}"
           APIKEY_PATH=$RUNNER_TEMP/apikey.p8
-          
+
           # import certificates from secrets
           echo -n "${{env.AWS_SECRET_DISTRIBUTION_P12_ENCODED}}" | base64 --decode -o $CERTIFICATE_PATH
           echo -n "${{env.AWS_SECRET_AUTH_KEY_P8_ENCODED}}" | base64 --decode -o $APIKEY_PATH
-          
+
           bundle exec fastlane prerelease configuration:${{ inputs.build_configuration }} \
             certificate_path:$CERTIFICATE_PATH \
             certificate_password:$CERTIFICATE_PASSWORD \

--- a/.github/workflows/merged.yml
+++ b/.github/workflows/merged.yml
@@ -3,24 +3,14 @@ name: iOS Deploy
 on:
   push:
     branches: [ develop, release/*, main ]
-  workflow_dispatch:
-    inputs:
-      build_configuration:
-        description: 'Which build configuration to use'
-        required: false
-        default: 'Staging'
-        type: choice
-        options:
-        - Staging
-        - Build
 
 permissions:
   id-token: write
   contents: read
 
 jobs:
-  test_staging_config:
-    name: Run Staging Configuration Tests
+  run_swiftlint:
+    name: Run Swiftlint
     runs-on: macos-13
     steps:
       - name: Add Path Globally
@@ -34,6 +24,20 @@ jobs:
 
       - name: Lint
         run: swiftlint --strict
+
+  test_staging_config:
+    needs: run_swiftlint
+    name: Run Staging Configuration Tests
+    runs-on: macos-13
+    steps:
+      - name: Add Path Globally
+        run: echo "/usr/local/bin" >> $GITHUB_PATH
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          lfs: 'true'
+          fetch-depth: 0
 
       - name: Run Staging Configuration Tests
         env:
@@ -52,6 +56,7 @@ jobs:
             testplan:OneLoginStaging
   
   test_build_config:
+    needs: run_swiftlint
     name: Run Build Configuration Tests
     runs-on: macos-13
     steps:
@@ -63,9 +68,6 @@ jobs:
         with:
           lfs: 'true'
           fetch-depth: 0
-
-      - name: Lint
-        run: swiftlint --strict
 
       - name: Run Build Configuration Tests
         env:
@@ -84,6 +86,7 @@ jobs:
             testplan:OneLoginBuild
 
   test_ui:
+    needs: run_swiftlint
     name: Run UI Tests
     runs-on: macos-13
     steps:
@@ -95,9 +98,6 @@ jobs:
         with:
           lfs: 'true'
           fetch-depth: 0
-
-      - name: Lint
-        run: swiftlint --strict
 
       - name: Run UI Tests
         env:
@@ -116,11 +116,9 @@ jobs:
             testplan:OneLoginUI
 
   deploy_apps:
-    if: github.event_name != 'workflow_dispatch'
     needs: [test_staging_config, test_build_config, test_ui]
     name: Deploy Staging and Build Apps
     runs-on: macos-13
-
     steps:
       - name: Add path globally
         run: echo "/usr/local/bin" >> $GITHUB_PATH
@@ -181,71 +179,6 @@ jobs:
             apikey_path:$APIKEY_PATH --verbose
 
           bundle exec fastlane prerelease configuration:"Build" \
-            certificate_path:$CERTIFICATE_PATH \
-            certificate_password:$CERTIFICATE_PASSWORD \
-            apikey_path:$APIKEY_PATH --verbose
-
-  manual_deploy_app:
-    if: github.event_name == 'workflow_dispatch'
-    needs: [test_${{ inputs.build_configuration }}_config, test_ui]
-    name: Manually Deploy App
-    runs-on: macos-13
-
-    steps:
-      - name: Add path globally
-        run: echo "/usr/local/bin" >> $GITHUB_PATH
-
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          lfs: 'true'
-
-      - name: Check Dependencies
-        uses: GetSidetrack/action-xcodeproj-spm-update@main
-        with:
-          workspace: "OneLogin.xcworkspace"
-          scheme: "OneLogin"
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          aws-region: eu-west-2
-          role-to-assume: ${{ secrets.GITHUBRUNNER_EC2_ACTIONS_ROLE_ARN }}
-          role-duration-seconds: 1200
-          role-skip-session-tagging: true
-
-      - name: Store ENV from AWS SecretManager
-        id: secrets
-        uses: say8425/aws-secrets-manager-actions@v2.2.1
-        with:
-          AWS_DEFAULT_REGION: "eu-west-2"
-          SECRET_NAME: "di-ipv-dca-mob-ios/github-actions-v2"
-
-      - name: Configuration and UITests then Manual Deploy to App Store Connect
-        env:
-          LC_ALL: "en_US.UTF-8"
-          LANG: "en_US.UTF-8"
-        run: |
-          gitbranch=$(echo ${GITHUB_REF:-dev} | sed s/refs\\/heads\\///g)
-          echo Pushed to branch: $gitbranch
-
-          export GEM_HOME=$HOME/.gem
-          export GEM_PATH=$HOME/.gem
-
-          # Fixes issue with bundle install
-          eval "$(rbenv init - zsh)"
-          bundle install
-
-          # create variables
-          CERTIFICATE_PATH=$RUNNER_TEMP/distribution.p12
-          CERTIFICATE_PASSWORD="${{env.AWS_SECRET_SIGNING_KEY_PASSWORD}}"
-          APIKEY_PATH=$RUNNER_TEMP/apikey.p8
-
-          # import certificates from secrets
-          echo -n "${{env.AWS_SECRET_DISTRIBUTION_P12_ENCODED}}" | base64 --decode -o $CERTIFICATE_PATH
-          echo -n "${{env.AWS_SECRET_AUTH_KEY_P8_ENCODED}}" | base64 --decode -o $APIKEY_PATH
-
-          bundle exec fastlane prerelease configuration:${{ inputs.build_configuration }} \
             certificate_path:$CERTIFICATE_PATH \
             certificate_password:$CERTIFICATE_PASSWORD \
             apikey_path:$APIKEY_PATH --verbose

--- a/.github/workflows/merged.yml
+++ b/.github/workflows/merged.yml
@@ -8,10 +8,11 @@ on:
       build_configuration:
         description: 'Which build configuration to use'
         required: false
-        default: 'Debug'
+        default: 'Staging'
         type: choice
         options:
-        - Debug
+        - Staging
+        - Build
 
 permissions:
   id-token: write

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		C873B1DF2AF826D3002C39E8 /* BuildAppEnvironmentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuildAppEnvironmentTests.swift; sourceTree = "<group>"; };
 		C873B1E12AF826D3002C39E8 /* StagingAppEnvironmentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StagingAppEnvironmentTests.swift; sourceTree = "<group>"; };
 		C880DDE12AEAB6C100020796 /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
+		C8C57CE32B0237620010D395 /* OneLoginUI.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = OneLoginUI.xctestplan; sourceTree = "<group>"; };
 		C8EBE8032AEFB7FF009B8A06 /* LoginSessionConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginSessionConfigurationTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -445,6 +446,7 @@
 				C873B1D72AF82403002C39E8 /* OneLoginUnit.xctestplan */,
 				C873B1D62AF82403002C39E8 /* OneLoginStaging.xctestplan */,
 				C873B1D52AF82403002C39E8 /* OneLoginBuild.xctestplan */,
+				C8C57CE32B0237620010D395 /* OneLoginUI.xctestplan */,
 			);
 			path = "Test Plans";
 			sourceTree = "<group>";

--- a/OneLogin.xcodeproj/xcshareddata/xcschemes/OneLoginBuild.xcscheme
+++ b/OneLogin.xcodeproj/xcshareddata/xcschemes/OneLoginBuild.xcscheme
@@ -35,6 +35,9 @@
          <TestPlanReference
             reference = "container:Tests/Test Plans/OneLoginUnit.xctestplan">
          </TestPlanReference>
+         <TestPlanReference
+            reference = "container:Tests/Test Plans/OneLoginUI.xctestplan">
+         </TestPlanReference>
       </TestPlans>
    </TestAction>
    <LaunchAction

--- a/Tests/Test Plans/OneLoginUI.xctestplan
+++ b/Tests/Test Plans/OneLoginUI.xctestplan
@@ -1,7 +1,7 @@
 {
   "configurations" : [
     {
-      "id" : "C24D5860-85C4-456A-810D-FD351C8AC13D",
+      "id" : "1B984F0D-A558-42A1-8956-E8DFC957CBEE",
       "name" : "Configuration 1",
       "options" : {
 
@@ -9,14 +9,14 @@
     }
   ],
   "defaultOptions" : {
-
+    "testTimeoutsEnabled" : true
   },
   "testTargets" : [
     {
       "target" : {
         "containerPath" : "container:OneLogin.xcodeproj",
-        "identifier" : "25537C4D2AF2B38E0059DCD2",
-        "name" : "OneLoginBuildConfigTests"
+        "identifier" : "219602062A976305008F3427",
+        "name" : "OneLoginUITests"
       }
     }
   ],

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,11 +16,11 @@ require 'securerandom'
 ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "600"
 
 default_platform(:ios)
-xcode_select("/Applications/Xcode_15.0.1.app")
 
 platform :ios do
   desc "Run Tests without Sonar Coverage"
   lane :testWithoutCoverage do |options|
+    xcode_select("/Applications/Xcode_15.0.1.app")
 
     clear_derived_data
       
@@ -32,9 +32,25 @@ platform :ios do
       testplan: options[:testplan]
     )
   end
+  
+  desc "Run Tests without Sonar Coverage"
+  lane :testWithoutCoverageForUITests do |options|
+    xcode_select("/Applications/Xcode_14.3.1.app")
+
+    clear_derived_data
+      
+    run_tests(
+      workspace: "OneLogin.xcworkspace",
+      device: "iPhone SE (3rd generation) (16.4)",
+      result_bundle: true,
+      scheme: options[:scheme],
+      testplan: options[:testplan]
+    )
+  end
 
   desc "Run Tests and Output Code Coverage"
   lane :test do |options|
+    xcode_select("/Applications/Xcode_15.0.1.app")
 
     clear_derived_data
       
@@ -74,6 +90,8 @@ platform :ios do
     
   desc "Push a new beta build to TestFlight"
   lane :prerelease do |options|
+    xcode_select("/Applications/Xcode_15.0.1.app")
+    
     clear_derived_data
 
     password = SecureRandom.hex


### PR DESCRIPTION
# DCMAW-7375: iOS | Fixing deploy workflow using github build agents

We’ve been blocked deploying builds to Testflight in Staging and Build because the github build agents were timing out or failing UITests.

This PR fixes that problem, using Xcode 14.3.1 with iOS 16.4.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
