### PR TITLE
feat: enrol user in Face ID local authentication from enrolment screen

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		C8520C252AE2BFAD006790C1 /* UIView+TestExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8520C242AE2BFAD006790C1 /* UIView+TestExtensions.swift */; };
 		C8520C2B2AE2C223006790C1 /* OnboardingViewControllerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8520C292AE2C1C5006790C1 /* OnboardingViewControllerFactory.swift */; };
 		C8520C2E2AE2C822006790C1 /* MockTokenResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8520C2D2AE2C822006790C1 /* MockTokenResponse.swift */; };
+		C85506FF2B7FB58D00AA9375 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = C85507012B7FB58D00AA9375 /* InfoPlist.strings */; };
 		C85966482AEC31AE006DF61D /* OnboardingViewControllerFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85966472AEC31AE006DF61D /* OnboardingViewControllerFactoryTests.swift */; };
 		C85E21042ACEE34900AF8B4E /* MainCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85E21032ACEE34900AF8B4E /* MainCoordinator.swift */; };
 		C85E210D2ACEE93C00AF8B4E /* OneLoginIntroViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85E210C2ACEE93C00AF8B4E /* OneLoginIntroViewModel.swift */; };
@@ -179,6 +180,8 @@
 		C8520C242AE2BFAD006790C1 /* UIView+TestExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+TestExtensions.swift"; sourceTree = "<group>"; };
 		C8520C292AE2C1C5006790C1 /* OnboardingViewControllerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewControllerFactory.swift; sourceTree = "<group>"; };
 		C8520C2D2AE2C822006790C1 /* MockTokenResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTokenResponse.swift; sourceTree = "<group>"; };
+		C85507002B7FB58D00AA9375 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		C85507022B7FB58F00AA9375 /* cy-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "cy-GB"; path = "cy-GB.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		C85966472AEC31AE006DF61D /* OnboardingViewControllerFactoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingViewControllerFactoryTests.swift; sourceTree = "<group>"; };
 		C85BD2412B03DC8800DE1D4B /* OneLoginBuild.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = OneLoginBuild.entitlements; sourceTree = "<group>"; };
 		C85E21032ACEE34900AF8B4E /* MainCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainCoordinator.swift; sourceTree = "<group>"; };
@@ -516,6 +519,7 @@
 			children = (
 				3BBF28E82A9F7D3200491BB1 /* LaunchScreen.storyboard */,
 				1EB56D6F2B7CDE6D00BD548E /* Localizable.strings */,
+				C85507012B7FB58D00AA9375 /* InfoPlist.strings */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -903,6 +907,7 @@
 				3BBF28F12A9F7D3200491BB1 /* LaunchScreen.storyboard in Resources */,
 				C89632ED2B0D0886002A1473 /* TokensView.xib in Resources */,
 				C8BACAFA2B4DCCBD00530419 /* FeatureFlagsBuild.json in Resources */,
+				C85506FF2B7FB58D00AA9375 /* InfoPlist.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1119,6 +1124,15 @@
 				3BBF28E92A9F7D3200491BB1 /* Base */,
 			);
 			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+		C85507012B7FB58D00AA9375 /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				C85507002B7FB58D00AA9375 /* en */,
+				C85507022B7FB58F00AA9375 /* cy-GB */,
+			);
+			name = InfoPlist.strings;
 			sourceTree = "<group>";
 		};
 /* End PBXVariantGroup section */

