### PR TITLE
feat: network error screen pops back to intro screen

### DIFF
--- a/Sources/Onboarding/MainCoordinator.swift
+++ b/Sources/Onboarding/MainCoordinator.swift
@@ -33,8 +33,8 @@ final class MainCoordinator: NSObject,
                 } else {
                     let networkErrorScreen = errorPresenter
                         .createNetworkConnectionError(analyticsService: analyticsService) { [unowned self] in
+                            root.popViewController(animated: true)
                             if networkMonitor.isConnected {
-                                root.popViewController(animated: true)
                                 displayAuthCoordinator()
                             }
                         }

--- a/Tests/ConfigTests/BuildConfig/BuildAppEnvironmentTests.swift
+++ b/Tests/ConfigTests/BuildConfig/BuildAppEnvironmentTests.swift
@@ -5,8 +5,10 @@ final class BuildAppEnvironmentTests: XCTestCase {
     func test_defaultEnvironment_retrieveFromPlist() throws {
         let sut = AppEnvironment.self
         XCTAssertEqual(sut.oneLoginAuthorize, URL(string: "https://auth-stub.mobile.build.account.gov.uk/authorize"))
+        XCTAssertEqual(sut.stsLoginAuthorize, URL(string: "https://token.build.account.gov.uk/authorize"))
         XCTAssertEqual(sut.oneLoginToken, URL(string: "https://mobile.build.account.gov.uk/token"))
         XCTAssertEqual(sut.oneLoginClientID, "TEST_CLIENT_ID")
+        XCTAssertEqual(sut.stsClientID, "bYrcuRVvnylvEgYSSbBjwXzHrwJ")
         XCTAssertEqual(sut.oneLoginRedirect, "https://mobile.build.account.gov.uk/redirect")
         XCTAssertFalse(sut.callingSTSEnabled)
     }

--- a/Tests/ConfigTests/StagingConfig/StagingAppEnvironmentTests.swift
+++ b/Tests/ConfigTests/StagingConfig/StagingAppEnvironmentTests.swift
@@ -5,8 +5,10 @@ final class StagingAppEnvironmentTests: XCTestCase {
     func test_defaultEnvironment_retrieveFromPlist() throws {
         let sut = AppEnvironment.self
         XCTAssertEqual(sut.oneLoginAuthorize, URL(string: "https://oidc.integration.account.gov.uk/authorize"))
+        XCTAssertEqual(sut.stsLoginAuthorize, URL(string: "https://token.staging.account.gov.uk/authorize"))
         XCTAssertEqual(sut.oneLoginToken, URL(string: "https://mobile.staging.account.gov.uk/token"))
         XCTAssertEqual(sut.oneLoginClientID, "sdJChz1oGajIz0O0tdPdh0CA2zW")
+        XCTAssertEqual(sut.stsClientID, "ctQpngJQrFFCrppZtYQFFoklHaq")
         XCTAssertEqual(sut.oneLoginRedirect, "https://mobile.staging.account.gov.uk/redirect")
         XCTAssertFalse(sut.callingSTSEnabled)
     }

--- a/Tests/UnitTests/Onboarding/MainCoordinatorTests.swift
+++ b/Tests/UnitTests/Onboarding/MainCoordinatorTests.swift
@@ -90,7 +90,7 @@ extension MainCoordinatorTests {
         XCTAssertTrue(vc?.viewModel is NetworkConnectionErrorViewModel)
     }
     
-    func test_networkErrorScreen_opensAuthCoordinator() throws {
+    func test_networkErrorScreen_reconnectingOpensAuthCoordinator() throws {
         // GIVEN the user is offline
         mockNetworkMonitor.isConnected = false
         // GIVEN the MainCoordinator is started
@@ -113,5 +113,28 @@ extension MainCoordinatorTests {
         // THEN the MainCoordinator should have an AuthenticationCoordinator as it's only child coordinator
         XCTAssertTrue(sut.childCoordinators.first is AuthenticationCoordinator)
         XCTAssertEqual(sut.childCoordinators.count, 1)
+    }
+    
+    func test_networkErrorScreen_popsToLogin() throws {
+        // GIVEN the user is offline
+        mockNetworkMonitor.isConnected = false
+        // GIVEN the MainCoordinator is started
+        sut.start()
+        // WHEN the button on the IntroViewController is tapped
+        let introScreen = sut.root.topViewController as? IntroViewController
+        let introButton: UIButton = try XCTUnwrap(introScreen?.view[child: "intro-button"])
+        XCTAssertEqual(sut.childCoordinators.count, 0)
+        introButton.sendActions(for: .touchUpInside)
+        // THEN the network error screen is shown
+        waitForTruth(!self.mockNetworkMonitor.isConnected, timeout: 2)
+        let vc = sut.root.topViewController as? GDSErrorViewController
+        XCTAssertTrue(vc != nil)
+        XCTAssertTrue(vc?.viewModel is NetworkConnectionErrorViewModel)
+        // GIVEN the user is online
+        // WHEN the button on the error screen is tapped
+        let errorPrimaryButton: UIButton = try XCTUnwrap(vc?.view[child: "error-primary-button"])
+        errorPrimaryButton.sendActions(for: .touchUpInside)
+        // THEN the MainCoordinator shouldn't have launched it's AuthenticationCoordinator
+        XCTAssertEqual(sut.childCoordinators.count, 0)
     }
 }


### PR DESCRIPTION
# feat: network error screen pops back to intro screen

The behaviour on the network error screen's "Try again" button encountered when tapping the sign in button without a network connection was incorrect, this PR corrects that to pop back to the intro screen.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
