### PR TITLE
fix: amending github env variable references

### DIFF
--- a/.github/workflows/merged.yml
+++ b/.github/workflows/merged.yml
@@ -186,8 +186,10 @@ jobs:
           APIKEY_PATH=$RUNNER_TEMP/apikey.p8
 
           # import certificates from secrets
-          echo -n "${{env.AWS_SECRET_DISTRIBUTION_P12_ENCODED}}" | base64 --decode -o $CERTIFICATE_PATH
-          echo -n "${{env.AWS_SECRET_AUTH_KEY_P8_ENCODED}}" | base64 --decode -o $APIKEY_PATH
+          echo -n "${{env.DI_IPV_DCA_MOB_IOS_GITHUB_ACTIONS_V2_AWS_SECRET_DISTRIBUTION_P12_ENCODED}}" \
+            | base64 --decode -o $CERTIFICATE_PATH
+          echo -n "${{env.DI_IPV_DCA_MOB_IOS_GITHUB_ACTIONS_V2_AWS_SECRET_AUTH_KEY_P8_ENCODED}}" \
+            | base64 --decode -o $APIKEY_PATH
 
           bundle exec fastlane prerelease configuration:"Staging" \
             certificate_path:$CERTIFICATE_PATH \


### PR DESCRIPTION
# fix: amending github env variable references

The way our AWS secrets are stored in our workflows changed slightly when changing the action to an officially supported AWS action. We were not accounting for this but this PR fixes that reference.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
~- [ ] Written Unit and Integration tests if needed~

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
