### PR TITLE
feat: enabling universal link

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -51,6 +51,8 @@
 		C8A13CAB2AFBD0CC00FCBD36 /* HTTPLogging in Frameworks */ = {isa = PBXBuildFile; productRef = C8A13CAA2AFBD0CC00FCBD36 /* HTTPLogging */; };
 		C8A13CAD2AFBD0CC00FCBD36 /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = C8A13CAC2AFBD0CC00FCBD36 /* Logging */; };
 		C8A13CB02AFBD0F100FCBD36 /* Coordination in Frameworks */ = {isa = PBXBuildFile; productRef = C8A13CAF2AFBD0F100FCBD36 /* Coordination */; };
+		C8B320792B062F9100FECDF0 /* AuthenticationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B320782B062F9100FECDF0 /* AuthenticationCoordinator.swift */; };
+		C8B3207B2B063CA100FECDF0 /* AuthenticationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B3207A2B063CA100FECDF0 /* AuthenticationCoordinatorTests.swift */; };
 		C8EBE8042AEFB7FF009B8A06 /* LoginSessionConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8EBE8032AEFB7FF009B8A06 /* LoginSessionConfigurationTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -128,6 +130,8 @@
 		C873B1DF2AF826D3002C39E8 /* BuildAppEnvironmentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuildAppEnvironmentTests.swift; sourceTree = "<group>"; };
 		C873B1E12AF826D3002C39E8 /* StagingAppEnvironmentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StagingAppEnvironmentTests.swift; sourceTree = "<group>"; };
 		C880DDE12AEAB6C100020796 /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
+		C8B320782B062F9100FECDF0 /* AuthenticationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationCoordinator.swift; sourceTree = "<group>"; };
+		C8B3207A2B063CA100FECDF0 /* AuthenticationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationCoordinatorTests.swift; sourceTree = "<group>"; };
 		C8C57CE32B0237620010D395 /* OneLoginUI.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = OneLoginUI.xctestplan; sourceTree = "<group>"; };
 		C8EBE8032AEFB7FF009B8A06 /* LoginSessionConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginSessionConfigurationTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -342,6 +346,7 @@
 			children = (
 				219602012A976305008F3427 /* MainCoordinatorTests.swift */,
 				C85DF8472AEBFE6D0064F68E /* Welcome */,
+				C8B3207A2B063CA100FECDF0 /* AuthenticationCoordinatorTests.swift */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -410,6 +415,7 @@
 			children = (
 				C85E21032ACEE34900AF8B4E /* MainCoordinator.swift */,
 				C85E210B2ACEE92900AF8B4E /* Welcome */,
+				C8B320782B062F9100FECDF0 /* AuthenticationCoordinator.swift */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -734,6 +740,7 @@
 				3BBF28F32A9F7D3200491BB1 /* AppDelegate.swift in Sources */,
 				C8098B972AEFF1AB001517A0 /* LoginSessionConfiguration+OneLogin.swift in Sources */,
 				C8098B992AEFF287001517A0 /* AnalyticsService+GDS.swift in Sources */,
+				C8B320792B062F9100FECDF0 /* AuthenticationCoordinator.swift in Sources */,
 				C85E21042ACEE34900AF8B4E /* MainCoordinator.swift in Sources */,
 				C880DDE22AEAB6C100020796 /* AppEnvironment.swift in Sources */,
 				21E04DFA2AE6B52B004C6660 /* OneLoginAnalyticsService.swift in Sources */,
@@ -752,6 +759,7 @@
 				21FA1C4D2AE183D20052136E /* MockLoginSession.swift in Sources */,
 				C8520C272AE2C0D1006790C1 /* IntroViewControllerTests.swift in Sources */,
 				21FA1C502AE18C8B0052136E /* OneLoginIntroViewModelTests.swift in Sources */,
+				C8B3207B2B063CA100FECDF0 /* AuthenticationCoordinatorTests.swift in Sources */,
 				21E04DFC2AE6BC5B004C6660 /* MockAnalyticsService.swift in Sources */,
 				C8520C252AE2BFAD006790C1 /* UIView+TestExtensions.swift in Sources */,
 				C8520C2E2AE2C822006790C1 /* MockTokenResponse.swift in Sources */,

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 		C8520C292AE2C1C5006790C1 /* OnboardingViewControllerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewControllerFactory.swift; sourceTree = "<group>"; };
 		C8520C2D2AE2C822006790C1 /* MockTokenResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTokenResponse.swift; sourceTree = "<group>"; };
 		C85966472AEC31AE006DF61D /* OnboardingViewControllerFactoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingViewControllerFactoryTests.swift; sourceTree = "<group>"; };
+		C85BD2412B03DC8800DE1D4B /* OneLoginBuild.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = OneLoginBuild.entitlements; sourceTree = "<group>"; };
 		C85DF8492AEBFF180064F68E /* MockOneLoginIntroViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOneLoginIntroViewModel.swift; sourceTree = "<group>"; };
 		C85E21032ACEE34900AF8B4E /* MainCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainCoordinator.swift; sourceTree = "<group>"; };
 		C85E210C2ACEE93C00AF8B4E /* OneLoginIntroViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneLoginIntroViewModel.swift; sourceTree = "<group>"; };
@@ -178,6 +179,7 @@
 		219601DE2A976302008F3427 = {
 			isa = PBXGroup;
 			children = (
+				C85BD2412B03DC8800DE1D4B /* OneLoginBuild.entitlements */,
 				3BBF28F52A9F7D4900491BB1 /* OneLogin-Info.plist */,
 				3BBF28E42A9F7D3200491BB1 /* Sources */,
 				219602002A976305008F3427 /* Tests */,
@@ -1419,6 +1421,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				AUTHORIZE_URL = "auth-stub.mobile.build.account.gov.uk";
 				CLIENT_ID = TEST_CLIENT_ID;
+				CODE_SIGN_ENTITLEMENTS = OneLoginBuild.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = N8W395F695;

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		3BBF28F12A9F7D3200491BB1 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3BBF28E82A9F7D3200491BB1 /* LaunchScreen.storyboard */; };
 		3BBF28F32A9F7D3200491BB1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BBF28ED2A9F7D3200491BB1 /* AppDelegate.swift */; };
 		3BBF28F42A9F7D3200491BB1 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BBF28EE2A9F7D3200491BB1 /* SceneDelegate.swift */; };
