### PR TITLE
feat: displaying network connection error and handling cancellation of modal

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -1719,7 +1719,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/govuk-one-login/mobile-ios-authentication.git";
 			requirement = {
-				branch = main;
+				branch = "feature/dcmaw-7694-handle-modal-cancel-error";
 				kind = branch;
 			};
 		};
@@ -1735,8 +1735,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/govuk-one-login/mobile-ios-coordination.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				branch = test;
+				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -1719,7 +1719,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/govuk-one-login/mobile-ios-authentication.git";
 			requirement = {
-				branch = "feature/dcmaw-7694-handle-modal-cancel-error";
+				branch = main;
 				kind = branch;
 			};
 		};
@@ -1735,7 +1735,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/govuk-one-login/mobile-ios-coordination.git";
 			requirement = {
-				branch = test;
+				branch = main;
 				kind = branch;
 			};
 		};

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -1719,7 +1719,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/govuk-one-login/mobile-ios-authentication.git";
 			requirement = {
-				branch = main;
+				branch = "feature/dcmaw-7253-transform-network-error";
 				kind = branch;
 			};
 		};

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-authentication.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "e98bd99fde3214010fa9f679b6b1bf9557ded40c"
+        "branch" : "feature/dcmaw-7694-handle-modal-cancel-error",
+        "revision" : "506aaeacca2648570f99c53d591e5afaa9013677"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-coordination.git",
       "state" : {
-        "revision" : "b732b24b67871d898f526a3e2165141719282964",
-        "version" : "1.0.0"
+        "branch" : "test",
+        "revision" : "cca4a6241862b55988f2375b3c144ebafbcf583b"
       }
     },
     {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-authentication.git",
       "state" : {
-        "branch" : "feature/dcmaw-7694-handle-modal-cancel-error",
-        "revision" : "506aaeacca2648570f99c53d591e5afaa9013677"
+        "branch" : "main",
+        "revision" : "10c321857c64d751af22a1cae1a93300158c9f76"
       }
     },
     {
@@ -114,7 +114,7 @@
       "location" : "https://github.com/govuk-one-login/mobile-ios-common.git",
       "state" : {
         "branch" : "main",
-        "revision" : "12e7f8554b6bc34739596f29ef1a6412ec4504a9"
+        "revision" : "9dfbd05be37efe9f531c5a320e178f9bc30a0e41"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-coordination.git",
       "state" : {
-        "branch" : "test",
-        "revision" : "cca4a6241862b55988f2375b3c144ebafbcf583b"
+        "branch" : "main",
+        "revision" : "92e36a080f715415d2c14c010c6570d398e6a670"
       }
     },
     {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-authentication.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "10c321857c64d751af22a1cae1a93300158c9f76"
+        "branch" : "feature/dcmaw-7253-transform-network-error",
+        "revision" : "42ad4aabe261dbb08055e57259a5e1e9f4f5d0ea"
       }
     },
     {

--- a/Sources/Onboarding/AuthenticationCoordinator.swift
+++ b/Sources/Onboarding/AuthenticationCoordinator.swift
@@ -28,7 +28,12 @@ final class AuthenticationCoordinator: NSObject,
             do {
                 mainCoordinator.tokens = try await session.performLoginFlow(configuration: LoginSessionConfiguration.oneLogin)
                 finish()
-            } catch let error where error is LoginError {
+            } catch LoginError.network {
+                let networkErrorScreen = errorPresenter.createNetworkConnectionError(analyticsService: analyticsService) {
+                    self.root.popViewController(animated: true)
+                }
+                root.pushViewController(networkErrorScreen, animated: true)
+            } catch LoginError.non200, LoginError.invalidRequest, LoginError.clientError {
                 let unableToLoginErrorScreen = errorPresenter.createUnableToLoginError(analyticsService: analyticsService) {
                     self.root.popViewController(animated: true)
                 }

--- a/Sources/Onboarding/AuthenticationCoordinator.swift
+++ b/Sources/Onboarding/AuthenticationCoordinator.swift
@@ -38,6 +38,8 @@ final class AuthenticationCoordinator: NSObject,
                     self.root.popViewController(animated: true)
                 }
                 root.pushViewController(unableToLoginErrorScreen, animated: true)
+            } catch LoginError.userCancelled {
+                return
             } catch {
                 let genericErrorScreen = errorPresenter.createGenericError(analyticsService: analyticsService) {
                     self.root.popViewController(animated: true)

--- a/Sources/Onboarding/MainCoordinator.swift
+++ b/Sources/Onboarding/MainCoordinator.swift
@@ -24,10 +24,14 @@ final class MainCoordinator: NSObject,
     
     func start() {
         let introViewController = viewControllerFactory.createIntroViewController(analyticsService: analyticsService) { [self] in
-            openChildInline(AuthenticationCoordinator(root: root,
-                                                      session: AppAuthSession(window: window),
-                                                      errorPresenter: errorPresenter,
-                                                      analyticsService: analyticsService))
+            if let authCoordinator = childCoordinators.first(where: { $0 is AuthenticationCoordinator }) as? AuthenticationCoordinator {
+                authCoordinator.start()
+            } else {
+                openChildInline(AuthenticationCoordinator(root: root,
+                                                          session: AppAuthSession(window: window),
+                                                          errorPresenter: errorPresenter,
+                                                          analyticsService: analyticsService))
+            }
         }
         root.setViewControllers([introViewController], animated: false)
     }

--- a/Tests/UnitTests/Mocks/Sessions+Services/MockLoginSession.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/MockLoginSession.swift
@@ -3,20 +3,18 @@ import UIKit
 
 final class MockLoginSession: LoginSession {
     let window: UIWindow
-    var didCallPresent = false
-    var didCallFinalise = false
-    var didCallCancel = false
-    var errorFromLoginFlow: Error?
     var sessionConfiguration: LoginSessionConfiguration?
-    var callbackURL: URL?
+    var didCallPerformLoginFlow = false
+    var errorFromLoginFlow: Error?
+    var errorFromFinalise: Error?
 
     init(window: UIWindow = UIWindow()) {
         self.window = window
     }
 
     func performLoginFlow(configuration: LoginSessionConfiguration) async throws -> TokenResponse {
-        didCallPresent = true
         sessionConfiguration = configuration
+        didCallPerformLoginFlow = true
         if let errorFromLoginFlow {
             throw errorFromLoginFlow
         } else {
@@ -25,11 +23,8 @@ final class MockLoginSession: LoginSession {
     }
 
     func finalise(redirectURL: URL) throws {
-        didCallFinalise = true
-        callbackURL = redirectURL
-    }
-
-    func cancel() {
-        didCallCancel = true
+        if let errorFromFinalise {
+            throw errorFromFinalise
+        }
     }
 }

--- a/Tests/UnitTests/Mocks/Sessions+Services/MockLoginSession.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/MockLoginSession.swift
@@ -2,7 +2,6 @@ import Authentication
 import UIKit
 
 final class MockLoginSession: LoginSession {
-
     let window: UIWindow
     var didCallPresent = false
     var didCallFinalise = false

--- a/Tests/UnitTests/Mocks/Sessions+Services/MockLoginSession.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/MockLoginSession.swift
@@ -2,33 +2,34 @@ import Authentication
 import UIKit
 
 final class MockLoginSession: LoginSession {
+
     let window: UIWindow
     var didCallPresent = false
     var didCallFinalise = false
     var didCallCancel = false
-    var errorFromFinalise: Error?
+    var errorFromLoginFlow: Error?
     var sessionConfiguration: LoginSessionConfiguration?
     var callbackURL: URL?
-    
+
     init(window: UIWindow = UIWindow()) {
         self.window = window
     }
-    
-    func present(configuration: LoginSessionConfiguration) {
+
+    func performLoginFlow(configuration: LoginSessionConfiguration) async throws -> TokenResponse {
         didCallPresent = true
         sessionConfiguration = configuration
-    }
-    
-    func finalise(redirectURL: URL) throws -> TokenResponse {
-        didCallFinalise = true
-        callbackURL = redirectURL
-        if let errorFromFinalise {
-            throw errorFromFinalise
+        if let errorFromLoginFlow {
+            throw errorFromLoginFlow
         } else {
             return try MockTokenResponse().getJSONData()
         }
     }
-    
+
+    func finalise(redirectURL: URL) throws {
+        didCallFinalise = true
+        callbackURL = redirectURL
+    }
+
     func cancel() {
         didCallCancel = true
     }

--- a/Tests/UnitTests/Onboarding/AuthenticationCoordinatorTests.swift
+++ b/Tests/UnitTests/Onboarding/AuthenticationCoordinatorTests.swift
@@ -7,9 +7,9 @@ import XCTest
 final class AuthenticationCoordinatorTests: XCTestCase {
     var window: UIWindow!
     var navigationController: UINavigationController!
-    var mockAnalyticsService: MockAnalyticsService!
-    var mockErrorPresenter: ErrorPresenter.Type!
     var mockLoginSession: MockLoginSession!
+    var mockErrorPresenter: ErrorPresenter.Type!
+    var mockAnalyticsService: MockAnalyticsService!
     var mockMainCoordinator: MainCoordinator!
     var sut: AuthenticationCoordinator!
     

--- a/Tests/UnitTests/Onboarding/AuthenticationCoordinatorTests.swift
+++ b/Tests/UnitTests/Onboarding/AuthenticationCoordinatorTests.swift
@@ -47,11 +47,11 @@ final class AuthenticationCoordinatorTests: XCTestCase {
 }
 
 extension AuthenticationCoordinatorTests {
-    func test_start_authenticationSession_configProperties() throws {
+    func test_start_loginSession_configProperties() throws {
         mockMainCoordinator.openChildInline(sut)
         // WHEN the AuthenticationCoordinator is started
         sut.start()
-        waitForTruth(self.mockLoginSession.sessionConfiguration != nil, timeout: 2)
+        waitForTruth(self.mockLoginSession.didCallPerformLoginFlow, timeout: 2)
         // THEN the session should have the correct login configuration details
         let sessionConfig = try XCTUnwrap(mockLoginSession.sessionConfiguration)
         XCTAssertEqual(sessionConfig.authorizationEndpoint, AppEnvironment.oneLoginAuthorize)
@@ -65,30 +65,19 @@ extension AuthenticationCoordinatorTests {
         XCTAssertEqual(sessionConfig.locale, .en)
     }
     
-    func test_start_authenticationSession_performLoginFlow() throws {
-        mockMainCoordinator.openChildInline(sut)
-        // GIVEN the AuthenticationCoordinator is started
-        sut.start()
-        // THEN the session should call present() with the configuration
-        waitForTruth(self.mockLoginSession.didCallPresent, timeout: 2)
-        waitForTruth(self.mockLoginSession.sessionConfiguration != nil, timeout: 2)
-    }
-    
     func test_handleUniversalLink_successful() throws {
         mockMainCoordinator.openChildInline(sut)
         // GIVEN the AuthenticationCoordinator has logged in via start()
         sut.start()
-        // WHEN the AuthenticationCoordinator calls finalise
-        let callbackURL = URL(string: "https://www.test.com")!
-        sut.handleUniversalLink(callbackURL)
-        
+        // WHEN the AuthenticationCoordinator calls performLoginFlow on the session and there is no error
+
         // swiftlint:disable line_length
         let accessToken = "eEd2wTsYiaXEcZrXYoClvP9uZVvsSsJm4fw8haqSLcH8!B!i=U!/viQGDK3aQq/M2aUdwoxUqevzDX!A8NJFWrZ4VfLP/lgMGXdop=l2QtkLtBvP=iYAXCIBjtyP3i-bY5aP3lF4YLnldq02!jQWfxe1TvWesyMi9D1GIDq!X7JAJTMVHUIKH?-C18/-fcgkxHsQZhs/oFsW/56fTPsvdJPteu10nMF1gY0f8AChM6Yl5FAKX=UOdTHIoVJvf9Dt"
         let refreshToken = "JPz2bPDtrU/NJAedvDC8Xk6eMFlf1qZn9MuYXvCDl?xTZlCUFR?oAwUzXlhlr29MiWf1!2NlFYJ5shibOLWPnwCD46LfzZ6fG3ThIgWYZUH/1n-1p/4?UxDuhP/4!Orx-AFFPezxppqSJK9xOsA0GY13sZwNG-61TSV-yzL=OijL3TxTJg7A5q5H7DwZz71CtYiFn1KIsENYQ-7xB8C63tS3epWRF-Tsb7BMWtIUIZC0gODblBz/eAQFCf6lvEjp"
         let idToken = "KdJzZf0ecdXFsSjIYXbh-0A4Hj-X!?JR5dhTqDgkoy6JDP7R5B1mtzD0cgprmflfyi7ihSvRWg1n=RrRgTjj5hG-t1tuN2zmqacHmUpbfKGsZKk6EwfvFxMYh4YINYfqLdFKLgY224uaCRI8F9rDghBoHx5=vMY=L6l3EwG5R8!HND2j2W5JKNwCTp3zKMS4WRYz3Xk?CJEKqa2oFNtFNdoz0rUIH-i/sCgqWkpE2093s0PyMZQ1x49M88mjx=0E"
         // swiftlint:enable line_length
-        XCTAssertTrue(mockLoginSession.didCallFinalise)
-        XCTAssertEqual(mockLoginSession.callbackURL, callbackURL)
+        
+        waitForTruth(self.mockLoginSession.didCallPerformLoginFlow, timeout: 2)
         guard let mainCoordinator = sut.parentCoordinator as? MainCoordinator else {
             XCTFail("Should be a MainCoordinator")
             return
@@ -99,112 +88,102 @@ extension AuthenticationCoordinatorTests {
         XCTAssertEqual(mainCoordinator.tokens?.idToken, idToken)
     }
     
-    func test_handleUniversalLink_loginError_network() throws {
+    func test_loginError_network() throws {
         mockLoginSession.errorFromLoginFlow = LoginError.network
         mockMainCoordinator.openChildInline(sut)
         // GIVEN the AuthenticationCoordinator has logged in via start()
         sut.start()
-        // WHEN the AuthenticationCoordinator calls finalise
-        let callbackURL = URL(string: "https://www.test.com")!
-        sut.handleUniversalLink(callbackURL)
-        XCTAssertTrue(mockLoginSession.didCallFinalise)
-        XCTAssertEqual(mockLoginSession.callbackURL, callbackURL)
-        // THEN the 'unable to login' error screen is shown
+        // WHEN the AuthenticationCoordinator calls performLoginFlow on the session and there is a network error
+        waitForTruth(self.mockLoginSession.didCallPerformLoginFlow, timeout: 2)
+        // THEN the 'network' error screen is shown
         let vc = sut.root.topViewController as? GDSErrorViewController
         XCTAssertTrue(vc != nil)
         XCTAssertTrue(vc?.viewModel is NetworkConnectionErrorViewModel)
     }
     
-    func test_handleUniversalLink_loginError_non200() throws {
+    func test_loginError_non200() throws {
         mockLoginSession.errorFromLoginFlow = LoginError.non200
         mockMainCoordinator.openChildInline(sut)
         // GIVEN the AuthenticationCoordinator has logged in via start()
         sut.start()
-        // WHEN the AuthenticationCoordinator calls finalise
-        let callbackURL = URL(string: "https://www.test.com")!
-        sut.handleUniversalLink(callbackURL)
-        XCTAssertTrue(mockLoginSession.didCallFinalise)
-        XCTAssertEqual(mockLoginSession.callbackURL, callbackURL)
+        // WHEN the AuthenticationCoordinator calls performLoginFlow on the session and there is a non200 error
+        waitForTruth(self.mockLoginSession.didCallPerformLoginFlow, timeout: 2)
         // THEN the 'unable to login' error screen is shown
         let vc = sut.root.topViewController as? GDSErrorViewController
         XCTAssertTrue(vc != nil)
         XCTAssertTrue(vc?.viewModel is UnableToLoginErrorViewModel)
     }
     
-    func test_handleUniversalLink_loginError_invalidRequest() throws {
+    func test_loginError_invalidRequest() throws {
         mockLoginSession.errorFromLoginFlow = LoginError.invalidRequest
         mockMainCoordinator.openChildInline(sut)
         // GIVEN the AuthenticationCoordinator has logged in via start()
         sut.start()
-        // WHEN the AuthenticationCoordinator calls finalise
-        let callbackURL = URL(string: "https://www.test.com")!
-        sut.handleUniversalLink(callbackURL)
-        XCTAssertTrue(mockLoginSession.didCallFinalise)
-        XCTAssertEqual(mockLoginSession.callbackURL, callbackURL)
+        // WHEN the AuthenticationCoordinator calls performLoginFlow on the session and there is an invalid request error
+        waitForTruth(self.mockLoginSession.didCallPerformLoginFlow, timeout: 2)
         // THEN the 'unable to login' error screen is shown
         let vc = sut.root.topViewController as? GDSErrorViewController
         XCTAssertTrue(vc != nil)
         XCTAssertTrue(vc?.viewModel is UnableToLoginErrorViewModel)
     }
     
-    func test_handleUniversalLink_loginError_clientError() throws {
+    func test_loginError_clientError() throws {
         mockLoginSession.errorFromLoginFlow = LoginError.clientError
         mockMainCoordinator.openChildInline(sut)
         // GIVEN the AuthenticationCoordinator has logged in via start()
         sut.start()
-        // WHEN the AuthenticationCoordinator calls finalise
-        let callbackURL = URL(string: "https://www.test.com")!
-        sut.handleUniversalLink(callbackURL)
-        XCTAssertTrue(mockLoginSession.didCallFinalise)
-        XCTAssertEqual(mockLoginSession.callbackURL, callbackURL)
+        // WHEN the AuthenticationCoordinator calls performLoginFlow on the session and there is an client error
+        waitForTruth(self.mockLoginSession.didCallPerformLoginFlow, timeout: 2)
         // THEN the 'unable to login' error screen is shown
         let vc = sut.root.topViewController as? GDSErrorViewController
         XCTAssertTrue(vc != nil)
         XCTAssertTrue(vc?.viewModel is UnableToLoginErrorViewModel)
     }
     
-    func test_handleUniversalLink_loginError_userCancelled() throws {
+    func test_loginError_userCancelled() throws {
         mockLoginSession.errorFromLoginFlow = LoginError.userCancelled
         mockMainCoordinator.start()
         mockMainCoordinator.openChildInline(sut)
         // GIVEN the AuthenticationCoordinator has logged in via start()
         sut.start()
-        // WHEN the AuthenticationCoordinator calls finalise
-        let callbackURL = URL(string: "https://www.test.com")!
-        sut.handleUniversalLink(callbackURL)
-        XCTAssertTrue(mockLoginSession.didCallFinalise)
-        XCTAssertEqual(mockLoginSession.callbackURL, callbackURL)
-        // THEN user is returned to
+        // WHEN the AuthenticationCoordinator calls performLoginFlow on the session and user cancelled the login modal
+        waitForTruth(self.mockLoginSession.didCallPerformLoginFlow, timeout: 2)
+        // THEN user is returned to the intro screen
         XCTAssertTrue(sut.root.topViewController is IntroViewController)
     }
     
-    func test_handleUniversalLink_loginError_generic() throws {
+    func test_loginError_generic() throws {
         mockLoginSession.errorFromLoginFlow = LoginError.generic(description: "")
         mockMainCoordinator.openChildInline(sut)
         // GIVEN the AuthenticationCoordinator has logged in via start()
         sut.start()
-        // WHEN the AuthenticationCoordinator calls finalise
-        let callbackURL = URL(string: "https://www.test.com")!
-        sut.handleUniversalLink(callbackURL)
-        XCTAssertTrue(mockLoginSession.didCallFinalise)
-        XCTAssertEqual(mockLoginSession.callbackURL, callbackURL)
-        // THEN the 'unable to login' error screen is shown
+        // WHEN the AuthenticationCoordinator calls performLoginFlow on the session and there is an generic error
+        waitForTruth(self.mockLoginSession.didCallPerformLoginFlow, timeout: 2)
+        // THEN the 'generic' error screen is shown
+        let vc = sut.root.topViewController as? GDSErrorViewController
+        XCTAssertTrue(vc != nil)
+        XCTAssertTrue(vc?.viewModel is GenericErrorViewModel)
+    }
+    
+    func test_loginError_catchAllError() throws {
+        mockLoginSession.errorFromLoginFlow = AuthenticationError.catchAll
+        mockMainCoordinator.openChildInline(sut)
+        // GIVEN the AuthenticationCoordinator has logged in via start()
+        sut.start()
+        // WHEN the AuthenticationCoordinator calls performLoginFlow on the session and there is an unknown error
+        waitForTruth(self.mockLoginSession.didCallPerformLoginFlow, timeout: 2)
+        // THEN the 'generic' error screen is shown
         let vc = sut.root.topViewController as? GDSErrorViewController
         XCTAssertTrue(vc != nil)
         XCTAssertTrue(vc?.viewModel is GenericErrorViewModel)
     }
     
     func test_handleUniversalLink_catchAllError() throws {
-        mockLoginSession.errorFromLoginFlow = AuthenticationError.catchAll
-        mockMainCoordinator.openChildInline(sut)
-        // GIVEN the AuthenticationCoordinator has logged in via start()
-        sut.start()
-        // WHEN the AuthenticationCoordinator calls finalise
+        mockLoginSession.errorFromFinalise = AuthenticationError.catchAll
+        // WHEN the AuthenticationCoordinator calls finalise on the session and there is an unknown error
         let callbackURL = URL(string: "https://www.test.com")!
         sut.handleUniversalLink(callbackURL)
-        XCTAssertTrue(mockLoginSession.didCallFinalise)
-        XCTAssertEqual(mockLoginSession.callbackURL, callbackURL)
-        // THEN the 'something went wrong' error screen is shown
+        // THEN the 'generic' error screen is shown
         let vc = sut.root.topViewController as? GDSErrorViewController
         XCTAssertTrue(vc != nil)
         XCTAssertTrue(vc?.viewModel is GenericErrorViewModel)

--- a/Tests/UnitTests/Onboarding/AuthenticationCoordinatorTests.swift
+++ b/Tests/UnitTests/Onboarding/AuthenticationCoordinatorTests.swift
@@ -98,7 +98,7 @@ extension AuthenticationCoordinatorTests {
     }
     
     func test_handleUniversalLink_finaliseCalled_catchAllError() throws {
-        mockLoginSession.errorFromFinalise = AuthenticationError.catchAll
+        mockLoginSession.errorFromLoginFlow = AuthenticationError.catchAll
         mockMainCoordinator.openChildInline(sut)
         // GIVEN the AuthenticationCoordinator has logged in via start()
         sut.start()
@@ -113,8 +113,8 @@ extension AuthenticationCoordinatorTests {
         XCTAssertTrue(vc?.viewModel is GenericErrorViewModel)
     }
     
-    func test_handleUniversalLink_finaliseCalled_loginError() throws {
-        mockLoginSession.errorFromFinalise = LoginError.generic(description: "")
+    func test_handleUniversalLink_finaliseCalled_non200LoginError() throws {
+        mockLoginSession.errorFromLoginFlow = LoginError.non200
         mockMainCoordinator.openChildInline(sut)
         // GIVEN the AuthenticationCoordinator has logged in via start()
         sut.start()

--- a/Tests/UnitTests/Onboarding/AuthenticationCoordinatorTests.swift
+++ b/Tests/UnitTests/Onboarding/AuthenticationCoordinatorTests.swift
@@ -47,10 +47,11 @@ final class AuthenticationCoordinatorTests: XCTestCase {
 }
 
 extension AuthenticationCoordinatorTests {
-    func test_start_authenticationSessionConfigProperties() throws {
+    func test_start_authenticationSession_configProperties() throws {
+        mockMainCoordinator.openChildInline(sut)
         // WHEN the AuthenticationCoordinator is started
         sut.start()
-        XCTAssertTrue(mockLoginSession.sessionConfiguration != nil)
+        waitForTruth(self.mockLoginSession.sessionConfiguration != nil, timeout: 2)
         // THEN the session should have the correct login configuration details
         let sessionConfig = try XCTUnwrap(mockLoginSession.sessionConfiguration)
         XCTAssertEqual(sessionConfig.authorizationEndpoint, AppEnvironment.oneLoginAuthorize)
@@ -64,15 +65,16 @@ extension AuthenticationCoordinatorTests {
         XCTAssertEqual(sessionConfig.locale, .en)
     }
     
-    func test_start_authenticationSessionPresent() throws {
+    func test_start_authenticationSession_performLoginFlow() throws {
+        mockMainCoordinator.openChildInline(sut)
         // GIVEN the AuthenticationCoordinator is started
         sut.start()
         // THEN the session should call present() with the configuration
-        XCTAssertTrue(mockLoginSession.didCallPresent)
-        XCTAssertTrue(mockLoginSession.sessionConfiguration != nil)
+        waitForTruth(self.mockLoginSession.didCallPresent, timeout: 2)
+        waitForTruth(self.mockLoginSession.sessionConfiguration != nil, timeout: 2)
     }
     
-    func test_handleUniversalLink_finaliseCalled_successful() throws {
+    func test_handleUniversalLink_successful() throws {
         mockMainCoordinator.openChildInline(sut)
         // GIVEN the AuthenticationCoordinator has logged in via start()
         sut.start()
@@ -85,7 +87,7 @@ extension AuthenticationCoordinatorTests {
         let refreshToken = "JPz2bPDtrU/NJAedvDC8Xk6eMFlf1qZn9MuYXvCDl?xTZlCUFR?oAwUzXlhlr29MiWf1!2NlFYJ5shibOLWPnwCD46LfzZ6fG3ThIgWYZUH/1n-1p/4?UxDuhP/4!Orx-AFFPezxppqSJK9xOsA0GY13sZwNG-61TSV-yzL=OijL3TxTJg7A5q5H7DwZz71CtYiFn1KIsENYQ-7xB8C63tS3epWRF-Tsb7BMWtIUIZC0gODblBz/eAQFCf6lvEjp"
         let idToken = "KdJzZf0ecdXFsSjIYXbh-0A4Hj-X!?JR5dhTqDgkoy6JDP7R5B1mtzD0cgprmflfyi7ihSvRWg1n=RrRgTjj5hG-t1tuN2zmqacHmUpbfKGsZKk6EwfvFxMYh4YINYfqLdFKLgY224uaCRI8F9rDghBoHx5=vMY=L6l3EwG5R8!HND2j2W5JKNwCTp3zKMS4WRYz3Xk?CJEKqa2oFNtFNdoz0rUIH-i/sCgqWkpE2093s0PyMZQ1x49M88mjx=0E"
         // swiftlint:enable line_length
-        waitForTruth(self.mockLoginSession.didCallFinalise, timeout: 3)
+        XCTAssertTrue(mockLoginSession.didCallFinalise)
         XCTAssertEqual(mockLoginSession.callbackURL, callbackURL)
         guard let mainCoordinator = sut.parentCoordinator as? MainCoordinator else {
             XCTFail("Should be a MainCoordinator")
@@ -97,23 +99,23 @@ extension AuthenticationCoordinatorTests {
         XCTAssertEqual(mainCoordinator.tokens?.idToken, idToken)
     }
     
-    func test_handleUniversalLink_finaliseCalled_catchAllError() throws {
-        mockLoginSession.errorFromLoginFlow = AuthenticationError.catchAll
+    func test_handleUniversalLink_loginError_network() throws {
+        mockLoginSession.errorFromLoginFlow = LoginError.network
         mockMainCoordinator.openChildInline(sut)
         // GIVEN the AuthenticationCoordinator has logged in via start()
         sut.start()
         // WHEN the AuthenticationCoordinator calls finalise
         let callbackURL = URL(string: "https://www.test.com")!
         sut.handleUniversalLink(callbackURL)
-        waitForTruth(self.mockLoginSession.didCallFinalise, timeout: 3)
+        XCTAssertTrue(mockLoginSession.didCallFinalise)
         XCTAssertEqual(mockLoginSession.callbackURL, callbackURL)
-        // THEN the 'something went wrong' error screen is shown
+        // THEN the 'unable to login' error screen is shown
         let vc = sut.root.topViewController as? GDSErrorViewController
         XCTAssertTrue(vc != nil)
-        XCTAssertTrue(vc?.viewModel is GenericErrorViewModel)
+        XCTAssertTrue(vc?.viewModel is NetworkConnectionErrorViewModel)
     }
     
-    func test_handleUniversalLink_finaliseCalled_non200LoginError() throws {
+    func test_handleUniversalLink_loginError_non200() throws {
         mockLoginSession.errorFromLoginFlow = LoginError.non200
         mockMainCoordinator.openChildInline(sut)
         // GIVEN the AuthenticationCoordinator has logged in via start()
@@ -121,11 +123,90 @@ extension AuthenticationCoordinatorTests {
         // WHEN the AuthenticationCoordinator calls finalise
         let callbackURL = URL(string: "https://www.test.com")!
         sut.handleUniversalLink(callbackURL)
-        waitForTruth(self.mockLoginSession.didCallFinalise, timeout: 3)
+        XCTAssertTrue(mockLoginSession.didCallFinalise)
         XCTAssertEqual(mockLoginSession.callbackURL, callbackURL)
         // THEN the 'unable to login' error screen is shown
         let vc = sut.root.topViewController as? GDSErrorViewController
         XCTAssertTrue(vc != nil)
         XCTAssertTrue(vc?.viewModel is UnableToLoginErrorViewModel)
+    }
+    
+    func test_handleUniversalLink_loginError_invalidRequest() throws {
+        mockLoginSession.errorFromLoginFlow = LoginError.invalidRequest
+        mockMainCoordinator.openChildInline(sut)
+        // GIVEN the AuthenticationCoordinator has logged in via start()
+        sut.start()
+        // WHEN the AuthenticationCoordinator calls finalise
+        let callbackURL = URL(string: "https://www.test.com")!
+        sut.handleUniversalLink(callbackURL)
+        XCTAssertTrue(mockLoginSession.didCallFinalise)
+        XCTAssertEqual(mockLoginSession.callbackURL, callbackURL)
+        // THEN the 'unable to login' error screen is shown
+        let vc = sut.root.topViewController as? GDSErrorViewController
+        XCTAssertTrue(vc != nil)
+        XCTAssertTrue(vc?.viewModel is UnableToLoginErrorViewModel)
+    }
+    
+    func test_handleUniversalLink_loginError_clientError() throws {
+        mockLoginSession.errorFromLoginFlow = LoginError.clientError
+        mockMainCoordinator.openChildInline(sut)
+        // GIVEN the AuthenticationCoordinator has logged in via start()
+        sut.start()
+        // WHEN the AuthenticationCoordinator calls finalise
+        let callbackURL = URL(string: "https://www.test.com")!
+        sut.handleUniversalLink(callbackURL)
+        XCTAssertTrue(mockLoginSession.didCallFinalise)
+        XCTAssertEqual(mockLoginSession.callbackURL, callbackURL)
+        // THEN the 'unable to login' error screen is shown
+        let vc = sut.root.topViewController as? GDSErrorViewController
+        XCTAssertTrue(vc != nil)
+        XCTAssertTrue(vc?.viewModel is UnableToLoginErrorViewModel)
+    }
+    
+    func test_handleUniversalLink_loginError_userCancelled() throws {
+        mockLoginSession.errorFromLoginFlow = LoginError.userCancelled
+        mockMainCoordinator.start()
+        mockMainCoordinator.openChildInline(sut)
+        // GIVEN the AuthenticationCoordinator has logged in via start()
+        sut.start()
+        // WHEN the AuthenticationCoordinator calls finalise
+        let callbackURL = URL(string: "https://www.test.com")!
+        sut.handleUniversalLink(callbackURL)
+        XCTAssertTrue(mockLoginSession.didCallFinalise)
+        XCTAssertEqual(mockLoginSession.callbackURL, callbackURL)
+        // THEN user is returned to
+        XCTAssertTrue(sut.root.topViewController is IntroViewController)
+    }
+    
+    func test_handleUniversalLink_loginError_generic() throws {
+        mockLoginSession.errorFromLoginFlow = LoginError.generic(description: "")
+        mockMainCoordinator.openChildInline(sut)
+        // GIVEN the AuthenticationCoordinator has logged in via start()
+        sut.start()
+        // WHEN the AuthenticationCoordinator calls finalise
+        let callbackURL = URL(string: "https://www.test.com")!
+        sut.handleUniversalLink(callbackURL)
+        XCTAssertTrue(mockLoginSession.didCallFinalise)
+        XCTAssertEqual(mockLoginSession.callbackURL, callbackURL)
+        // THEN the 'unable to login' error screen is shown
+        let vc = sut.root.topViewController as? GDSErrorViewController
+        XCTAssertTrue(vc != nil)
+        XCTAssertTrue(vc?.viewModel is GenericErrorViewModel)
+    }
+    
+    func test_handleUniversalLink_catchAllError() throws {
+        mockLoginSession.errorFromLoginFlow = AuthenticationError.catchAll
+        mockMainCoordinator.openChildInline(sut)
+        // GIVEN the AuthenticationCoordinator has logged in via start()
+        sut.start()
+        // WHEN the AuthenticationCoordinator calls finalise
+        let callbackURL = URL(string: "https://www.test.com")!
+        sut.handleUniversalLink(callbackURL)
+        XCTAssertTrue(mockLoginSession.didCallFinalise)
+        XCTAssertEqual(mockLoginSession.callbackURL, callbackURL)
+        // THEN the 'something went wrong' error screen is shown
+        let vc = sut.root.topViewController as? GDSErrorViewController
+        XCTAssertTrue(vc != nil)
+        XCTAssertTrue(vc?.viewModel is GenericErrorViewModel)
     }
 }

--- a/Tests/UnitTests/Onboarding/MainCoordinatorTests.swift
+++ b/Tests/UnitTests/Onboarding/MainCoordinatorTests.swift
@@ -19,6 +19,7 @@ final class MainCoordinatorTests: XCTestCase {
     }
     
     override func tearDown() {
+        window = nil
         navigationController = nil
         sut = nil
         


### PR DESCRIPTION
# DCMAW-7253: User sees Network Connection Error screen when offline

This PR displays a network connection error screen when a user is offline and a network connection error is thrown. Updates to the [Authentication package](https://github.com/govuk-one-login/mobile-ios-authentication/pull/22) mean that errors are now owned by the package, `AuthenticationCoordinator` has been updated to catch these specific errors. 

The cancelation of web authentication modal is now properly handled as well. 

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