--- a/Sources/Onboarding/OnboardingCoordinator.swift
+++ b/Sources/Onboarding/OnboardingCoordinator.swift
@@ -22,41 +22,53 @@ final class OnboardingCoordinator: NSObject,
     
     func start() {
         root.isNavigationBarHidden = true
-        if localAuth.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil) {
-            switch localAuth.biometryType {
-            case .touchID:
-                let touchIDEnrollmentScreen = viewControllerFactory
-                    .createTouchIDEnrollmentScreen(analyticsService: analyticsService) { [unowned self] in
-                        finish()
-                    } secondaryButtonAction: { [unowned self] in
-                        finish()
-                    }
-                root.pushViewController(touchIDEnrollmentScreen, animated: true)
-            case .faceID:
-                let faceIDEnrollmentScreen = viewControllerFactory
-                    .createFaceIDEnrollmentScreen(analyticsService: analyticsService) { [unowned self] in
-                        Task { await enrolBiometrics(reason: "Here's ya reason") }
-                    } secondaryButtonAction: { [unowned self] in
-                        finish()
-                    }
-                root.pushViewController(faceIDEnrollmentScreen, animated: true)
-            case .opticID, .none:
-                return
-            @unknown default:
-                return
-            }
-        } else if !localAuth.canEvaluatePolicy(.deviceOwnerAuthentication, error: nil) {
-            let passcodeInformationScreen = viewControllerFactory
-                .createPasscodeInformationScreen(analyticsService: analyticsService) { [unowned self] in
-                    finish()
-                }
-            root.pushViewController(passcodeInformationScreen, animated: true)
+        if canUseLocalAuth(.deviceOwnerAuthenticationWithBiometrics) {
+            showEnrolmentGuidance()
+        } else if !canUseLocalAuth(.deviceOwnerAuthentication) {
+            showPasscodeInfo()
         } else {
             finish()
         }
     }
     
-    func enrolBiometrics(reason: String) async {
+    private func canUseLocalAuth(_ policy: LAPolicy) -> Bool {
+        localAuth.canEvaluatePolicy(policy, error: nil)
+    }
+    
+    private func showEnrolmentGuidance() {
+        switch localAuth.biometryType {
+        case .touchID:
+            let touchIDEnrollmentScreen = viewControllerFactory
+                .createTouchIDEnrollmentScreen(analyticsService: analyticsService) { [unowned self] in
+                    finish()
+                } secondaryButtonAction: { [unowned self] in
+                    finish()
+                }
+            root.pushViewController(touchIDEnrollmentScreen, animated: true)
+        case .faceID:
+            let faceIDEnrollmentScreen = viewControllerFactory
+                .createFaceIDEnrollmentScreen(analyticsService: analyticsService) { [unowned self] in
+                    Task { await enrolLocalAuth(reason: " ") }
+                } secondaryButtonAction: { [unowned self] in
+                    finish()
+                }
+            root.pushViewController(faceIDEnrollmentScreen, animated: true)
+        case .opticID, .none:
+            return
+        @unknown default:
+            return
+        }
+    }
+    
+    private func showPasscodeInfo() {
+        let passcodeInformationScreen = viewControllerFactory
+            .createPasscodeInformationScreen(analyticsService: analyticsService) { [unowned self] in
+                finish()
+            }
+        root.pushViewController(passcodeInformationScreen, animated: true)
+    }
+    
+    private func enrolLocalAuth(reason: String) async {
         do {
             if try await localAuth
                 .evaluatePolicy(.deviceOwnerAuthentication, localizedReason: NSLocalizedString(reason, comment: "")) {
@@ -65,7 +77,7 @@ final class OnboardingCoordinator: NSObject,
                 return
             }
         } catch {
-            print("Auth error: \(error)")
+            return
         }
     }
 }

--- a/Sources/Onboarding/OnboardingCoordinator.swift
+++ b/Sources/Onboarding/OnboardingCoordinator.swift
@@ -35,7 +35,7 @@ final class OnboardingCoordinator: NSObject,
             case .faceID:
                 let faceIDEnrollmentScreen = viewControllerFactory
                     .createFaceIDEnrollmentScreen(analyticsService: analyticsService) { [unowned self] in
-                        finish()
+                        Task { await enrolBiometrics(reason: "Here's ya reason") }
                     } secondaryButtonAction: { [unowned self] in
                         finish()
                     }
