### PR TITLE
feat: show unable to login error screen

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		3BBF28F12A9F7D3200491BB1 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3BBF28E82A9F7D3200491BB1 /* LaunchScreen.storyboard */; };
 		3BBF28F32A9F7D3200491BB1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BBF28ED2A9F7D3200491BB1 /* AppDelegate.swift */; };
 		3BBF28F42A9F7D3200491BB1 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BBF28EE2A9F7D3200491BB1 /* SceneDelegate.swift */; };
+		410464F62B29D078000E7CB2 /* UnableToLoginErrorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410464F52B29D078000E7CB2 /* UnableToLoginErrorViewModelTests.swift */; };
 		4195E6CB2B0CD32F0065E2BB /* TokenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4195E6CA2B0CD32F0065E2BB /* TokenCoordinator.swift */; };
 		41A0BD0A2B272118009AE51F /* ErrorScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A0BD092B272118009AE51F /* ErrorScreen.swift */; };
 		41A0BD0C2B2725C8009AE51F /* TokensScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A0BD0B2B2725C8009AE51F /* TokensScreen.swift */; };
@@ -111,6 +112,7 @@
 		3BBF28ED2A9F7D3200491BB1 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		3BBF28EE2A9F7D3200491BB1 /* SceneDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		3BBF28F52A9F7D4900491BB1 /* OneLogin-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "OneLogin-Info.plist"; sourceTree = "<group>"; };
+		410464F52B29D078000E7CB2 /* UnableToLoginErrorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnableToLoginErrorViewModelTests.swift; sourceTree = "<group>"; };
 		412B95A02B0529B800C390B2 /* OneLoginStaging.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = OneLoginStaging.entitlements; sourceTree = "<group>"; };
 		4195E6CA2B0CD32F0065E2BB /* TokenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenCoordinator.swift; sourceTree = "<group>"; };
 		41A0BD092B272118009AE51F /* ErrorScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorScreen.swift; sourceTree = "<group>"; };
@@ -303,6 +305,7 @@
 			isa = PBXGroup;
 			children = (
 				41A0BD0F2B275168009AE51F /* GenericErrorViewModelTests.swift */,
+				410464F52B29D078000E7CB2 /* UnableToLoginErrorViewModelTests.swift */,
 			);
 			path = Errors;
 			sourceTree = "<group>";
@@ -822,6 +825,7 @@
 				C8EBE8042AEFB7FF009B8A06 /* LoginSessionConfigurationTests.swift in Sources */,
 				21FA1C4D2AE183D20052136E /* MockLoginSession.swift in Sources */,
 				41A0BD112B2758E6009AE51F /* GenericErrorViewModelTests.swift in Sources */,
+				410464F62B29D078000E7CB2 /* UnableToLoginErrorViewModelTests.swift in Sources */,
 				21FA1C502AE18C8B0052136E /* OneLoginIntroViewModelTests.swift in Sources */,
 				41FF35AF2B222CAC00419DB3 /* AuthenticationCoordinatorTests.swift in Sources */,
 				21E04DFC2AE6BC5B004C6660 /* MockAnalyticsService.swift in Sources */,

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -1711,7 +1711,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/govuk-one-login/mobile-ios-authentication.git";
 			requirement = {
-				branch = "feature/dcmaw-7113-expose-LoginError";
+				branch = main;
 				kind = branch;
 			};
 		};

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		C8A13CAB2AFBD0CC00FCBD36 /* HTTPLogging in Frameworks */ = {isa = PBXBuildFile; productRef = C8A13CAA2AFBD0CC00FCBD36 /* HTTPLogging */; };
 		C8A13CAD2AFBD0CC00FCBD36 /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = C8A13CAC2AFBD0CC00FCBD36 /* Logging */; };
 		C8A13CB02AFBD0F100FCBD36 /* Coordination in Frameworks */ = {isa = PBXBuildFile; productRef = C8A13CAF2AFBD0F100FCBD36 /* Coordination */; };
+		C8AA11D82B29C7FA00CE718B /* UnableToLoginErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8AA11D72B29C7FA00CE718B /* UnableToLoginErrorViewModel.swift */; };
 		C8B320792B062F9100FECDF0 /* AuthenticationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B320782B062F9100FECDF0 /* AuthenticationCoordinator.swift */; };
 		C8B5EFC52B0E53EE004EA4D4 /* XCTestCase+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B5EFC42B0E53EE004EA4D4 /* XCTestCase+Extensions.swift */; };
 		C8EBE8042AEFB7FF009B8A06 /* LoginSessionConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8EBE8032AEFB7FF009B8A06 /* LoginSessionConfigurationTests.swift */; };
@@ -145,6 +146,7 @@
 		C880DDE12AEAB6C100020796 /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
 		C89632EC2B0D0886002A1473 /* TokensView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = TokensView.xib; path = Sources/Screens/Tokens/TokensView.xib; sourceTree = SOURCE_ROOT; };
 		C89632EE2B0D0895002A1473 /* TokensViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TokensViewController.swift; path = Sources/Screens/Tokens/TokensViewController.swift; sourceTree = SOURCE_ROOT; };
+		C8AA11D72B29C7FA00CE718B /* UnableToLoginErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnableToLoginErrorViewModel.swift; sourceTree = "<group>"; };
 		C8B320782B062F9100FECDF0 /* AuthenticationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationCoordinator.swift; sourceTree = "<group>"; };
 		C8B3207A2B063CA100FECDF0 /* AuthenticationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationCoordinatorTests.swift; sourceTree = "<group>"; };
 		C8B5EFC42B0E53EE004EA4D4 /* XCTestCase+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Extensions.swift"; sourceTree = "<group>"; };
@@ -309,6 +311,7 @@
 			isa = PBXGroup;
 			children = (
 				41FF35AB2B21F1AA00419DB3 /* GenericErrorViewModel.swift */,
+				C8AA11D72B29C7FA00CE718B /* UnableToLoginErrorViewModel.swift */,
 			);
 			path = Errors;
 			sourceTree = "<group>";
@@ -801,6 +804,7 @@
 				C8B320792B062F9100FECDF0 /* AuthenticationCoordinator.swift in Sources */,
 				C85E21042ACEE34900AF8B4E /* MainCoordinator.swift in Sources */,
 				41FF35AC2B21F1AA00419DB3 /* GenericErrorViewModel.swift in Sources */,