+		412B95A12B0529FB00C390B2 /* OneLoginStaging.entitlements in Resources */ = {isa = PBXBuildFile; fileRef = 412B95A02B0529B800C390B2 /* OneLoginStaging.entitlements */; };
+		412B95A22B0529FE00C390B2 /* OneLoginBuild.entitlements in Resources */ = {isa = PBXBuildFile; fileRef = C85BD2412B03DC8800DE1D4B /* OneLoginBuild.entitlements */; };
 		C8098B972AEFF1AB001517A0 /* LoginSessionConfiguration+OneLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8098B962AEFF1AB001517A0 /* LoginSessionConfiguration+OneLogin.swift */; };
 		C8098B992AEFF287001517A0 /* AnalyticsService+GDS.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8098B982AEFF287001517A0 /* AnalyticsService+GDS.swift */; };
 		C80B871A2B029E230087C6D5 /* LoginUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80B87192B029E230087C6D5 /* LoginUITests.swift */; };
@@ -99,6 +101,7 @@
 		3BBF28ED2A9F7D3200491BB1 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		3BBF28EE2A9F7D3200491BB1 /* SceneDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		3BBF28F52A9F7D4900491BB1 /* OneLogin-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "OneLogin-Info.plist"; sourceTree = "<group>"; };
+		412B95A02B0529B800C390B2 /* OneLoginStaging.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = OneLoginStaging.entitlements; sourceTree = "<group>"; };
 		C8098B962AEFF1AB001517A0 /* LoginSessionConfiguration+OneLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoginSessionConfiguration+OneLogin.swift"; sourceTree = "<group>"; };
 		C8098B982AEFF287001517A0 /* AnalyticsService+GDS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnalyticsService+GDS.swift"; sourceTree = "<group>"; };
 		C80B87192B029E230087C6D5 /* LoginUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginUITests.swift; sourceTree = "<group>"; };
@@ -179,6 +182,7 @@
 		219601DE2A976302008F3427 = {
 			isa = PBXGroup;
 			children = (
+				412B95A02B0529B800C390B2 /* OneLoginStaging.entitlements */,
 				C85BD2412B03DC8800DE1D4B /* OneLoginBuild.entitlements */,
 				3BBF28F52A9F7D4900491BB1 /* OneLogin-Info.plist */,
 				3BBF28E42A9F7D3200491BB1 /* Sources */,
@@ -656,6 +660,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				412B95A22B0529FE00C390B2 /* OneLoginBuild.entitlements in Resources */,
+				412B95A12B0529FB00C390B2 /* OneLoginStaging.entitlements in Resources */,
 				C873B1D82AF82403002C39E8 /* OneLoginBuild.xctestplan in Resources */,
 				3BBF28F02A9F7D3200491BB1 /* Assets.xcassets in Resources */,
 				3BBF28F12A9F7D3200491BB1 /* LaunchScreen.storyboard in Resources */,
