### PR TITLE
fix: updating to latest ui common package commit

### DIFF
--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -114,7 +114,7 @@
       "location" : "https://github.com/govuk-one-login/mobile-ios-common.git",
       "state" : {
         "branch" : "main",
-        "revision" : "7dec63da8f8bf99b90b69eefb279cb400014327e"
+        "revision" : "12e7f8554b6bc34739596f29ef1a6412ec4504a9"
       }
     },
     {


### PR DESCRIPTION
# iOS | Unblock One Login deployment pipeline using Xcode 14 on UI tests

Updating to the latest common UI package commit which had a breaking change for the One Login repo to do with using the `viewIsAppearing` lifecycle event when running on versions of Xcode below 15.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
~- [] Written Unit and Integration tests if needed~

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