@@ -53,6 +53,19 @@ final class OnboardingCoordinator: NSObject,
             root.pushViewController(passcodeInformationScreen, animated: true)
         } else {
             finish()
+        }
+    }
+    
+    func enrolBiometrics(reason: String) async {
+        do {
+            if try await localAuth
+                .evaluatePolicy(.deviceOwnerAuthentication, localizedReason: NSLocalizedString(reason, comment: "")) {
+                finish()
+            } else {
+                return
+            }
+        } catch {
+            print("Auth error: \(error)")
         }
     }
 }

--- a/Sources/Resources/cy-GB.lproj/InfoPlist.strings
+++ b/Sources/Resources/cy-GB.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+// MARK: Face ID enrollment prompt
+"NSFaceIDUsageDescription" = "Nid yw eich ID Wyneb yn cael ei rannu â GOV.UK One Login.";

--- a/Sources/Resources/en.lproj/InfoPlist.strings
+++ b/Sources/Resources/en.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+// MARK: Face ID enrollment prompt
+"NSFaceIDUsageDescription" = "Your Face ID is not shared with GOV.UK One Login.";

--- a/Sources/Utilities/LAContexting.swift
+++ b/Sources/Utilities/LAContexting.swift
@@ -2,6 +2,7 @@ import LocalAuthentication
 
 protocol LAContexting {
     var biometryType: LABiometryType { get }
+    
     func canEvaluatePolicy(_ policy: LAPolicy, error: NSErrorPointer) -> Bool
     func evaluatePolicy(_ policy: LAPolicy, localizedReason: String) async throws -> Bool
 }

--- a/Sources/Utilities/LAContexting.swift
+++ b/Sources/Utilities/LAContexting.swift
@@ -3,6 +3,7 @@ import LocalAuthentication
 protocol LAContexting {
     var biometryType: LABiometryType { get }
     func canEvaluatePolicy(_ policy: LAPolicy, error: NSErrorPointer) -> Bool
+    func evaluatePolicy(_ policy: LAPolicy, localizedReason: String) async throws -> Bool
 }
 
 extension LAContext: LAContexting { }

--- a/Tests/UnitTests/Mocks/Sessions+Services/MockLAContext.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/MockLAContext.swift
@@ -4,18 +4,23 @@ import LocalAuthentication
 final class MockLAContext: LAContexting {
     var biometryType: LABiometryType = .touchID
     
-    var returnedFromEvaluatePolicyForBiometrics: Bool = false
-    var returnedFromEvaluatePolicyForAuthentication: Bool = false
+    var returnedFromCanEvaluatePolicyForBiometrics: Bool = false
+    var returnedFromCanEvaluatePolicyForAuthentication: Bool = false
+    var errorFromEvaluatePolicy: Error?
+    var returnedFromEvaluatePolicy: Bool = true
     
     func canEvaluatePolicy(_ policy: LAPolicy, error: NSErrorPointer) -> Bool {
         if policy == .deviceOwnerAuthenticationWithBiometrics {
-            return returnedFromEvaluatePolicyForBiometrics
+            return returnedFromCanEvaluatePolicyForBiometrics
         } else {
-            return returnedFromEvaluatePolicyForAuthentication
+            return returnedFromCanEvaluatePolicyForAuthentication
         }
     }
     
     func evaluatePolicy(_ policy: LAPolicy, localizedReason: String) async throws -> Bool {
-        <#code#>
+        if let errorFromEvaluatePolicy {
+            throw errorFromEvaluatePolicy
+        }
+        return returnedFromEvaluatePolicy
     }
 }

--- a/Tests/UnitTests/Mocks/Sessions+Services/MockLAContext.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/MockLAContext.swift
@@ -14,4 +14,8 @@ final class MockLAContext: LAContexting {
             return returnedFromEvaluatePolicyForAuthentication
         }
     }