@@ -1240,6 +1246,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				AUTHORIZE_URL = oidc.integration.account.gov.uk;
 				CLIENT_ID = sdJChz1oGajIz0O0tdPdh0CA2zW;
+				CODE_SIGN_ENTITLEMENTS = OneLoginStaging.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = N8W395F695;

--- a/OneLoginBuild.entitlements
+++ b/OneLoginBuild.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:www.mobile.build.account.gov.uk</string>
+		<string>applinks:mobile.build.account.gov.uk</string>
 	</array>
 </dict>
 </plist>

--- a/OneLoginBuild.entitlements
+++ b/OneLoginBuild.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:www.mobile.build.account.gov.uk</string>
+	</array>
+</dict>
+</plist>

--- a/OneLoginStaging.entitlements
+++ b/OneLoginStaging.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:www.mobile.staging.account.gov.uk</string>
+		<string>applinks:mobile.staging.account.gov.uk</string>
 	</array>
 </dict>
 </plist>

--- a/OneLoginStaging.entitlements
+++ b/OneLoginStaging.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:www.mobile.staging.account.gov.uk</string>
+	</array>
+</dict>
+</plist>

--- a/Sources/Application/SceneDelegate.swift
+++ b/Sources/Application/SceneDelegate.swift
@@ -17,6 +17,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let session = AppAuthSession(window: window!)
         initialiseMainCoordinator(in: window!,
                                   session: session)
+        if let webURL = connectionOptions.userActivities.first?.webpageURL {
+            print(webURL)
+        }
+    }
+    
+    func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+        print(userActivity.webpageURL!)
     }
     
     func initialiseMainCoordinator(in window: UIWindow,

--- a/Sources/Application/SceneDelegate.swift
+++ b/Sources/Application/SceneDelegate.swift
@@ -5,7 +5,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
     var coordinator: MainCoordinator?
     let navigationController = UINavigationController()
-
+    
     func scene(_ scene: UIScene,
                willConnectTo session: UISceneSession,
                options connectionOptions: UIScene.ConnectionOptions) {
@@ -15,24 +15,20 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         window = UIWindow(windowScene: windowScene)
         let session = AppAuthSession(window: window!)
-        initialiseMainCoordinator(in: window!,
-                                  session: session)
-        if let webURL = connectionOptions.userActivities.first?.webpageURL {
-            print(webURL)
-        }
+        initialiseMainCoordinator(session: session)
     }
     
     func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
-        print(userActivity.webpageURL!)
+        if let incomingURL = userActivity.webpageURL {
+            coordinator?.authCoordinator?.handleDeepLink(incomingURL)
+        }
     }
     
-    func initialiseMainCoordinator(in window: UIWindow,
-                                   session: LoginSession) {
-        coordinator = MainCoordinator(window: window,
-                                      root: navigationController,
+    func initialiseMainCoordinator(session: LoginSession) {
+        coordinator = MainCoordinator(root: navigationController,
                                       session: session)
+        window!.rootViewController = navigationController
+        window!.makeKeyAndVisible()
         coordinator?.start()
-        window.rootViewController = navigationController
-        window.makeKeyAndVisible()
     }
 }

--- a/Sources/Application/SceneDelegate.swift
+++ b/Sources/Application/SceneDelegate.swift
@@ -19,9 +19,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
     
     func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
-        if let incomingURL = userActivity.webpageURL {
-            coordinator?.authCoordinator?.handleUniversalLink(incomingURL)
-        }
+        guard let incomingURL = userActivity.webpageURL,
+              let authCoordinator = coordinator?.childCoordinators.first(where: { $0 is AuthenticationCoordinator }) as? AuthenticationCoordinator else { return }
+        authCoordinator.handleUniversalLink(incomingURL)
     }
     
     func initialiseMainCoordinator(session: LoginSession) {

--- a/Sources/Application/SceneDelegate.swift
+++ b/Sources/Application/SceneDelegate.swift
@@ -20,7 +20,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
         guard let incomingURL = userActivity.webpageURL,
-              let authCoordinator = coordinator?.childCoordinators.first(where: { $0 is AuthenticationCoordinator }) as? AuthenticationCoordinator else { return }
+              let authCoordinator = coordinator?.childCoordinators
+            .first(where: { $0 is AuthenticationCoordinator }) as? AuthenticationCoordinator else { return }
         authCoordinator.handleUniversalLink(incomingURL)
     }
     

