### PR TITLE
Add mobile-platform team as codeowners on iOS one login app repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,3 @@
-# This is the CODEOWNERS file. These owners will be the default owners for everything in the DI-IPV-DCA-iOS repository
-# The following below will be requested for review when someone opens a pull request.
+# The following team(s) will be requested for review when someone opens a pull request in this repository.
 
-
-*  @alphagov/di-doc-checking-shark-iOS
+* @govuk-one-login/mobile-platform


### PR DESCRIPTION
# Add mobile-platform team as codeowners on iOS one login app repository

Aligns code ownership on this repository with documentation here https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3791945770/Mobile+Platform+repositories+and+Github+Teams

# Checklist

I've checked things I think are relevant on this change. 

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [ ] Ran the app locally ensuring it builds 
- [ ] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
