### PR TITLE
Revert "fix: updating to latest ui common package commit"

### DIFF
--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -114,7 +114,7 @@
       "location" : "https://github.com/govuk-one-login/mobile-ios-common.git",
       "state" : {
         "branch" : "main",
-        "revision" : "12e7f8554b6bc34739596f29ef1a6412ec4504a9"
+        "revision" : "7dec63da8f8bf99b90b69eefb279cb400014327e"
       }
     },
     {


### PR DESCRIPTION
Reverts govuk-one-login/mobile-ios-one-login-app#35 as UI tests are still failing