### PR TITLE
feat: network connection error screen

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		41A0BD0A2B272118009AE51F /* ErrorScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A0BD092B272118009AE51F /* ErrorScreen.swift */; };
 		41A0BD0C2B2725C8009AE51F /* TokensScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A0BD0B2B2725C8009AE51F /* TokensScreen.swift */; };
 		41A0BD112B2758E6009AE51F /* GenericErrorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A0BD0F2B275168009AE51F /* GenericErrorViewModelTests.swift */; };
+		41C5E32F2B45A36E00212A12 /* NetworkConnectionErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41C5E32E2B45A36E00212A12 /* NetworkConnectionErrorViewModel.swift */; };
 		41FF35AA2B21F06C00419DB3 /* ErrorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41FF35A92B21F06C00419DB3 /* ErrorPresenter.swift */; };
 		41FF35AC2B21F1AA00419DB3 /* GenericErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41FF35AB2B21F1AA00419DB3 /* GenericErrorViewModel.swift */; };
 		41FF35AF2B222CAC00419DB3 /* AuthenticationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B3207A2B063CA100FECDF0 /* AuthenticationCoordinatorTests.swift */; };
@@ -120,6 +121,7 @@
 		41A0BD092B272118009AE51F /* ErrorScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorScreen.swift; sourceTree = "<group>"; };
 		41A0BD0B2B2725C8009AE51F /* TokensScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokensScreen.swift; sourceTree = "<group>"; };
 		41A0BD0F2B275168009AE51F /* GenericErrorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericErrorViewModelTests.swift; sourceTree = "<group>"; };
+		41C5E32E2B45A36E00212A12 /* NetworkConnectionErrorViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkConnectionErrorViewModel.swift; sourceTree = "<group>"; };
 		41FF35A92B21F06C00419DB3 /* ErrorPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorPresenter.swift; sourceTree = "<group>"; };
 		41FF35AB2B21F1AA00419DB3 /* GenericErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericErrorViewModel.swift; sourceTree = "<group>"; };
 		C8098B962AEFF1AB001517A0 /* LoginSessionConfiguration+OneLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoginSessionConfiguration+OneLogin.swift"; sourceTree = "<group>"; };
@@ -316,6 +318,7 @@
 			isa = PBXGroup;
 			children = (
 				41FF35AB2B21F1AA00419DB3 /* GenericErrorViewModel.swift */,
+				41C5E32E2B45A36E00212A12 /* NetworkConnectionErrorViewModel.swift */,
 				C8AA11D72B29C7FA00CE718B /* UnableToLoginErrorViewModel.swift */,
 			);
 			path = Errors;
@@ -808,6 +811,7 @@
 				C8098B972AEFF1AB001517A0 /* LoginSessionConfiguration+OneLogin.swift in Sources */,
 				C8098B992AEFF287001517A0 /* AnalyticsService+GDS.swift in Sources */,
 				C8B320792B062F9100FECDF0 /* AuthenticationCoordinator.swift in Sources */,
+				41C5E32F2B45A36E00212A12 /* NetworkConnectionErrorViewModel.swift in Sources */,
 				C85E21042ACEE34900AF8B4E /* MainCoordinator.swift in Sources */,
 				41FF35AC2B21F1AA00419DB3 /* GenericErrorViewModel.swift in Sources */,
 				C8AA11D82B29C7FA00CE718B /* UnableToLoginErrorViewModel.swift in Sources */,

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		41A0BD0C2B2725C8009AE51F /* TokensScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A0BD0B2B2725C8009AE51F /* TokensScreen.swift */; };
 		41A0BD112B2758E6009AE51F /* GenericErrorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A0BD0F2B275168009AE51F /* GenericErrorViewModelTests.swift */; };
 		41C5E32F2B45A36E00212A12 /* NetworkConnectionErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41C5E32E2B45A36E00212A12 /* NetworkConnectionErrorViewModel.swift */; };
+		41C5E3322B45B07D00212A12 /* NetworkConnectionErrorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41C5E3302B45AFAA00212A12 /* NetworkConnectionErrorViewModelTests.swift */; };
 		41FF35AA2B21F06C00419DB3 /* ErrorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41FF35A92B21F06C00419DB3 /* ErrorPresenter.swift */; };
 		41FF35AC2B21F1AA00419DB3 /* GenericErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41FF35AB2B21F1AA00419DB3 /* GenericErrorViewModel.swift */; };
 		41FF35AF2B222CAC00419DB3 /* AuthenticationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B3207A2B063CA100FECDF0 /* AuthenticationCoordinatorTests.swift */; };
