### PR TITLE
fix: use AWS defined action for storing secrets from secret manager

### DIFF
--- a/.github/workflows/merged.yml
+++ b/.github/workflows/merged.yml
@@ -165,12 +165,10 @@ jobs:
           role-duration-seconds: 1200
           role-skip-session-tagging: true
 
-      - name: Store ENV from AWS SecretManager
-        id: secrets
-        uses: say8425/aws-secrets-manager-actions@v2.2.1
+      - name: Store Secrets from AWS SecretManager
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2.0.1
         with:
-          AWS_DEFAULT_REGION: "eu-west-2"
-          SECRET_NAME: "di-ipv-dca-mob-ios/github-actions-v2"
+          secret-ids: "di-ipv-dca-mob-ios/github-actions-v2"
 
       - name: Build App, Deploy to App Store Connect
         env:

--- a/.github/workflows/merged.yml
+++ b/.github/workflows/merged.yml
@@ -138,7 +138,7 @@ jobs:
 
       - name: Upload Artifact
         if: failure()
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: UITestArtifact
           path: ./fastlane/UITestArtifact.zip


### PR DESCRIPTION
# fix: use AWS defined action for storing secrets from secret manager

We have been using a third-party GitHub action for storing the secrets from AWS secrets manager but there's an official Amazon action for this purpose which is properly supported.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
~- [ ] Written Unit and Integration tests if needed~

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code ~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
