### PR TITLE
ci: adding camera use description

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -938,6 +938,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "OneLogin-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "One Login";
+				INFOPLIST_KEY_NSCameraUsageDescription = "This app does not use the camera";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -1383,6 +1384,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "OneLogin-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "One Login - Build";
+				INFOPLIST_KEY_NSCameraUsageDescription = "This app does not use the camera";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -140,7 +140,7 @@ platform :ios do
       build_number = latest_testflight_build_number(
         app_identifier: app_identifier,
         version: version
-      ) + 1
+      ) + 3
 
       increment_build_number(
         xcodeproj: project_name,


### PR DESCRIPTION
# DCMAW-7388: iOS | Add Camera use description

When deploying builds of the app to Testflight for One Login Staging and Build the build was rejected because an entitlement for camera usage was not given a camera use description.
Furthermore, the build automatically rejected by App Store Connect is still counted but not exposed through the App Store Connect interface or API. Retrying the deploy action then created conflicts as the incremented build number created in the workflow was already accounted for on the App Store Connect side.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
~- [] Written Unit and Integration tests if needed~

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