@@ -122,6 +123,7 @@
 		41A0BD0B2B2725C8009AE51F /* TokensScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokensScreen.swift; sourceTree = "<group>"; };
 		41A0BD0F2B275168009AE51F /* GenericErrorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericErrorViewModelTests.swift; sourceTree = "<group>"; };
 		41C5E32E2B45A36E00212A12 /* NetworkConnectionErrorViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkConnectionErrorViewModel.swift; sourceTree = "<group>"; };
+		41C5E3302B45AFAA00212A12 /* NetworkConnectionErrorViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkConnectionErrorViewModelTests.swift; sourceTree = "<group>"; };
 		41FF35A92B21F06C00419DB3 /* ErrorPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorPresenter.swift; sourceTree = "<group>"; };
 		41FF35AB2B21F1AA00419DB3 /* GenericErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericErrorViewModel.swift; sourceTree = "<group>"; };
 		C8098B962AEFF1AB001517A0 /* LoginSessionConfiguration+OneLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoginSessionConfiguration+OneLogin.swift"; sourceTree = "<group>"; };
@@ -309,6 +311,7 @@
 			isa = PBXGroup;
 			children = (
 				41A0BD0F2B275168009AE51F /* GenericErrorViewModelTests.swift */,
+				41C5E3302B45AFAA00212A12 /* NetworkConnectionErrorViewModelTests.swift */,
 				410464F52B29D078000E7CB2 /* UnableToLoginErrorViewModelTests.swift */,
 			);
 			path = Errors;
@@ -838,6 +841,7 @@
 				21E04DFC2AE6BC5B004C6660 /* MockAnalyticsService.swift in Sources */,
 				C8520C252AE2BFAD006790C1 /* UIView+TestExtensions.swift in Sources */,
 				C8520C2E2AE2C822006790C1 /* MockTokenResponse.swift in Sources */,
+				41C5E3322B45B07D00212A12 /* NetworkConnectionErrorViewModelTests.swift in Sources */,
 				C8B5EFC52B0E53EE004EA4D4 /* XCTestCase+Extensions.swift in Sources */,
 				219602022A976305008F3427 /* MainCoordinatorTests.swift in Sources */,
 				C87913C12B275F4900545B33 /* ErrorPresenterTests.swift in Sources */,

--- a/Sources/Analytics/Errors/ErrorAnalytics.swift
+++ b/Sources/Analytics/Errors/ErrorAnalytics.swift
@@ -4,5 +4,5 @@ import Logging
 enum ErrorAnalyticsScreen: String, LoggableScreen, NamedScreen {
     case generic = "genericErrorScreen"
     case unableToLogin = "unableToLoginErrorScreen"
-    case networkConnectionError = "networkConnectionErrorScreen"
+    case networkConnection = "networkConnectionErrorScreen"
 }

--- a/Sources/Analytics/Errors/ErrorAnalytics.swift
+++ b/Sources/Analytics/Errors/ErrorAnalytics.swift
@@ -4,4 +4,5 @@ import Logging
 enum ErrorAnalyticsScreen: String, LoggableScreen, NamedScreen {
     case generic = "genericErrorScreen"
     case unableToLogin = "unableToLoginErrorScreen"
+    case networkConnectionError = "networkConnectionErrorScreen"
 }