+				C8AA11D82B29C7FA00CE718B /* UnableToLoginErrorViewModel.swift in Sources */,
 				C880DDE22AEAB6C100020796 /* AppEnvironment.swift in Sources */,
 				21E04DFA2AE6B52B004C6660 /* OneLoginAnalyticsService.swift in Sources */,
 				41FF35AA2B21F06C00419DB3 /* ErrorPresenter.swift in Sources */,
@@ -1699,7 +1703,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/govuk-one-login/mobile-ios-authentication.git";
 			requirement = {
-				branch = main;
+				branch = "feature/dcmaw-7113-expose-LoginError";
 				kind = branch;
 			};
 		};

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1EDA358C2B29FAAD0062FA46 /* LoginModalSecondScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EDA358B2B29FAAD0062FA46 /* LoginModalSecondScreen.swift */; };
 		219602022A976305008F3427 /* MainCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219602012A976305008F3427 /* MainCoordinatorTests.swift */; };
 		21E04DFA2AE6B52B004C6660 /* OneLoginAnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E04DF92AE6B52B004C6660 /* OneLoginAnalyticsService.swift */; };
 		21E04DFC2AE6BC5B004C6660 /* MockAnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E04DFB2AE6BC5B004C6660 /* MockAnalyticsService.swift */; };
@@ -97,6 +98,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1EDA358B2B29FAAD0062FA46 /* LoginModalSecondScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginModalSecondScreen.swift; sourceTree = "<group>"; };
 		219601E72A976302008F3427 /* OneLogin.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OneLogin.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		219601FD2A976305008F3427 /* OneLoginUnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OneLoginUnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		219602012A976305008F3427 /* MainCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -353,6 +355,7 @@
 				41A0BD092B272118009AE51F /* ErrorScreen.swift */,
 				C80B871E2B029EAB0087C6D5 /* LoginModal.swift */,
 				41A0BD0B2B2725C8009AE51F /* TokensScreen.swift */,
+				1EDA358B2B29FAAD0062FA46 /* LoginModalSecondScreen.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -849,6 +852,7 @@
 				C80B871A2B029E230087C6D5 /* LoginUITests.swift in Sources */,
 				C80B87282B029F440087C6D5 /* ScreenObject.swift in Sources */,
 				C80B871F2B029EAB0087C6D5 /* LoginModal.swift in Sources */,