--- a/Sources/Application/SceneDelegate.swift
+++ b/Sources/Application/SceneDelegate.swift
@@ -20,7 +20,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
         if let incomingURL = userActivity.webpageURL {
-            coordinator?.authCoordinator?.handleDeepLink(incomingURL)
+            coordinator?.authCoordinator?.handleUniversalLink(incomingURL)
         }
     }
     

--- a/Sources/Onboarding/AuthenticationCoordinator.swift
+++ b/Sources/Onboarding/AuthenticationCoordinator.swift
@@ -6,7 +6,7 @@ final class AuthenticationCoordinator: NSObject,
                                        ChildCoordinator,
                                        NavigationCoordinator {
     let root: UINavigationController
-    let parentCoordinator: ParentCoordinator?
+    var parentCoordinator: ParentCoordinator?
     let session: LoginSession
     
     init(root: UINavigationController,

--- a/Sources/Onboarding/AuthenticationCoordinator.swift
+++ b/Sources/Onboarding/AuthenticationCoordinator.swift
@@ -5,8 +5,8 @@ import UIKit
 final class AuthenticationCoordinator: NSObject,
                                        ChildCoordinator,
                                        NavigationCoordinator {
-    var root: UINavigationController
-    var parentCoordinator: ParentCoordinator?
+    let root: UINavigationController
+    let parentCoordinator: ParentCoordinator?
     let session: LoginSession
     
     init(root: UINavigationController,

--- a/Sources/Onboarding/AuthenticationCoordinator.swift
+++ b/Sources/Onboarding/AuthenticationCoordinator.swift
@@ -21,13 +21,6 @@ final class AuthenticationCoordinator: NSObject,
     }
     
     func handleUniversalLink(_ url: URL) {
-        print(url)
-        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true) else { return }
-        
-        guard let authCode = components.queryItems?.first(where: { $0.name == "code" })?.value,
-              let state = components.queryItems?.first(where: { $0.name == "state" })?.value else { return }
-        
-        print(authCode)
-        print(state)
+        // This method will contain the call to throwing session.finalise(url:) and errors will be handled with qualifying the URL
     }
 }

--- a/Sources/Onboarding/AuthenticationCoordinator.swift
+++ b/Sources/Onboarding/AuthenticationCoordinator.swift
@@ -20,7 +20,14 @@ final class AuthenticationCoordinator: NSObject,
         session.present(configuration: configuration)
     }
     
-    func handleDeepLink(_ url: URL) {
+    func handleUniversalLink(_ url: URL) {
         print(url)
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true) else { return }
+        
+        guard let authCode = components.queryItems?.first(where: { $0.name == "code" })?.value,
+              let state = components.queryItems?.first(where: { $0.name == "state" })?.value else { return }
+        
+        print(authCode)
+        print(state)
     }
 }

--- a/Sources/Onboarding/AuthenticationCoordinator.swift
+++ b/Sources/Onboarding/AuthenticationCoordinator.swift
@@ -1,0 +1,26 @@
+import Authentication
+import Coordination
+import UIKit
+
+final class AuthenticationCoordinator: NSObject,
+                                       ChildCoordinator,
+                                       NavigationCoordinator {
+    var root: UINavigationController
+    var parentCoordinator: ParentCoordinator?
+    let session: LoginSession
+    
+    init(root: UINavigationController,
+         session: LoginSession) {
+        self.root = root
+        self.session = session
+    }
+    
+    func start() {
+        let configuration = LoginSessionConfiguration.oneLogin
+        session.present(configuration: configuration)
+    }
+    
+    func handleDeepLink(_ url: URL) {
+        print(url)
+    }
+}

--- a/Sources/Onboarding/MainCoordinator.swift
+++ b/Sources/Onboarding/MainCoordinator.swift
@@ -4,26 +4,30 @@ import Logging
 import UIKit
 
 final class MainCoordinator: NSObject,
+                             ParentCoordinator,
                              NavigationCoordinator {
-    private let window: UIWindow
     let root: UINavigationController
     let session: LoginSession
     let analyticsService: AnalyticsService
+    var childCoordinators = [ChildCoordinator]()
     private let viewControllerFactory = OnboardingViewControllerFactory.self
+    var authCoordinator: AuthenticationCoordinator?
     
-    init(window: UIWindow,
-         root: UINavigationController,
+    init(root: UINavigationController,
          session: LoginSession,
          analyticsService: AnalyticsService = OneLoginAnalyticsService()) {
-        self.window = window
         self.root = root
         self.session = session
         self.analyticsService = analyticsService
     }
     
     func start() {
+        authCoordinator = AuthenticationCoordinator(root: root,
+                                                    session: session)
         let introViewController = viewControllerFactory.createIntroViewController(analyticsService: analyticsService,
-                                                                                  session: session)
+                                                                                  session: session) {
+            self.openChildInline(self.authCoordinator!)
+        }
         root.setViewControllers([introViewController], animated: false)
     }
 }