+    
+    func evaluatePolicy(_ policy: LAPolicy, localizedReason: String) async throws -> Bool {
+        <#code#>
+    }
 }

--- a/Tests/UnitTests/Onboarding/OnboardingCoordinatorTests.swift
+++ b/Tests/UnitTests/Onboarding/OnboardingCoordinatorTests.swift
@@ -34,11 +34,15 @@ final class OnboardingCoordinatorTests: XCTestCase {
         
         super.tearDown()
     }
+    
+    private enum LocalAuthError: Error {
+        case evident
+    }
 }
 
 extension OnboardingCoordinatorTests {
     func test_start_noDeviceLocalAuthSet() throws {
-        mockLAContext.returnedFromEvaluatePolicyForAuthentication = false
+        mockLAContext.returnedFromCanEvaluatePolicyForAuthentication = false
         mockMainCoordinator.tokens = try MockTokenResponse().getJSONData()
         // WHEN the OnboardingCoordinator has shown the local auth guidance via start()
         mockMainCoordinator.openChildInline(sut)
@@ -55,7 +59,7 @@ extension OnboardingCoordinatorTests {
     }
     
     func test_start_deviceLocalAuthSet_passcode() throws {
-        mockLAContext.returnedFromEvaluatePolicyForAuthentication = true
+        mockLAContext.returnedFromCanEvaluatePolicyForAuthentication = true
         mockMainCoordinator.tokens = try MockTokenResponse().getJSONData()
         // GIVEN device passcode is set
         // WHEN the OnboardingCoordinator has shown the local auth guidance via start()
@@ -66,9 +70,9 @@ extension OnboardingCoordinatorTests {
     }
     
     func test_start_deviceLocalAuthSet_touchID_primaryButton() throws {
-        mockLAContext.returnedFromEvaluatePolicyForBiometrics = true
+        mockLAContext.returnedFromCanEvaluatePolicyForBiometrics = true
         mockMainCoordinator.tokens = try MockTokenResponse().getJSONData()
-        // GIVEN device passcode is set
+        // GIVEN the user has enabled biometrics
         // WHEN the OnboardingCoordinator has shown the local auth guidance via start()
         mockMainCoordinator.openChildInline(sut)
         // THEN the view controller should be the token screen
@@ -84,9 +88,9 @@ extension OnboardingCoordinatorTests {
     }
     
     func test_start_deviceLocalAuthSet_touchID_secondaryButton() throws {
-        mockLAContext.returnedFromEvaluatePolicyForBiometrics = true
+        mockLAContext.returnedFromCanEvaluatePolicyForBiometrics = true
         mockMainCoordinator.tokens = try MockTokenResponse().getJSONData()
-        // GIVEN device passcode is set
+        // GIVEN the user has enabled biometrics
         // WHEN the OnboardingCoordinator has shown the local auth guidance via start()
         mockMainCoordinator.openChildInline(sut)
         // THEN the view controller should be the token screen
@@ -101,11 +105,11 @@ extension OnboardingCoordinatorTests {
         XCTAssertTrue(navigationController.topViewController is TokensViewController)
     }
     
-    func test_start_deviceLocalAuthSet_faceID_primaryButton() throws {
-        mockLAContext.returnedFromEvaluatePolicyForBiometrics = true
+    func test_start_deviceLocalAuthSet_faceID_primaryButton_passed() throws {
+        mockLAContext.returnedFromCanEvaluatePolicyForBiometrics = true
         mockMainCoordinator.tokens = try MockTokenResponse().getJSONData()
         mockLAContext.biometryType = .faceID
-        // GIVEN device passcode is set
+        // GIVEN the user has enabled biometrics
         // WHEN the OnboardingCoordinator has shown the local auth guidance via start()
         mockMainCoordinator.openChildInline(sut)
         // THEN the view controller should be the token screen
@@ -120,11 +124,51 @@ extension OnboardingCoordinatorTests {
         XCTAssertTrue(navigationController.topViewController is TokensViewController)
     }
     
-    func test_start_deviceLocalAuthSet_faceID_secondaryButton() throws {
-        mockLAContext.returnedFromEvaluatePolicyForBiometrics = true
+    func test_start_deviceLocalAuthSet_faceID_primaryButton_failed() throws {
+        mockLAContext.returnedFromCanEvaluatePolicyForBiometrics = true
+        mockLAContext.returnedFromEvaluatePolicy = false
         mockMainCoordinator.tokens = try MockTokenResponse().getJSONData()
         mockLAContext.biometryType = .faceID
-        // GIVEN device passcode is set
+        // GIVEN the user has enabled biometrics
+        // WHEN the OnboardingCoordinator has shown the local auth guidance via start()
+        mockMainCoordinator.openChildInline(sut)
+        // THEN the view controller should be the token screen
+        waitForTruth(self.navigationController.viewControllers.count == 1, timeout: 2)
+        let vc = try XCTUnwrap(navigationController.topViewController as? GDSInformationViewController)
+        XCTAssertTrue(vc.viewModel is FaceIDEnrollmentViewModel)
+        // WHEN the button on the enrolment screen is tapped
+        let enrolmentPrimaryButton: UIButton = try XCTUnwrap(vc.view[child: "information-primary-button"])
+        enrolmentPrimaryButton.sendActions(for: .touchUpInside)
+        // THEN user remains on the enrolment screen
+        waitForTruth(self.navigationController.viewControllers.count == 1, timeout: 2)
+        XCTAssertTrue(navigationController.topViewController is GDSInformationViewController)
+    }
+    
+    func test_start_deviceLocalAuthSet_faceID_primaryButton_error() throws {
+        mockLAContext.returnedFromCanEvaluatePolicyForBiometrics = true
+        mockLAContext.errorFromEvaluatePolicy = LocalAuthError.evident
+        mockMainCoordinator.tokens = try MockTokenResponse().getJSONData()
+        mockLAContext.biometryType = .faceID
+        // GIVEN the user has enabled biometrics
+        // WHEN the OnboardingCoordinator has shown the local auth guidance via start()
+        mockMainCoordinator.openChildInline(sut)
+        // THEN the view controller should be the token screen
+        waitForTruth(self.navigationController.viewControllers.count == 1, timeout: 2)
+        let vc = try XCTUnwrap(navigationController.topViewController as? GDSInformationViewController)
+        XCTAssertTrue(vc.viewModel is FaceIDEnrollmentViewModel)
+        // WHEN the button on the enrolment screen is tapped
+        let enrolmentPrimaryButton: UIButton = try XCTUnwrap(vc.view[child: "information-primary-button"])
+        enrolmentPrimaryButton.sendActions(for: .touchUpInside)
+        // THEN user remains on the enrolment screen
+        waitForTruth(self.navigationController.viewControllers.count == 1, timeout: 2)
+        XCTAssertTrue(navigationController.topViewController is GDSInformationViewController)
+    }
+    
+    func test_start_deviceLocalAuthSet_faceID_secondaryButton() throws {
+        mockLAContext.returnedFromCanEvaluatePolicyForBiometrics = true
+        mockMainCoordinator.tokens = try MockTokenResponse().getJSONData()
+        mockLAContext.biometryType = .faceID
+        // GIVEN the user has enabled biometrics
         // WHEN the OnboardingCoordinator has shown the local auth guidance via start()
         mockMainCoordinator.openChildInline(sut)
         // THEN the view controller should be the token screen


### PR DESCRIPTION
# feat: enrol user in Face ID local authentication from enrolment screen

This PR implements Local Authentication for iOS devices using Face ID at the point of enrolment. When the user selects "Use Face ID" on the enrolment screen primary button, they will need to perform local authentication in order to move to the home screen, failing local authentication will keep them on the enrolment screen.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