+				1EDA358C2B29FAAD0062FA46 /* LoginModalSecondScreen.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -28,15 +28,6 @@
       }
     },
     {
-      "identity" : "di-mobile-ios-networking",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/alphagov/di-mobile-ios-networking",
-      "state" : {
-        "branch" : "main",
-        "revision" : "8724c7ffcbc2546e3b1fa57f1021769e12b475ea"
-      }
-    },
-    {
       "identity" : "firebase-ios-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk.git",
@@ -114,7 +105,7 @@
       "location" : "https://github.com/govuk-one-login/mobile-ios-authentication.git",
       "state" : {
         "branch" : "feature/dcmaw-7113-expose-LoginError",
-        "revision" : "c0352872ba1e16921f979fce8b8004979a590537"
+        "revision" : "4179d8893a6d2711385e5a3fc69dcdefd7dd0847"
       }
     },
     {
@@ -123,7 +114,7 @@
       "location" : "https://github.com/govuk-one-login/mobile-ios-common.git",
       "state" : {
         "branch" : "main",
-        "revision" : "d9935d207fc7971c42bb76686c738b409ee321e2"
+        "revision" : "6e255f70a79847adf5d65454343787b4a34ac683"
       }
     },
     {
@@ -141,7 +132,16 @@
       "location" : "https://github.com/govuk-one-login/mobile-ios-logging.git",
       "state" : {
         "branch" : "main",
-        "revision" : "4bbe40149d696385fcc5438507bf9842a176846e"
+        "revision" : "713666197ee9011e17a044419711bcb8b88a70c5"
+      }
+    },
+    {
+      "identity" : "mobile-ios-networking",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/govuk-one-login/mobile-ios-networking.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "8724c7ffcbc2546e3b1fa57f1021769e12b475ea"
       }
     },
     {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-authentication.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "e20a465366c82447b09f6b3c10fa223fb7a21923"
+        "branch" : "feature/dcmaw-7113-expose-LoginError",
+        "revision" : "c0352872ba1e16921f979fce8b8004979a590537"
       }
     },
     {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-authentication.git",
       "state" : {
-        "branch" : "feature/dcmaw-7113-expose-LoginError",
-        "revision" : "4179d8893a6d2711385e5a3fc69dcdefd7dd0847"
+        "branch" : "main",
+        "revision" : "e98bd99fde3214010fa9f679b6b1bf9557ded40c"
       }
     },
     {
@@ -114,7 +114,7 @@
       "location" : "https://github.com/govuk-one-login/mobile-ios-common.git",
       "state" : {
         "branch" : "main",
-        "revision" : "6e255f70a79847adf5d65454343787b4a34ac683"
+        "revision" : "7dec63da8f8bf99b90b69eefb279cb400014327e"
       }
     },
     {

--- a/Sources/Analytics/Errors/ErrorAnalytics.swift
+++ b/Sources/Analytics/Errors/ErrorAnalytics.swift
@@ -3,4 +3,5 @@ import Logging
 
 enum ErrorAnalyticsScreen: String, LoggableScreen, NamedScreen {
     case generic = "genericErrorScreen"
+    case unableToLogin = "unableToLoginErrorScreen"
 }

--- a/Sources/Errors/GenericErrorViewModel.swift
+++ b/Sources/Errors/GenericErrorViewModel.swift
@@ -3,6 +3,7 @@ import GDSCommon
 import Logging
 
 struct GenericErrorViewModel: GDSErrorViewModel, BaseViewModel {
+    // TODO: String keys for localisation needed
     let image: String = "exclamationmark.circle"
     let title: GDSLocalisedString = "Something went wrong"
     let body: GDSLocalisedString = "Try again later"

--- a/Sources/Errors/GenericErrorViewModel.swift
+++ b/Sources/Errors/GenericErrorViewModel.swift
@@ -3,8 +3,8 @@ import GDSCommon
 import Logging
 
 struct GenericErrorViewModel: GDSErrorViewModel, BaseViewModel {
-    // TODO: String keys for localisation needed
     let image: String = "exclamationmark.circle"
+    // TODO: DCMAW-7083: String keys for localisation needed
     let title: GDSLocalisedString = "Something went wrong"
     let body: GDSLocalisedString = "Try again later"
     let primaryButtonViewModel: ButtonViewModel

--- a/Sources/Errors/UnableToLoginErrorViewModel.swift
+++ b/Sources/Errors/UnableToLoginErrorViewModel.swift
@@ -3,8 +3,8 @@ import GDSCommon
 import Logging
 
 struct UnableToLoginErrorViewModel: GDSErrorViewModel, BaseViewModel {
-    // TODO: String keys for localisation needed
     let image: String = "exclamationmark.circle"
+    // TODO: DCMAW-7083: String keys for localisation needed
     let title: GDSLocalisedString = "There was a problem signing you in"
     let body: GDSLocalisedString = "You can try signing in again.\n\nIf this does not work, you may need to try again later."
     let primaryButtonViewModel: ButtonViewModel

--- a/Sources/Errors/UnableToLoginErrorViewModel.swift
+++ b/Sources/Errors/UnableToLoginErrorViewModel.swift
@@ -3,6 +3,7 @@ import GDSCommon
 import Logging
 
 struct UnableToLoginErrorViewModel: GDSErrorViewModel, BaseViewModel {
+    // TODO: String keys for localisation needed
     let image: String = "exclamationmark.circle"
     let title: GDSLocalisedString = "There was a problem signing you in"
     let body: GDSLocalisedString = "You can try signing in again.\n\nIf this does not work, you may need to try again later."

--- a/Sources/Errors/UnableToLoginErrorViewModel.swift
+++ b/Sources/Errors/UnableToLoginErrorViewModel.swift
@@ -1,0 +1,33 @@
+import GDSAnalytics
+import GDSCommon
+import Logging
+
+struct UnableToLoginErrorViewModel: GDSErrorViewModel, BaseViewModel {
+    let image: String = "exclamationmark.circle"
+    let title: GDSLocalisedString = "There was a problem signing you in"
+    let body: GDSLocalisedString = "You can try signing in again.\n\nIf this does not work, you may need to try again later."
+    let primaryButtonViewModel: ButtonViewModel
+    let secondaryButtonViewModel: ButtonViewModel? = nil
+    let analyticsService: AnalyticsService
+    
+    let rightBarButtonTitle: GDSLocalisedString? = nil
+    let backButtonIsHidden: Bool = true
+    
+    init(analyticsService: AnalyticsService, action: @escaping () -> Void) {
+        self.analyticsService = analyticsService
+        self.primaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "Close",
+                                                               analyticsService: analyticsService) {
+            action()
+        }
+    }
+    
+    func didAppear() {
+        let screen = ScreenView(screen: ErrorAnalyticsScreen.unableToLogin,
+                                titleKey: title.stringKey)
+        analyticsService.trackScreen(screen)
+    }
+    
+    func didDismiss() {
+        // Here for BaseViewModel compliance
+    }
+}

--- a/Sources/Onboarding/AuthenticationCoordinator.swift
+++ b/Sources/Onboarding/AuthenticationCoordinator.swift
@@ -32,6 +32,11 @@ final class AuthenticationCoordinator: NSObject,
         Task(priority: .userInitiated) {
             do {
                 mainCoordinator.tokens = try await session.finalise(redirectURL: url)
+            } catch let error where error is LoginError {
+                let unableToLoginErrorScreen = errorPresenter.createUnableToLoginError(analyticsService: analyticsService) {
+                    self.root.popViewController(animated: true)
+                }
+                root.pushViewController(unableToLoginErrorScreen, animated: true)
             } catch {
                 let genericErrorScreen = errorPresenter.createGenericError(analyticsService: analyticsService) {
                     self.root.popViewController(animated: true)

--- a/Sources/Onboarding/Welcome/OneLoginIntroViewModel.swift
+++ b/Sources/Onboarding/Welcome/OneLoginIntroViewModel.swift
@@ -4,6 +4,7 @@ import Logging
 import UIKit
 
 struct OneLoginIntroViewModel: IntroViewModel, BaseViewModel {
+    // TODO: String keys for localisation needed
     let image: UIImage = UIImage(named: "badge") ?? UIImage()
     let title: GDSLocalisedString = "GOV.UK One Login"
     let body: GDSLocalisedString = "Sign in with the email address you use for your GOV.UK One Login."

--- a/Sources/Onboarding/Welcome/OneLoginIntroViewModel.swift
+++ b/Sources/Onboarding/Welcome/OneLoginIntroViewModel.swift
@@ -4,8 +4,8 @@ import Logging
 import UIKit
 
 struct OneLoginIntroViewModel: IntroViewModel, BaseViewModel {
-    // TODO: String keys for localisation needed
     let image: UIImage = UIImage(named: "badge") ?? UIImage()
+    // TODO: DCMAW-7083: String keys for localisation needed
     let title: GDSLocalisedString = "GOV.UK One Login"
     let body: GDSLocalisedString = "Sign in with the email address you use for your GOV.UK One Login."
     let introButtonViewModel: ButtonViewModel

--- a/Sources/Utilities/ErrorPresenter.swift
+++ b/Sources/Utilities/ErrorPresenter.swift
@@ -9,4 +9,12 @@ final class ErrorPresenter {
         }
         return GDSErrorViewController(viewModel: viewModel)
     }
+    
+    static func createUnableToLoginError(analyticsService: AnalyticsService,
+                                         action: @escaping () -> Void) -> GDSErrorViewController {
+        let viewModel = UnableToLoginErrorViewModel(analyticsService: analyticsService) {
+            action()
+        }
+        return GDSErrorViewController(viewModel: viewModel)
+    }
 }

--- a/Tests/UITests/LoginUITests.swift
+++ b/Tests/UITests/LoginUITests.swift
@@ -26,18 +26,27 @@ extension LoginUITests {
         let loginModal = sut.tapLoginButton()
         XCTAssertEqual(loginModal.title.label, "Welcome to the Auth Stub")
         XCTAssertEqual(loginModal.loginButton.label, "Login")
-        let userInfoScreen = loginModal.tapBrowserLoginButton()
-        XCTAssertEqual(userInfoScreen.title.label, "Logged in")
+        let tokensScreen = loginModal.tapBrowserLoginButton()
+        XCTAssertEqual(tokensScreen.title.label, "Logged in")
     }
 
     func test_loginCancelPath() throws {
+        XCTAssertEqual(sut.title.label, "GOV.UK One Login")
+        XCTAssertEqual(sut.body.label, "Sign in with the email address you use for your GOV.UK One Login.")
+        XCTAssertEqual(sut.signInButton.label, "Sign in")
         let loginModal = sut.tapLoginButton()
+        XCTAssertEqual(loginModal.title.label, "Welcome to the Auth Stub")
+        XCTAssertEqual(loginModal.loginButton.label, "Login")
         loginModal.tapCancelButton()
         XCTAssertTrue(sut.isVisible)
     }
 
     func test_loginGenericError() throws {
+        XCTAssertEqual(sut.title.label, "GOV.UK One Login")
+        XCTAssertEqual(sut.body.label, "Sign in with the email address you use for your GOV.UK One Login.")
+        XCTAssertEqual(sut.signInButton.label, "Sign in")
         let loginModal = sut.tapLoginButton()
+        XCTAssertEqual(loginModal.title.label, "Welcome to the Auth Stub")
         XCTAssertEqual(loginModal.oAuthErrorButton.label, "Redirect with OAuth error")
         let errorScreen = loginModal.tapBrowserRedirectWithOAuthErrorButton()
         XCTAssertEqual(errorScreen.title.label, "Something went wrong")

--- a/Tests/UITests/LoginUITests.swift
+++ b/Tests/UITests/LoginUITests.swift
@@ -2,16 +2,16 @@ import XCTest
 
 final class LoginUITests: XCTestCase {
     var sut: WelcomeScreen!
-
+    
     override func setUp() async throws {
         continueAfterFailure = false
-
+        
         await MainActor.run {
             sut = WelcomeScreen()
             sut.app.launch()
         }
     }
-
+    
     override func tearDown() {
         sut.app.terminate()
         sut = nil
@@ -29,7 +29,7 @@ extension LoginUITests {
         let tokensScreen = loginModal.tapBrowserLoginButton()
         XCTAssertEqual(tokensScreen.title.label, "Logged in")
     }
-
+    
     func test_loginCancelPath() throws {
         XCTAssertEqual(sut.title.label, "GOV.UK One Login")
         XCTAssertEqual(sut.body.label, "Sign in with the email address you use for your GOV.UK One Login.")
@@ -40,8 +40,8 @@ extension LoginUITests {
         loginModal.tapCancelButton()
         XCTAssertTrue(sut.isVisible)
     }
-
-    func test_loginGenericError() throws {
+    
+    func test_OAuthLoginError() throws {
         XCTAssertEqual(sut.title.label, "GOV.UK One Login")
         XCTAssertEqual(sut.body.label, "Sign in with the email address you use for your GOV.UK One Login.")
         XCTAssertEqual(sut.signInButton.label, "Sign in")
@@ -49,8 +49,57 @@ extension LoginUITests {
         XCTAssertEqual(loginModal.title.label, "Welcome to the Auth Stub")
         XCTAssertEqual(loginModal.oAuthErrorButton.label, "Redirect with OAuth error")
         let errorScreen = loginModal.tapBrowserRedirectWithOAuthErrorButton()
-        XCTAssertEqual(errorScreen.title.label, "Something went wrong")
-        XCTAssertEqual(errorScreen.body.label, "Try again later")
+        XCTAssertEqual(errorScreen.title.label, "There was a problem signing you in")
+        XCTAssertEqual(errorScreen.body.label, "You can try signing in again.\n\nIf this does not work, you may need to try again later.")
+        XCTAssertEqual(errorScreen.closeButton.label, "Close")
+    }
+    
+    func test_invalidStateError() throws {
+        XCTAssertEqual(sut.title.label, "GOV.UK One Login")
+        XCTAssertEqual(sut.body.label, "Sign in with the email address you use for your GOV.UK One Login.")
+        XCTAssertEqual(sut.signInButton.label, "Sign in")
+        let loginModal = sut.tapLoginButton()
+        XCTAssertEqual(loginModal.title.label, "Welcome to the Auth Stub")
+        XCTAssertEqual(loginModal.oAuthErrorButton.label, "Redirect with OAuth error")
+        let errorScreen = loginModal.tapBrowserInvalidStateErrorButton()
+        XCTAssertEqual(errorScreen.title.label, "There was a problem signing you in")
+        XCTAssertEqual(errorScreen.body.label, "You can try signing in again.\n\nIf this does not work, you may need to try again later.")
+        XCTAssertEqual(errorScreen.closeButton.label, "Close")
+    }
+    
+    func test_fourHundredResponseError() throws {
+        XCTAssertEqual(sut.title.label, "GOV.UK One Login")
+        XCTAssertEqual(sut.body.label, "Sign in with the email address you use for your GOV.UK One Login.")
+        XCTAssertEqual(sut.signInButton.label, "Sign in")
+        let loginModal = sut.tapLoginButton()
+        XCTAssertEqual(loginModal.title.label, "Welcome to the Auth Stub")
+        XCTAssertEqual(loginModal.oAuthErrorButton.label, "Redirect with OAuth error")
+        
+        let loginModalSecondScreen = loginModal.tapBrowserFourHundredResponseErrorButton()
+        XCTAssertEqual(loginModalSecondScreen.title.label, "Welcome to the Auth Stub")
+        XCTAssertEqual(loginModalSecondScreen.loginButton.label, "Login")
+        
+        let errorScreen = loginModalSecondScreen.tapBrowserLoginButton()
+        XCTAssertEqual(errorScreen.title.label, "There was a problem signing you in")
+        XCTAssertEqual(errorScreen.body.label, "You can try signing in again.\n\nIf this does not work, you may need to try again later.")
+        XCTAssertEqual(errorScreen.closeButton.label, "Close")
+    }
+    
+    func test_fiveHundredResponseError() throws {
+        XCTAssertEqual(sut.title.label, "GOV.UK One Login")
+        XCTAssertEqual(sut.body.label, "Sign in with the email address you use for your GOV.UK One Login.")
+        XCTAssertEqual(sut.signInButton.label, "Sign in")
+        let loginModal = sut.tapLoginButton()
+        XCTAssertEqual(loginModal.title.label, "Welcome to the Auth Stub")
+        XCTAssertEqual(loginModal.oAuthErrorButton.label, "Redirect with OAuth error")
+        
+        let loginModalSecondScreen = loginModal.tapBrowserFiveHundredResponseErrorButton()
+        XCTAssertEqual(loginModalSecondScreen.title.label, "Welcome to the Auth Stub")
+        XCTAssertEqual(loginModalSecondScreen.loginButton.label, "Login")
+        
+        let errorScreen = loginModalSecondScreen.tapBrowserLoginButton()
+        XCTAssertEqual(errorScreen.title.label, "There was a problem signing you in")
+        XCTAssertEqual(errorScreen.body.label, "You can try signing in again.\n\nIf this does not work, you may need to try again later.")
         XCTAssertEqual(errorScreen.closeButton.label, "Close")
     }
 }

--- a/Tests/UITests/LoginUITests.swift
+++ b/Tests/UITests/LoginUITests.swift
@@ -20,34 +20,43 @@ final class LoginUITests: XCTestCase {
 
 extension LoginUITests {
     func test_loginHappyPath() throws {
+        // Welcome Screen
         XCTAssertEqual(sut.title.label, "GOV.UK One Login")
         XCTAssertEqual(sut.body.label, "Sign in with the email address you use for your GOV.UK One Login.")
         XCTAssertEqual(sut.signInButton.label, "Sign in")
+        // Launch Login Modal
         let loginModal = sut.tapLoginButton()
         XCTAssertEqual(loginModal.title.label, "Welcome to the Auth Stub")
         XCTAssertEqual(loginModal.loginButton.label, "Login")
+        // Select 'Login' Button
         let tokensScreen = loginModal.tapBrowserLoginButton()
         XCTAssertEqual(tokensScreen.title.label, "Logged in")
     }
     
     func test_loginCancelPath() throws {
+        // Welcome Screen
         XCTAssertEqual(sut.title.label, "GOV.UK One Login")
         XCTAssertEqual(sut.body.label, "Sign in with the email address you use for your GOV.UK One Login.")
         XCTAssertEqual(sut.signInButton.label, "Sign in")
+        // Launch Login Modal
         let loginModal = sut.tapLoginButton()
         XCTAssertEqual(loginModal.title.label, "Welcome to the Auth Stub")
         XCTAssertEqual(loginModal.loginButton.label, "Login")
+        // Select 'Cancel' Button
         loginModal.tapCancelButton()
         XCTAssertTrue(sut.isVisible)
     }
     
     func test_OAuthLoginError() throws {
+        // Welcome Screen
         XCTAssertEqual(sut.title.label, "GOV.UK One Login")
         XCTAssertEqual(sut.body.label, "Sign in with the email address you use for your GOV.UK One Login.")
         XCTAssertEqual(sut.signInButton.label, "Sign in")
+        // Login Modal
         let loginModal = sut.tapLoginButton()
         XCTAssertEqual(loginModal.title.label, "Welcome to the Auth Stub")
         XCTAssertEqual(loginModal.oAuthErrorButton.label, "Redirect with OAuth error")
+        // Redirect with OAuth error
         let errorScreen = loginModal.tapBrowserRedirectWithOAuthErrorButton()
         XCTAssertEqual(errorScreen.title.label, "There was a problem signing you in")
         XCTAssertEqual(errorScreen.body.label, "You can try signing in again.\n\nIf this does not work, you may need to try again later.")
@@ -55,12 +64,15 @@ extension LoginUITests {
     }
     
     func test_invalidStateError() throws {
+        // Welcome Screen
         XCTAssertEqual(sut.title.label, "GOV.UK One Login")
         XCTAssertEqual(sut.body.label, "Sign in with the email address you use for your GOV.UK One Login.")
         XCTAssertEqual(sut.signInButton.label, "Sign in")
+        // Login Modal
         let loginModal = sut.tapLoginButton()
         XCTAssertEqual(loginModal.title.label, "Welcome to the Auth Stub")
         XCTAssertEqual(loginModal.oAuthErrorButton.label, "Redirect with OAuth error")
+        // Redirect with invalid state
         let errorScreen = loginModal.tapBrowserInvalidStateErrorButton()
         XCTAssertEqual(errorScreen.title.label, "There was a problem signing you in")
         XCTAssertEqual(errorScreen.body.label, "You can try signing in again.\n\nIf this does not work, you may need to try again later.")
@@ -68,17 +80,19 @@ extension LoginUITests {
     }
     
     func test_fourHundredResponseError() throws {
+        // Welcome Screen
         XCTAssertEqual(sut.title.label, "GOV.UK One Login")
         XCTAssertEqual(sut.body.label, "Sign in with the email address you use for your GOV.UK One Login.")
         XCTAssertEqual(sut.signInButton.label, "Sign in")
+        // Login Modal
         let loginModal = sut.tapLoginButton()
         XCTAssertEqual(loginModal.title.label, "Welcome to the Auth Stub")
         XCTAssertEqual(loginModal.oAuthErrorButton.label, "Redirect with OAuth error")
-        
+        // Set up 400 response from /token
         let loginModalSecondScreen = loginModal.tapBrowserFourHundredResponseErrorButton()
         XCTAssertEqual(loginModalSecondScreen.title.label, "Welcome to the Auth Stub")
         XCTAssertEqual(loginModalSecondScreen.loginButton.label, "Login")
-        
+        // Second Modal Screen
         let errorScreen = loginModalSecondScreen.tapBrowserLoginButton()
         XCTAssertEqual(errorScreen.title.label, "There was a problem signing you in")
         XCTAssertEqual(errorScreen.body.label, "You can try signing in again.\n\nIf this does not work, you may need to try again later.")
@@ -86,17 +100,19 @@ extension LoginUITests {
     }
     
     func test_fiveHundredResponseError() throws {
+        // Welcome Screen
         XCTAssertEqual(sut.title.label, "GOV.UK One Login")
         XCTAssertEqual(sut.body.label, "Sign in with the email address you use for your GOV.UK One Login.")
         XCTAssertEqual(sut.signInButton.label, "Sign in")
+        // Login Modal
         let loginModal = sut.tapLoginButton()
         XCTAssertEqual(loginModal.title.label, "Welcome to the Auth Stub")
         XCTAssertEqual(loginModal.oAuthErrorButton.label, "Redirect with OAuth error")
-        
+        // Set up 500 response from /token
         let loginModalSecondScreen = loginModal.tapBrowserFiveHundredResponseErrorButton()
         XCTAssertEqual(loginModalSecondScreen.title.label, "Welcome to the Auth Stub")
         XCTAssertEqual(loginModalSecondScreen.loginButton.label, "Login")
-        
+        // Second Modal Screen
         let errorScreen = loginModalSecondScreen.tapBrowserLoginButton()
         XCTAssertEqual(errorScreen.title.label, "There was a problem signing you in")
         XCTAssertEqual(errorScreen.body.label, "You can try signing in again.\n\nIf this does not work, you may need to try again later.")

--- a/Tests/UITests/ScreenObjects/App/ErrorScreen.swift
+++ b/Tests/UITests/ScreenObjects/App/ErrorScreen.swift
@@ -2,23 +2,23 @@ import XCTest
 
 struct ErrorScreen: ScreenObject {
     let app: XCUIApplication
-
+    
     var view: XCUIElement {
         app.scrollViews.firstMatch
     }
-
+    
     var title: XCUIElement {
         app.staticTexts["error-title"]
     }
-
+    
     var body: XCUIElement {
         app.staticTexts["error-body"]
     }
-
+    
     var closeButton: XCUIElement {
         app.buttons["error-primary-button"]
     }
-
+    
     func tapCloseButton() {
         closeButton.tap()
     }

--- a/Tests/UITests/ScreenObjects/App/LoginModal.swift
+++ b/Tests/UITests/ScreenObjects/App/LoginModal.swift
@@ -2,23 +2,23 @@ import XCTest
 
 struct LoginModal: ScreenObject {
     let app: XCUIApplication
-
+    
     var cancelButton: XCUIElement {
         app.buttons["Cancel"]
     }
-
+    
     var view: XCUIElement {
         app.webViews.firstMatch
     }
-
+    
     var title: XCUIElement {
         view.staticTexts["Welcome to the Auth Stub"]
     }
-
+    
     var loginButton: XCUIElement {
         view.buttons["Login"]
     }
-
+    
     var oAuthErrorButton: XCUIElement {
         view.buttons["Redirect with OAuth error"]
     }
@@ -34,38 +34,38 @@ struct LoginModal: ScreenObject {
     var fiveHundredResponseErrorButton: XCUIElement {
         view.buttons["Set up 500 response from /token"]
     }
-
+    
     func tapCancelButton() {
         cancelButton.tap()
     }
-
+    
     func tapBrowserLoginButton() -> TokensScreen {
         loginButton.tap()
         
         return TokensScreen(app: app).waitForAppearance()
     }
-
+    
     func tapBrowserRedirectWithOAuthErrorButton() -> ErrorScreen {
         oAuthErrorButton.tap()
-
+        
         return ErrorScreen(app: app).waitForAppearance()
     }
     
     func tapBrowserInvalidStateErrorButton() -> ErrorScreen {
         invalidStateButton.tap()
-
+        
         return ErrorScreen(app: app).waitForAppearance()
     }
     
     func tapBrowserFourHundredResponseErrorButton() -> LoginModalSecondScreen {
         fourHundredResponseErrorButton.tap()
-
+        
         return LoginModalSecondScreen(app: app).waitForAppearance()
     }
     
     func tapBrowserFiveHundredResponseErrorButton() -> LoginModalSecondScreen {
         fiveHundredResponseErrorButton.tap()
-
+        
         return LoginModalSecondScreen(app: app).waitForAppearance()
     }
 }

--- a/Tests/UITests/ScreenObjects/App/LoginModal.swift
+++ b/Tests/UITests/ScreenObjects/App/LoginModal.swift
@@ -22,6 +22,18 @@ struct LoginModal: ScreenObject {
     var oAuthErrorButton: XCUIElement {
         view.buttons["Redirect with OAuth error"]
     }
+    
+    var invalidStateButton: XCUIElement {
+        view.buttons["Redirect with invalid state"]
+    }
+    
+    var fourHundredResponseErrorButton: XCUIElement {
+        view.buttons["Set up 400 response from /token"]
+    }
+    
+    var fiveHundredResponseErrorButton: XCUIElement {
+        view.buttons["Set up 500 response from /token"]
+    }
 
     func tapCancelButton() {
         cancelButton.tap()
@@ -37,5 +49,23 @@ struct LoginModal: ScreenObject {
         oAuthErrorButton.tap()
 
         return ErrorScreen(app: app).waitForAppearance()
+    }
+    
+    func tapBrowserInvalidStateErrorButton() -> ErrorScreen {
+        invalidStateButton.tap()
+
+        return ErrorScreen(app: app).waitForAppearance()
+    }
+    
+    func tapBrowserFourHundredResponseErrorButton() -> LoginModalSecondScreen {
+        fourHundredResponseErrorButton.tap()
+
+        return LoginModalSecondScreen(app: app).waitForAppearance()
+    }
+    
+    func tapBrowserFiveHundredResponseErrorButton() -> LoginModalSecondScreen {
+        fiveHundredResponseErrorButton.tap()
+
+        return LoginModalSecondScreen(app: app).waitForAppearance()
     }
 }

--- a/Tests/UITests/ScreenObjects/App/LoginModalSecondScreen.swift
+++ b/Tests/UITests/ScreenObjects/App/LoginModalSecondScreen.swift
@@ -1,0 +1,23 @@
+import XCTest
+
+struct LoginModalSecondScreen: ScreenObject {
+    let app: XCUIApplication
+    
+    var view: XCUIElement {
+        app.webViews.firstMatch
+    }
+    
+    var title: XCUIElement {
+        view.staticTexts["Welcome to the Auth Stub"]
+    }
+    
+    var loginButton: XCUIElement {
+        view.buttons["Login"]
+    }
+    
+    func tapBrowserLoginButton() -> ErrorScreen {
+        loginButton.tap()
+        
+        return ErrorScreen(app: app).waitForAppearance()
+    }
+}

--- a/Tests/UITests/ScreenObjects/App/TokensScreen.swift
+++ b/Tests/UITests/ScreenObjects/App/TokensScreen.swift
@@ -2,11 +2,11 @@ import XCTest
 
 struct TokensScreen: ScreenObject {
     let app: XCUIApplication
-
+    
     var view: XCUIElement {
         app.firstMatch
     }
-
+    
     var title: XCUIElement {
         app.staticTexts["Logged in"]
     }

--- a/Tests/UITests/ScreenObjects/App/WelcomeScreen.swift
+++ b/Tests/UITests/ScreenObjects/App/WelcomeScreen.swift
@@ -2,26 +2,26 @@ import XCTest
 
 struct WelcomeScreen: ScreenObject {
     let app = XCUIApplication()
-
+    
     var view: XCUIElement {
         app.scrollViews.firstMatch
     }
-
+    
     var title: XCUIElement {
         app.staticTexts["intro-title"]
     }
-
+    
     var body: XCUIElement {
         app.staticTexts["intro-body"]
     }
-
+    
     var signInButton: XCUIElement {
         app.buttons["intro-button"]
     }
-
+    
     func tapLoginButton() -> LoginModal {
         signInButton.tap()
-
+        
         let loginModal = LoginModal(app: app).waitForAppearance()
         let browserElements = [
             loginModal.view,

--- a/Tests/UITests/ScreenObjects/App/WelcomeScreen.swift
+++ b/Tests/UITests/ScreenObjects/App/WelcomeScreen.swift
@@ -23,7 +23,15 @@ struct WelcomeScreen: ScreenObject {
         signInButton.tap()
 
         let loginModal = LoginModal(app: app).waitForAppearance()
-        _ = loginModal.view.waitForExistence(timeout: .timeout)
+        let browserElements = [
+            loginModal.view,
+            loginModal.title,
+            loginModal.loginButton,
+            loginModal.oAuthErrorButton
+        ]
+        _ = browserElements.map {
+            $0.waitForExistence(timeout: .timeout)
+        }
         return loginModal
     }
 }

--- a/Tests/UITests/ScreenObjects/App/WelcomeScreen.swift
+++ b/Tests/UITests/ScreenObjects/App/WelcomeScreen.swift
@@ -27,7 +27,10 @@ struct WelcomeScreen: ScreenObject {
             loginModal.view,
             loginModal.title,
             loginModal.loginButton,
-            loginModal.oAuthErrorButton
+            loginModal.oAuthErrorButton,
+            loginModal.invalidStateButton,
+            loginModal.fourHundredResponseErrorButton,
+            loginModal.fiveHundredResponseErrorButton
         ]
         _ = browserElements.map {
             $0.waitForExistence(timeout: .timeout)

--- a/Tests/UITests/ScreenObjects/ScreenObject.swift
+++ b/Tests/UITests/ScreenObjects/ScreenObject.swift
@@ -8,7 +8,7 @@ extension ScreenObject {
     var isVisible: Bool {
         view.isHittable
     }
-
+    
     func waitForAppearance() -> Self {
         _ = view.waitForExistence(timeout: .timeout)
         return self

--- a/Tests/UnitTests/Errors/UnableToLoginErrorViewModelTests.swift
+++ b/Tests/UnitTests/Errors/UnableToLoginErrorViewModelTests.swift
@@ -6,21 +6,21 @@ final class UnableToLoginErrorViewModelTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
     var sut: UnableToLoginErrorViewModel!
     var didCallButtonAction = false
-
+    
     override func setUp() {
         super.setUp()
-
+        
         mockAnalyticsService = MockAnalyticsService()
         sut = UnableToLoginErrorViewModel(analyticsService: mockAnalyticsService) {
             self.didCallButtonAction = true
         }
     }
-
+    
     override func tearDown() {
         mockAnalyticsService = nil
         sut = nil
         didCallButtonAction = false
-
+        
         super.tearDown()
     }
 }
@@ -31,7 +31,7 @@ extension UnableToLoginErrorViewModelTests {
         XCTAssertEqual(sut.title.value, "There was a problem signing you in")
         XCTAssertEqual(sut.body.value, "You can try signing in again.\n\nIf this does not work, you may need to try again later.")
     }
-
+    
     func test_buttonAction() throws {
         XCTAssertFalse(didCallButtonAction)
         XCTAssertEqual(mockAnalyticsService.eventsLogged.count, 0)
@@ -43,7 +43,7 @@ extension UnableToLoginErrorViewModelTests {
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["text"], event.parameters["text"])
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["type"], event.parameters["type"])
     }
-
+    
     func test_didAppear() throws {
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 0)
         sut.didAppear()

--- a/Tests/UnitTests/Errors/UnableToLoginErrorViewModelTests.swift
+++ b/Tests/UnitTests/Errors/UnableToLoginErrorViewModelTests.swift
@@ -1,0 +1,56 @@
+import GDSAnalytics
+@testable import OneLogin
+import XCTest
+
+final class UnableToLoginErrorViewModelTests: XCTestCase {
+    var mockAnalyticsService: MockAnalyticsService!
+    var sut: UnableToLoginErrorViewModel!
+    var didCallButtonAction = false
+
+    override func setUp() {
+        super.setUp()
+
+        mockAnalyticsService = MockAnalyticsService()
+        sut = UnableToLoginErrorViewModel(analyticsService: mockAnalyticsService) {
+            self.didCallButtonAction = true
+        }
+    }
+
+    override func tearDown() {
+        mockAnalyticsService = nil
+        sut = nil
+        didCallButtonAction = false
+
+        super.tearDown()
+    }
+}
+
+extension UnableToLoginErrorViewModelTests {
+    func test_labelContents() throws {
+        XCTAssertEqual(sut.image, "exclamationmark.circle")
+        XCTAssertEqual(sut.title.value, "There was a problem signing you in")
+        XCTAssertEqual(sut.body.value, "You can try signing in again.\n\nIf this does not work, you may need to try again later.")
+    }
+
+    func test_buttonAction() throws {
+        XCTAssertFalse(didCallButtonAction)
+        XCTAssertEqual(mockAnalyticsService.eventsLogged.count, 0)
+        sut.primaryButtonViewModel.action()
+        XCTAssertTrue(didCallButtonAction)
+        XCTAssertEqual(mockAnalyticsService.eventsLogged.count, 1)
+        let event = ButtonEvent(textKey: sut.primaryButtonViewModel.title.value)
+        XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
+        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["text"], event.parameters["text"])
+        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["type"], event.parameters["type"])
+    }
+
+    func test_didAppear() throws {
+        XCTAssertEqual(mockAnalyticsService.screensVisited.count, 0)
+        sut.didAppear()
+        XCTAssertEqual(mockAnalyticsService.screensVisited.count, 1)
+        let screen = ScreenView(screen: ErrorAnalyticsScreen.unableToLogin,
+                                titleKey: "There was a problem signing you in")
+        XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.screen.name])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
+    }
+}

--- a/Tests/UnitTests/Mocks/Sessions+Services/MockLoginSession.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/MockLoginSession.swift
@@ -9,7 +9,7 @@ final class MockLoginSession: LoginSession {
     var errorFromFinalise: Error?
     var sessionConfiguration: LoginSessionConfiguration?
     var callbackURL: URL?
-
+    
     init(window: UIWindow = UIWindow()) {
         self.window = window
     }

--- a/Tests/UnitTests/Mocks/Sessions+Services/MockLoginSession.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/MockLoginSession.swift
@@ -9,11 +9,7 @@ final class MockLoginSession: LoginSession {
     var throwErrorFromFinalise = false
     var sessionConfiguration: LoginSessionConfiguration?
     var callbackURL: URL?
-    
-    private enum LoginError: Error {
-        case genericError
-    }
-    
+
     init(window: UIWindow = UIWindow()) {
         self.window = window
     }
@@ -27,7 +23,7 @@ final class MockLoginSession: LoginSession {
         didCallFinalise = true
         callbackURL = redirectURL
         if throwErrorFromFinalise {
-            throw LoginError.genericError
+            throw LoginError.generic(description: "")
         } else {
             return try MockTokenResponse().getJSONData()
         }

--- a/Tests/UnitTests/Mocks/Sessions+Services/MockLoginSession.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/MockLoginSession.swift
@@ -6,7 +6,7 @@ final class MockLoginSession: LoginSession {
     var didCallPresent = false
     var didCallFinalise = false
     var didCallCancel = false
-    var throwErrorFromFinalise = false
+    var errorFromFinalise: Error?
     var sessionConfiguration: LoginSessionConfiguration?
     var callbackURL: URL?
 
@@ -22,8 +22,8 @@ final class MockLoginSession: LoginSession {
     func finalise(redirectURL: URL) throws -> TokenResponse {
         didCallFinalise = true
         callbackURL = redirectURL
-        if throwErrorFromFinalise {
-            throw LoginError.generic(description: "")
+        if let errorFromFinalise {
+            throw errorFromFinalise
         } else {
             return try MockTokenResponse().getJSONData()
         }

--- a/Tests/UnitTests/Onboarding/AuthenticationCoordinatorTests.swift
+++ b/Tests/UnitTests/Onboarding/AuthenticationCoordinatorTests.swift
@@ -40,6 +40,10 @@ final class AuthenticationCoordinatorTests: XCTestCase {
         
         super.tearDown()
     }
+
+    private enum AuthenticationError: Error {
+        case catchAll
+    }
 }
 
 extension AuthenticationCoordinatorTests {
@@ -93,8 +97,21 @@ extension AuthenticationCoordinatorTests {
         XCTAssertEqual(mainCoordinator.tokens?.idToken, idToken)
     }
     
-    func test_handleUniversalLink_finaliseCalled_genericError() throws {
-        mockLoginSession.throwErrorFromFinalise = true
+    func test_handleUniversalLink_finaliseCalled_catchAllError() throws {
+        mockLoginSession.errorFromFinalise = AuthenticationError.catchAll
+        mockMainCoordinator.openChildInline(sut)
+        // GIVEN the AuthenticationCoordinator has logged in via start()
+        sut.start()
+        // WHEN the AuthenticationCoordinator calls finalise
+        let callbackURL = URL(string: "https://www.test.com")!
+        sut.handleUniversalLink(callbackURL)
+        waitForTruth(self.mockLoginSession.didCallFinalise, timeout: 3)
+        XCTAssertEqual(mockLoginSession.callbackURL, callbackURL)
+        XCTAssertTrue(sut.root.topViewController is GDSErrorViewController)
+    }
+
+    func test_handleUniversalLink_finaliseCalled_loginError() throws {
+        mockLoginSession.errorFromFinalise = LoginError.generic(description: "")
         mockMainCoordinator.openChildInline(sut)
         // GIVEN the AuthenticationCoordinator has logged in via start()
         sut.start()

--- a/Tests/UnitTests/Onboarding/AuthenticationCoordinatorTests.swift
+++ b/Tests/UnitTests/Onboarding/AuthenticationCoordinatorTests.swift
@@ -40,7 +40,7 @@ final class AuthenticationCoordinatorTests: XCTestCase {
         
         super.tearDown()
     }
-
+    
     private enum AuthenticationError: Error {
         case catchAll
     }
@@ -109,7 +109,7 @@ extension AuthenticationCoordinatorTests {
         XCTAssertEqual(mockLoginSession.callbackURL, callbackURL)
         XCTAssertTrue(sut.root.topViewController is GDSErrorViewController)
     }
-
+    
     func test_handleUniversalLink_finaliseCalled_loginError() throws {
         mockLoginSession.errorFromFinalise = LoginError.generic(description: "")
         mockMainCoordinator.openChildInline(sut)

--- a/Tests/UnitTests/Onboarding/AuthenticationCoordinatorTests.swift
+++ b/Tests/UnitTests/Onboarding/AuthenticationCoordinatorTests.swift
@@ -107,7 +107,10 @@ extension AuthenticationCoordinatorTests {
         sut.handleUniversalLink(callbackURL)
         waitForTruth(self.mockLoginSession.didCallFinalise, timeout: 3)
         XCTAssertEqual(mockLoginSession.callbackURL, callbackURL)
-        XCTAssertTrue(sut.root.topViewController is GDSErrorViewController)
+        // THEN the 'something went wrong' error screen is shown
+        let vc = sut.root.topViewController as? GDSErrorViewController
+        XCTAssertTrue(vc != nil)
+        XCTAssertTrue(vc?.viewModel is GenericErrorViewModel)
     }
     
     func test_handleUniversalLink_finaliseCalled_loginError() throws {
@@ -120,6 +123,9 @@ extension AuthenticationCoordinatorTests {
         sut.handleUniversalLink(callbackURL)
         waitForTruth(self.mockLoginSession.didCallFinalise, timeout: 3)
         XCTAssertEqual(mockLoginSession.callbackURL, callbackURL)
-        XCTAssertTrue(sut.root.topViewController is GDSErrorViewController)
+        // THEN the 'unable to login' error screen is shown
+        let vc = sut.root.topViewController as? GDSErrorViewController
+        XCTAssertTrue(vc != nil)
+        XCTAssertTrue(vc?.viewModel is UnableToLoginErrorViewModel)
     }
 }

--- a/Tests/UnitTests/Utilities/ErrorPresenterTests.swift
+++ b/Tests/UnitTests/Utilities/ErrorPresenterTests.swift
@@ -30,4 +30,13 @@ extension ErrorPresenterTests {
         introButton.sendActions(for: .touchUpInside)
         XCTAssertTrue(didCallAction)
     }
+    
+    func test_unableToLoginErrorCallsAction() throws {
+        let introView = sut.createUnableToLoginError(analyticsService: mockAnalyticsService) {
+            self.didCallAction = true
+        }
+        let introButton: UIButton = try XCTUnwrap(introView.view[child: "error-primary-button"])
+        introButton.sendActions(for: .touchUpInside)
+        XCTAssertTrue(didCallAction)
+    }
 }


### PR DESCRIPTION
# DCMAW-7113: iOS | User sees 'Unable to login' error when Auth returns incorrect state
# DCMAW-7414: iOS | User sees 'Unable to login' error when a login API error occurs
# DCMAW-7413: iOS | User sees 'Unable to login' error when oAuth error occurs

This PR shows an "Unable to log in" error screen when a `LoginError` is thrown from the [authentication package](https://github.com/govuk-one-login/mobile-ios-authentication)

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