--- a/Sources/Onboarding/MainCoordinator.swift
+++ b/Sources/Onboarding/MainCoordinator.swift
@@ -25,9 +25,9 @@ final class MainCoordinator: NSObject,
         authCoordinator = AuthenticationCoordinator(root: root,
                                                     session: session)
         let introViewController = viewControllerFactory.createIntroViewController(analyticsService: analyticsService,
-                                                                                  session: session) {
-            self.openChildInline(self.authCoordinator!)
+                                                                                  session: session) { [self] in
+            guard let authCoordinator else { return }
+            openChildInline(authCoordinator)
         }
-        root.setViewControllers([introViewController], animated: false)
     }
 }

--- a/Sources/Onboarding/MainCoordinator.swift
+++ b/Sources/Onboarding/MainCoordinator.swift
@@ -11,7 +11,6 @@ final class MainCoordinator: NSObject,
     let analyticsService: AnalyticsService
     var childCoordinators = [ChildCoordinator]()
     private let viewControllerFactory = OnboardingViewControllerFactory.self
-    var authCoordinator: AuthenticationCoordinator?
     
     init(root: UINavigationController,
          session: LoginSession,
@@ -22,12 +21,10 @@ final class MainCoordinator: NSObject,
     }
     
     func start() {
-        authCoordinator = AuthenticationCoordinator(root: root,
-                                                    session: session)
         let introViewController = viewControllerFactory.createIntroViewController(analyticsService: analyticsService,
                                                                                   session: session) { [self] in
-            guard let authCoordinator else { return }
-            openChildInline(authCoordinator)
+            openChildInline(AuthenticationCoordinator(root: root, session: session))
         }
+        root.setViewControllers([introViewController], animated: false)
     }
 }