--- a/Sources/Errors/NetworkConnectionErrorViewModel.swift
+++ b/Sources/Errors/NetworkConnectionErrorViewModel.swift
@@ -3,16 +3,16 @@ import GDSCommon
 import Logging
 
 struct NetworkConnectionErrorViewModel: GDSErrorViewModel, BaseViewModel {
-    var image: String = "exclamationmark.circle"
+    let image: String = "exclamationmark.circle"
     // TODO: DCMAW-7083: String keys for localisation needed
-    var title: GDSLocalisedString = "You appear to be offline"
-    var body: GDSLocalisedString = "GOV.UK One Login is not avaliable offline. \nReconnect to the internet and try again."
-    var primaryButtonViewModel: ButtonViewModel
-    var secondaryButtonViewModel: ButtonViewModel? = nil
+    let title: GDSLocalisedString = "You appear to be offline"
+    let body: GDSLocalisedString = "GOV.UK One Login is not avaliable offline. \nReconnect to the internet and try again."
+    let primaryButtonViewModel: ButtonViewModel
+    let secondaryButtonViewModel: ButtonViewModel? = nil
     let analyticsService: AnalyticsService
     
-    var rightBarButtonTitle: GDSLocalisedString? = nil
-    var backButtonIsHidden: Bool = true
+    let rightBarButtonTitle: GDSLocalisedString? = nil
+    let backButtonIsHidden: Bool = true
     
     init(analyticsService: AnalyticsService, action: @escaping () -> Void) {
         self.analyticsService = analyticsService

--- a/Sources/Errors/NetworkConnectionErrorViewModel.swift
+++ b/Sources/Errors/NetworkConnectionErrorViewModel.swift
@@ -6,7 +6,7 @@ struct NetworkConnectionErrorViewModel: GDSErrorViewModel, BaseViewModel {
     var image: String = "exclamationmark.circle"
     // TODO: DCMAW-7083: String keys for localisation needed
     var title: GDSLocalisedString = "You appear to be offline"
-    var body: GDSLocalisedString = "GOV.UK One Login is not avaliable offline. \nReconnect to the internet to continue."
+    var body: GDSLocalisedString = "GOV.UK One Login is not avaliable offline. \nReconnect to the internet and try again."
     var primaryButtonViewModel: ButtonViewModel
     var secondaryButtonViewModel: ButtonViewModel? = nil
     let analyticsService: AnalyticsService

--- a/Sources/Errors/NetworkConnectionErrorViewModel.swift
+++ b/Sources/Errors/NetworkConnectionErrorViewModel.swift
@@ -23,7 +23,7 @@ struct NetworkConnectionErrorViewModel: GDSErrorViewModel, BaseViewModel {
     }
     
     func didAppear() {
-        let screen = ScreenView(screen: ErrorAnalyticsScreen.networkConnectionError,
+        let screen = ScreenView(screen: ErrorAnalyticsScreen.networkConnection,
                                 titleKey: title.stringKey)
         analyticsService.trackScreen(screen)
     }

--- a/Sources/Errors/NetworkConnectionErrorViewModel.swift
+++ b/Sources/Errors/NetworkConnectionErrorViewModel.swift
@@ -1,0 +1,34 @@
+import GDSAnalytics
+import GDSCommon
+import Logging
+
+struct NetworkConnectionErrorViewModel: GDSErrorViewModel, BaseViewModel {
+    var image: String = "exclamationmark.circle"
+    // TODO: DCMAW-7083: String keys for localisation needed
+    var title: GDSLocalisedString = "You appear to be offline"
+    var body: GDSLocalisedString = "GOV.UK One Login is not avaliable offline. \nReconnect to the internet to continue."
+    var primaryButtonViewModel: ButtonViewModel
+    var secondaryButtonViewModel: ButtonViewModel? = nil
+    let analyticsService: AnalyticsService
+    
+    var rightBarButtonTitle: GDSLocalisedString? = nil
+    var backButtonIsHidden: Bool = true
+    
+    init(analyticsService: AnalyticsService, action: @escaping () -> Void) {
+        self.analyticsService = analyticsService
+        self.primaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "Try again",
+                                                               analyticsService: analyticsService) {
+            action()
+        }
+    }
+    
+    func didAppear() {
+        let screen = ScreenView(screen: ErrorAnalyticsScreen.networkConnectionError,
+                                titleKey: title.stringKey)
+        analyticsService.trackScreen(screen)
+    }
+    
+    func didDismiss() {
+        // Here for BaseViewModel compliance
+    }
+}

--- a/Sources/Utilities/ErrorPresenter.swift
+++ b/Sources/Utilities/ErrorPresenter.swift
@@ -17,4 +17,12 @@ final class ErrorPresenter {
         }
         return GDSErrorViewController(viewModel: viewModel)
     }
+    
+    static func createNetworkConnectionError(analyticsService: AnalyticsService,
+                                             action: @escaping () -> Void) -> GDSErrorViewController {
+        let viewModel = NetworkConnectionErrorViewModel(analyticsService: analyticsService) {
+            action()
+        }
+        return GDSErrorViewController(viewModel: viewModel)
+    }
 }

--- a/Tests/UnitTests/Errors/NetworkConnectionErrorViewModelTests.swift
+++ b/Tests/UnitTests/Errors/NetworkConnectionErrorViewModelTests.swift
@@ -29,7 +29,7 @@ extension NetworkConnectionErrorViewModelTests {
     func test_labelContents() throws {
         XCTAssertEqual(sut.image, "exclamationmark.circle")
         XCTAssertEqual(sut.title.value, "You appear to be offline")
-        XCTAssertEqual(sut.body.value, "GOV.UK One Login is not avaliable offline. \nReconnect to the internet to continue.")
+        XCTAssertEqual(sut.body.value, "GOV.UK One Login is not avaliable offline. \nReconnect to the internet and try again.")
     }
     
     func test_buttonAction() throws {

--- a/Tests/UnitTests/Errors/NetworkConnectionErrorViewModelTests.swift
+++ b/Tests/UnitTests/Errors/NetworkConnectionErrorViewModelTests.swift
@@ -48,7 +48,7 @@ extension NetworkConnectionErrorViewModelTests {
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 0)
         sut.didAppear()
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 1)
-        let screen = ScreenView(screen: ErrorAnalyticsScreen.networkConnectionError,
+        let screen = ScreenView(screen: ErrorAnalyticsScreen.networkConnection,
                                 titleKey: "You appear to be offline")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])

--- a/Tests/UnitTests/Errors/NetworkConnectionErrorViewModelTests.swift
+++ b/Tests/UnitTests/Errors/NetworkConnectionErrorViewModelTests.swift
@@ -1,0 +1,56 @@
+import GDSAnalytics
+@testable import OneLogin
+import XCTest
+
+final class NetworkConnectionErrorViewModelTests: XCTestCase {
+    var mockAnalyticsService: MockAnalyticsService!
+    var sut: NetworkConnectionErrorViewModel!
+    var didCallButtonAction = false
+    
+    override func setUp() {
+        super.setUp()
+        
+        mockAnalyticsService = MockAnalyticsService()
+        sut = NetworkConnectionErrorViewModel(analyticsService: mockAnalyticsService) {
+            self.didCallButtonAction = true
+        }
+    }
+    
+    override func tearDown() {
+        mockAnalyticsService = nil
+        sut = nil
+        didCallButtonAction = false
+        
+        super.tearDown()
+    }
+}
+
+extension NetworkConnectionErrorViewModelTests {
+    func test_labelContents() throws {
+        XCTAssertEqual(sut.image, "exclamationmark.circle")
+        XCTAssertEqual(sut.title.value, "You appear to be offline")
+        XCTAssertEqual(sut.body.value, "GOV.UK One Login is not avaliable offline. \nReconnect to the internet to continue.")
+    }
+    
+    func test_buttonAction() throws {
+        XCTAssertFalse(didCallButtonAction)
+        XCTAssertEqual(mockAnalyticsService.eventsLogged.count, 0)
+        sut.primaryButtonViewModel.action()
+        XCTAssertTrue(didCallButtonAction)
+        XCTAssertEqual(mockAnalyticsService.eventsLogged.count, 1)
+        let event = ButtonEvent(textKey: sut.primaryButtonViewModel.title.value)
+        XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
+        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["text"], event.parameters["text"])
+        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["type"], event.parameters["type"])
+    }
+    
+    func test_didAppear() throws {
+        XCTAssertEqual(mockAnalyticsService.screensVisited.count, 0)
+        sut.didAppear()
+        XCTAssertEqual(mockAnalyticsService.screensVisited.count, 1)
+        let screen = ScreenView(screen: ErrorAnalyticsScreen.networkConnectionError,
+                                titleKey: "You appear to be offline")
+        XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.screen.name])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
+    }
+}