--- a/Sources/Onboarding/MainCoordinator.swift
+++ b/Sources/Onboarding/MainCoordinator.swift
@@ -21,8 +21,7 @@ final class MainCoordinator: NSObject,
     }
     
     func start() {
-        let introViewController = viewControllerFactory.createIntroViewController(analyticsService: analyticsService,
-                                                                                  session: session) { [self] in
+        let introViewController = viewControllerFactory.createIntroViewController(analyticsService: analyticsService) { [self] in
             openChildInline(AuthenticationCoordinator(root: root, session: session))
         }
         root.setViewControllers([introViewController], animated: false)

--- a/Sources/Utilities/OnboardingViewControllerFactory.swift
+++ b/Sources/Utilities/OnboardingViewControllerFactory.swift
@@ -3,10 +3,11 @@ import GDSCommon
 import Logging
 
 final class OnboardingViewControllerFactory {
-    static func createIntroViewController(analyticsService: AnalyticsService, session: LoginSession) -> IntroViewController {
+    static func createIntroViewController(analyticsService: AnalyticsService,
+                                          session: LoginSession,
+                                          action: @escaping () -> Void) -> IntroViewController {
         let viewModel = OneLoginIntroViewModel(analyticsService: analyticsService) {
-            let configuration = LoginSessionConfiguration.oneLogin
-            session.present(configuration: configuration)
+            action()
         }
         return IntroViewController(viewModel: viewModel)
     }

--- a/Sources/Utilities/OnboardingViewControllerFactory.swift
+++ b/Sources/Utilities/OnboardingViewControllerFactory.swift
@@ -4,7 +4,6 @@ import Logging
 
 final class OnboardingViewControllerFactory {
     static func createIntroViewController(analyticsService: AnalyticsService,
-                                          session: LoginSession,
                                           action: @escaping () -> Void) -> IntroViewController {
         let viewModel = OneLoginIntroViewModel(analyticsService: analyticsService) {
             action()

--- a/Tests/UnitTests/Onboarding/AuthenticationCoordinatorTests.swift
+++ b/Tests/UnitTests/Onboarding/AuthenticationCoordinatorTests.swift
@@ -29,8 +29,10 @@ final class AuthenticationCoordinatorTests: XCTestCase {
 
 extension AuthenticationCoordinatorTests {
     func test_authenticationSessionConfigProperties() throws {
+        // WHEN the AuthenticationCoordinator is stared
         sut.start()
         XCTAssertTrue(mockLoginSession.sessionConfiguration != nil)
+        // THEN the session should have the correct login configuration details
         let sessionConfig = try XCTUnwrap(mockLoginSession.sessionConfiguration)
         XCTAssertEqual(sessionConfig.authorizationEndpoint, AppEnvironment.oneLoginAuthorize)
         XCTAssertEqual(sessionConfig.tokenEndpoint, AppEnvironment.oneLoginToken)

--- a/Tests/UnitTests/Onboarding/AuthenticationCoordinatorTests.swift
+++ b/Tests/UnitTests/Onboarding/AuthenticationCoordinatorTests.swift
@@ -28,7 +28,7 @@ final class AuthenticationCoordinatorTests: XCTestCase {
 }
 
 extension AuthenticationCoordinatorTests {
-    func authenticationSessionConfigProperties() throws {
+    func test_authenticationSessionConfigProperties() throws {
         sut.start()
         XCTAssertTrue(mockLoginSession.sessionConfiguration != nil)
         let sessionConfig = try XCTUnwrap(mockLoginSession.sessionConfiguration)

--- a/Tests/UnitTests/Onboarding/AuthenticationCoordinatorTests.swift
+++ b/Tests/UnitTests/Onboarding/AuthenticationCoordinatorTests.swift
@@ -1,0 +1,46 @@
+import Authentication
+import GDSCommon
+@testable import OneLogin
+import XCTest
+
+@MainActor
+final class AuthenticationCoordinatorTests: XCTestCase {
+    var window: UIWindow!
+    var navigationController: UINavigationController!
+    var mockLoginSession: MockLoginSession!
+    var sut: AuthenticationCoordinator!
+    
+    override func setUp() {
+        super.setUp()
+        
+        window = .init()
+        navigationController = .init()
+        mockLoginSession = MockLoginSession(window: window)
+        sut = AuthenticationCoordinator(root: navigationController, session: mockLoginSession)
+    }
+    
+    override func tearDown() {
+        navigationController = nil
+        mockLoginSession = nil
+        sut = nil
+        
+        super.tearDown()
+    }
+}
+
+extension AuthenticationCoordinatorTests {
+    func authenticationSessionConfigProperties() throws {
+        sut.start()
+        XCTAssertTrue(mockLoginSession.sessionConfiguration != nil)
+        let sessionConfig = try XCTUnwrap(mockLoginSession.sessionConfiguration)
+        XCTAssertEqual(sessionConfig.authorizationEndpoint, AppEnvironment.oneLoginAuthorize)
+        XCTAssertEqual(sessionConfig.tokenEndpoint, AppEnvironment.oneLoginToken)
+        XCTAssertEqual(sessionConfig.responseType, LoginSessionConfiguration.ResponseType.code)
+        XCTAssertEqual(sessionConfig.scopes, [.openid])
+        XCTAssertEqual(sessionConfig.clientID, AppEnvironment.oneLoginClientID)
+        XCTAssertEqual(sessionConfig.prefersEphemeralWebSession, true)
+        XCTAssertEqual(sessionConfig.redirectURI, AppEnvironment.oneLoginRedirect)
+        XCTAssertEqual(sessionConfig.vectorsOfTrust, ["Cl.Cm.P0"])
+        XCTAssertEqual(sessionConfig.locale, .en)
+    }
+}

--- a/Tests/UnitTests/Onboarding/AuthenticationCoordinatorTests.swift
+++ b/Tests/UnitTests/Onboarding/AuthenticationCoordinatorTests.swift
@@ -1,5 +1,4 @@
 import Authentication
-import GDSCommon
 @testable import OneLogin
 import XCTest
 

--- a/Tests/UnitTests/Onboarding/MainCoordinatorTests.swift
+++ b/Tests/UnitTests/Onboarding/MainCoordinatorTests.swift
@@ -28,14 +28,14 @@ final class MainCoordinatorTests: XCTestCase {
 }
 
 extension MainCoordinatorTests {
-    func test_mainCoordinatorStart() throws {
+    func test_mainCoordinatorStart_displaysIntroViewController() throws {
         XCTAssertTrue(navigationController.viewControllers.count == 0)
         sut.start()
         XCTAssertTrue(navigationController.viewControllers.count == 1)
         XCTAssert(navigationController.topViewController is IntroViewController)
     }
     
-    func test_mainCoordinatorOpensSubCoordinator() throws {
+    func test_mainCoordinatorStart_opensSubCoordinator() throws {
         sut.start()
         let introScreen = navigationController.topViewController as? IntroViewController
         let introButton: UIButton = try XCTUnwrap(introScreen?.view[child: "intro-button"])

--- a/Tests/UnitTests/Onboarding/MainCoordinatorTests.swift
+++ b/Tests/UnitTests/Onboarding/MainCoordinatorTests.swift
@@ -15,11 +15,10 @@ final class MainCoordinatorTests: XCTestCase {
         window = .init()
         navigationController = .init()
         loginSession = MockLoginSession(window: window)
-        sut = MainCoordinator(window: window, root: navigationController, session: loginSession)
+        sut = MainCoordinator(root: navigationController, session: loginSession)
     }
     
     override func tearDown() {
-        window = nil
         navigationController = nil
         loginSession = nil
         sut = nil

--- a/Tests/UnitTests/Onboarding/MainCoordinatorTests.swift
+++ b/Tests/UnitTests/Onboarding/MainCoordinatorTests.swift
@@ -28,10 +28,20 @@ final class MainCoordinatorTests: XCTestCase {
 }
 
 extension MainCoordinatorTests {
-    func test_MainCoordinatorStart() throws {
+    func test_mainCoordinatorStart() throws {
         XCTAssertTrue(navigationController.viewControllers.count == 0)
         sut.start()
         XCTAssertTrue(navigationController.viewControllers.count == 1)
         XCTAssert(navigationController.topViewController is IntroViewController)
+    }
+    
+    func test_mainCoordinatorOpensSubCoordinator() throws {
+        sut.start()
+        let introScreen = navigationController.topViewController as? IntroViewController
+        let introButton: UIButton = try XCTUnwrap(introScreen?.view[child: "intro-button"])
+        XCTAssertEqual(sut.childCoordinators.count, 0)
+        introButton.sendActions(for: .touchUpInside)
+        XCTAssertTrue(sut.childCoordinators.first is AuthenticationCoordinator)
+        XCTAssertEqual(sut.childCoordinators.count, 1)
     }
 }

--- a/Tests/UnitTests/Onboarding/MainCoordinatorTests.swift
+++ b/Tests/UnitTests/Onboarding/MainCoordinatorTests.swift
@@ -29,18 +29,23 @@ final class MainCoordinatorTests: XCTestCase {
 
 extension MainCoordinatorTests {
     func test_mainCoordinatorStart_displaysIntroViewController() throws {
+        // WHEN the MainCoordinator is stared
         XCTAssertTrue(navigationController.viewControllers.count == 0)
         sut.start()
+        // THEN the visible view controller should be an IntroViewController
         XCTAssertTrue(navigationController.viewControllers.count == 1)
         XCTAssert(navigationController.topViewController is IntroViewController)
     }
     
     func test_mainCoordinatorStart_opensSubCoordinator() throws {
+        // GIVEN the MainCoordinator is stared
         sut.start()
+        // WHEN the button on the IntroViewController is tapped
         let introScreen = navigationController.topViewController as? IntroViewController
         let introButton: UIButton = try XCTUnwrap(introScreen?.view[child: "intro-button"])
         XCTAssertEqual(sut.childCoordinators.count, 0)
         introButton.sendActions(for: .touchUpInside)
+        // THEN the MainCoordinator should have an AuthenticationCoordinator as it's only child coordinator
         XCTAssertTrue(sut.childCoordinators.first is AuthenticationCoordinator)
         XCTAssertEqual(sut.childCoordinators.count, 1)
     }

--- a/Tests/UnitTests/Onboarding/Welcome/IntroViewControllerTests.swift
+++ b/Tests/UnitTests/Onboarding/Welcome/IntroViewControllerTests.swift
@@ -41,7 +41,9 @@ extension IntroViewControllerTests {
     func test_sessionPresent() throws {
         XCTAssertFalse(mockLoginSession.didCallPresent)
         let introButton: UIButton = try XCTUnwrap(sut.view[child: "intro-button"])
+        // WHEN the IntroViewController button is tapped
         introButton.sendActions(for: .touchUpInside)
+        // THEN the action should be called
         XCTAssertTrue(mockLoginSession.didCallPresent)
         XCTAssertTrue(mockLoginSession.sessionConfiguration != nil)
     }
@@ -49,7 +51,9 @@ extension IntroViewControllerTests {
     func test_triggerButtonAnalytics() throws {
         XCTAssertEqual(mockAnalyticsService.eventsLogged.count, 0)
         let introButton: UIButton = try XCTUnwrap(sut.view[child: "intro-button"])
+        // WHEN the IntroViewController button is tapped
         introButton.sendActions(for: .touchUpInside)
+        // THEN the event analytics should be logged
         XCTAssertEqual(mockAnalyticsService.eventsLogged.count, 1)
         let event = ButtonEvent(textKey: "testbutton")
         XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
@@ -58,8 +62,10 @@ extension IntroViewControllerTests {
     
     func test_triggerScreenAnalytics() throws {
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 0)
+        // WHEN the IntroViewController button is shown
         sut.beginAppearanceTransition(true, animated: false)
         sut.endAppearanceTransition()
+        // THEN the screen analytics should be logged
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 1)
         let screen = ScreenView(screen: IntroAnalyticsScreen.welcomeScreen,
                                 titleKey: "testtitle")

--- a/Tests/UnitTests/Utilities/OnboardingViewControllerFactoryTests.swift
+++ b/Tests/UnitTests/Utilities/OnboardingViewControllerFactoryTests.swift
@@ -12,13 +12,11 @@ final class OnboardingViewControllerFactoryTests: XCTestCase {
         super.setUp()
         
         mockAnalyticsService = MockAnalyticsService()
-        mockLoginSession = MockLoginSession(window: UIWindow())
         sut = OnboardingViewControllerFactory.self
     }
     
     override func tearDown() {
         mockAnalyticsService = nil
-        mockLoginSession = nil
         sut = nil
         didCallAction = false
         
@@ -28,8 +26,7 @@ final class OnboardingViewControllerFactoryTests: XCTestCase {
 
 extension OnboardingViewControllerFactoryTests {
     func test_introViewControllerCallsAction() throws {
-        let introView = sut.createIntroViewController(analyticsService: mockAnalyticsService,
-                                                      session: mockLoginSession) {
+        let introView = sut.createIntroViewController(analyticsService: mockAnalyticsService) {
             self.didCallAction = true
         }
         let introButton: UIButton = try XCTUnwrap(introView.view[child: "intro-button"])

--- a/Tests/UnitTests/Utilities/OnboardingViewControllerFactoryTests.swift
+++ b/Tests/UnitTests/Utilities/OnboardingViewControllerFactoryTests.swift
@@ -1,4 +1,4 @@
-import Authentication
+import GDSCommon
 @testable import OneLogin
 import XCTest
 
@@ -6,6 +6,7 @@ final class OnboardingViewControllerFactoryTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
     var mockLoginSession: MockLoginSession!
     var sut: OnboardingViewControllerFactory.Type!
+    var didCallAction = false
     
     override func setUp() {
         super.setUp()
@@ -19,26 +20,20 @@ final class OnboardingViewControllerFactoryTests: XCTestCase {
         mockAnalyticsService = nil
         mockLoginSession = nil
         sut = nil
+        didCallAction = false
         
         super.tearDown()
     }
 }
 
 extension OnboardingViewControllerFactoryTests {
-    func test_introViewControllerSessionConfigProperties() throws {
-        let introView = sut.createIntroViewController(analyticsService: mockAnalyticsService, session: mockLoginSession)
+    func test_introViewControllerCallsAction() throws {
+        let introView = sut.createIntroViewController(analyticsService: mockAnalyticsService,
+                                                      session: mockLoginSession) {
+            self.didCallAction = true
+        }
         let introButton: UIButton = try XCTUnwrap(introView.view[child: "intro-button"])
         introButton.sendActions(for: .touchUpInside)
-        XCTAssertTrue(mockLoginSession.sessionConfiguration != nil)
-        let sessionConfig = try XCTUnwrap(mockLoginSession.sessionConfiguration)
-        XCTAssertEqual(sessionConfig.authorizationEndpoint, AppEnvironment.oneLoginAuthorize)
-        XCTAssertEqual(sessionConfig.tokenEndpoint, AppEnvironment.oneLoginToken)
-        XCTAssertEqual(sessionConfig.responseType, LoginSessionConfiguration.ResponseType.code)
-        XCTAssertEqual(sessionConfig.scopes, [.openid])
-        XCTAssertEqual(sessionConfig.clientID, AppEnvironment.oneLoginClientID)
-        XCTAssertEqual(sessionConfig.prefersEphemeralWebSession, true)
-        XCTAssertEqual(sessionConfig.redirectURI, AppEnvironment.oneLoginRedirect)
-        XCTAssertEqual(sessionConfig.vectorsOfTrust, ["Cl.Cm.P0"])
-        XCTAssertEqual(sessionConfig.locale, .en)
+        XCTAssertTrue(didCallAction)
     }
 }


### PR DESCRIPTION
# iOS | Receive Auth Code and State from deeplink

This PR is to enable universal linking into the One Login app from domains for staging and build.
Much of the qualifying of the returned query parameters i.e. `authorizationCode` and `state` are handled as part of the [authentication package](https://github.com/govuk-one-login/mobile-ios-authentication)

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