--- a/Tests/UnitTests/Utilities/ErrorPresenterTests.swift
+++ b/Tests/UnitTests/Utilities/ErrorPresenterTests.swift
@@ -41,7 +41,7 @@ extension ErrorPresenterTests {
     }
     
     func test_networkConnectionErrorCallsAction() throws {
-        let introView = sut.createNetworkConnectionError(analyticsService: mockAnalyticsService){
+        let introView = sut.createNetworkConnectionError(analyticsService: mockAnalyticsService) {
             self.didCallAction = true
         }
         let introButton: UIButton = try XCTUnwrap(introView.view[child: "error-primary-button"])

--- a/Tests/UnitTests/Utilities/ErrorPresenterTests.swift
+++ b/Tests/UnitTests/Utilities/ErrorPresenterTests.swift
@@ -39,4 +39,13 @@ extension ErrorPresenterTests {
         introButton.sendActions(for: .touchUpInside)
         XCTAssertTrue(didCallAction)
     }
+    
+    func test_networkConnectionErrorCallsAction() throws {
+        let introView = sut.createNetworkConnectionError(analyticsService: mockAnalyticsService){
+            self.didCallAction = true
+        }
+        let introButton: UIButton = try XCTUnwrap(introView.view[child: "error-primary-button"])
+        introButton.sendActions(for: .touchUpInside)
+        XCTAssertTrue(didCallAction)
+    }
 }


### PR DESCRIPTION
# DCMAW-7419: Network connection error screen created

_This PR created a network connection error screen, which is ready to be used when an network connection error is thrown._

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
