### PR TITLE
feat: user sees sign in page when app fails to retrieve tokens from secure store

### DIFF
--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -59,7 +59,7 @@ final class LoginCoordinator: NSObject,
             tokenHolder.accessToken = try userStore.secureStoreService.readItem(itemName: .accessToken)
             finish()
         } catch is SecureStoreError {
-            try? userStore.secureStoreService.deleteItem(itemName: .accessTokenExpiry)
+            userStore.refreshStorage()
             start()
         } catch {
             print("Local Authentication error: \(error)")

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -58,7 +58,7 @@ final class LoginCoordinator: NSObject,
         do {
             tokenHolder.accessToken = try userStore.secureStoreService.readItem(itemName: .accessToken)
             finish()
-        } catch is SecureStoreError {
+        } catch SecureStoreError.unableToRetrieveFromUserDefaults {
             userStore.refreshStorage()
             start()
         } catch {

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -58,6 +58,9 @@ final class LoginCoordinator: NSObject,
         do {
             tokenHolder.accessToken = try userStore.secureStoreService.readItem(itemName: .accessToken)
             finish()
+        } catch is SecureStoreError {
+            try? userStore.secureStoreService.deleteItem(itemName: .accessTokenExpiry)
+            start()
         } catch {
             print("Local Authentication error: \(error)")
         }

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -58,7 +58,9 @@ final class LoginCoordinator: NSObject,
         do {
             tokenHolder.accessToken = try userStore.secureStoreService.readItem(itemName: .accessToken)
             finish()
-        } catch SecureStoreError.unableToRetrieveFromUserDefaults {
+        } catch SecureStoreError.unableToRetrieveFromUserDefaults,
+                SecureStoreError.cantInitialiseData,
+                SecureStoreError.cantRetrieveKey {
             userStore.refreshStorage()
             start()
         } catch {

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -13,7 +13,6 @@ final class LoginCoordinatorTests: XCTestCase {
     var mockNetworkMonitor: NetworkMonitoring!
     var mockSecureStore: MockSecureStoreService!
     var mockDefaultStore: MockDefaultsStore!
-    var mockUserStore: MockUserStore!
     var sut: LoginCoordinator!
     
     override func setUp() {

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -1,5 +1,6 @@
 import GDSCommon
 @testable import OneLogin
+import SecureStore
 import XCTest
 
 @MainActor
@@ -51,10 +52,6 @@ final class LoginCoordinatorTests: XCTestCase {
     }
     
     private enum AuthenticationError: Error {
-        case generic
-    }
-    
-    private enum SecureStoreError: Error {
         case generic
     }
 }
@@ -152,15 +149,14 @@ extension LoginCoordinatorTests {
     func test_getAccessToken_errors() throws {
         mockDefaultStore.set(Date() + 60, forKey: .accessTokenExpiry)
         // GIVEN the secure store returns an error from reading an item
-        mockSecureStore.errorFromReadItem = SecureStoreError.generic
+        mockSecureStore.errorFromReadItem = SecureStoreError.unableToRetrieveFromUserDefaults
         // WHEN the LoginCoordinator's getAccessToken method is called
         sut.getAccessToken()
         // THEN the token holder's access token property should not get the access token from secure store
         XCTAssertEqual(sut.tokenHolder.accessToken, nil)
-        XCTAssertTrue(mockSecureStore.didCallDeleteItem)
         // THEN login flow should be triggered
-        sut.start()
-        XCTAssertTrue(mockSecureStore.didCallStart)
+        XCTAssertTrue(sut.root.viewControllers.count == 1)
+        XCTAssertTrue(sut.root.topViewController is IntroViewController)
     }
     
     func test_launchOnboardingCoordinator_succeeds() throws {

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -156,6 +156,7 @@ extension LoginCoordinatorTests {
         // THEN login flow should be triggered
         XCTAssertTrue(mockSecureStore.didCallDeleteStore)
         XCTAssertTrue(mockDefaultStore.didCallRemoveObject)
+        XCTAssertNil(mockDefaultStore.value(forKey: .accessTokenExpiry))
         XCTAssertTrue(sut.root.viewControllers.count == 1)
         XCTAssertTrue(sut.root.topViewController is IntroViewController)
     }

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -146,14 +146,42 @@ extension LoginCoordinatorTests {
         XCTAssertEqual(sut.tokenHolder.accessToken, "123456789")
     }
     
-    func test_getAccessToken_errors() throws {
-        // GIVEN the secure store returns an error from reading an item
+    func test_getAccessToken_error_unableToRetrieveFromUserDefaults() throws {
+        // GIVEN the secure store returns a unableToRetrieveFromUserDefaults error from reading an item
         mockSecureStore.errorFromReadItem = SecureStoreError.unableToRetrieveFromUserDefaults
         // WHEN the LoginCoordinator's getAccessToken method is called
         sut.getAccessToken()
         // THEN the token holder's access token property should not get the access token from secure store
         XCTAssertEqual(sut.tokenHolder.accessToken, nil)
-        // THEN login flow should be triggered
+        // THEN user store should be refreshed
+        XCTAssertTrue(mockSecureStore.didCallDeleteStore)
+        XCTAssertNil(mockDefaultStore.savedData[.accessTokenExpiry])
+        XCTAssertTrue(sut.root.viewControllers.count == 1)
+        XCTAssertTrue(sut.root.topViewController is IntroViewController)
+    }
+    
+    func test_getAccessToken_error_cantInitialiseData() throws {
+        // GIVEN the secure store returns a cantInitialiseData error from reading an item
+        mockSecureStore.errorFromReadItem = SecureStoreError.cantInitialiseData
+        // WHEN the LoginCoordinator's getAccessToken method is called
+        sut.getAccessToken()
+        // THEN the token holder's access token property should not get the access token from secure store
+        XCTAssertEqual(sut.tokenHolder.accessToken, nil)
+        // THEN user store should be refreshed
+        XCTAssertTrue(mockSecureStore.didCallDeleteStore)
+        XCTAssertNil(mockDefaultStore.savedData[.accessTokenExpiry])
+        XCTAssertTrue(sut.root.viewControllers.count == 1)
+        XCTAssertTrue(sut.root.topViewController is IntroViewController)
+    }
+    
+    func test_getAccessToken_error_cantRetrieveKey() throws {
+        // GIVEN the secure store returns a cantRetrieveKey error from reading an item
+        mockSecureStore.errorFromReadItem = SecureStoreError.cantRetrieveKey
+        // WHEN the LoginCoordinator's getAccessToken method is called
+        sut.getAccessToken()
+        // THEN the token holder's access token property should not get the access token from secure store
+        XCTAssertEqual(sut.tokenHolder.accessToken, nil)
+        // THEN user store should be refreshed
         XCTAssertTrue(mockSecureStore.didCallDeleteStore)
         XCTAssertNil(mockDefaultStore.savedData[.accessTokenExpiry])
         XCTAssertTrue(sut.root.viewControllers.count == 1)

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -152,7 +152,7 @@ extension LoginCoordinatorTests {
     func test_getAccessToken_errors() throws {
         mockDefaultStore.set(Date() + 60, forKey: .accessTokenExpiry)
         // GIVEN the secure store returns an error from reading an item
-        mockSecureStore.isErrorFromReadItem = true
+        mockSecureStore.errorFromReadItem = SecureStoreError.generic
         // WHEN the LoginCoordinator's getAccessToken method is called
         sut.getAccessToken()
         // THEN the token holder's access token property should not get the access token from secure store

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -147,7 +147,6 @@ extension LoginCoordinatorTests {
     }
     
     func test_getAccessToken_errors() throws {
-        mockDefaultStore.set(Date() + 60, forKey: .accessTokenExpiry)
         // GIVEN the secure store returns an error from reading an item
         mockSecureStore.errorFromReadItem = SecureStoreError.unableToRetrieveFromUserDefaults
         // WHEN the LoginCoordinator's getAccessToken method is called

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -155,8 +155,7 @@ extension LoginCoordinatorTests {
         XCTAssertEqual(sut.tokenHolder.accessToken, nil)
         // THEN login flow should be triggered
         XCTAssertTrue(mockSecureStore.didCallDeleteStore)
-        XCTAssertTrue(mockDefaultStore.didCallRemoveObject)
-        XCTAssertNil(mockDefaultStore.value(forKey: .accessTokenExpiry))
+        XCTAssertNil(mockDefaultStore.savedData[.accessTokenExpiry])
         XCTAssertTrue(sut.root.viewControllers.count == 1)
         XCTAssertTrue(sut.root.topViewController is IntroViewController)
     }

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -13,6 +13,7 @@ final class LoginCoordinatorTests: XCTestCase {
     var mockNetworkMonitor: NetworkMonitoring!
     var mockSecureStore: MockSecureStoreService!
     var mockDefaultStore: MockDefaultsStore!
+    var mockUserStore: MockUserStore!
     var sut: LoginCoordinator!
     
     override func setUp() {
@@ -155,6 +156,8 @@ extension LoginCoordinatorTests {
         // THEN the token holder's access token property should not get the access token from secure store
         XCTAssertEqual(sut.tokenHolder.accessToken, nil)
         // THEN login flow should be triggered
+        XCTAssertTrue(mockSecureStore.didCallDeleteStore)
+        XCTAssertTrue(mockDefaultStore.didCallRemoveObject)
         XCTAssertTrue(sut.root.viewControllers.count == 1)
         XCTAssertTrue(sut.root.topViewController is IntroViewController)
     }

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -152,11 +152,15 @@ extension LoginCoordinatorTests {
     func test_getAccessToken_errors() throws {
         mockDefaultStore.set(Date() + 60, forKey: .accessTokenExpiry)
         // GIVEN the secure store returns an error from reading an item
-        mockSecureStore.errorFromReadItem = SecureStoreError.generic
+        mockSecureStore.isErrorFromReadItem = true
         // WHEN the LoginCoordinator's getAccessToken method is called
         sut.getAccessToken()
         // THEN the token holder's access token property should not get the access token from secure store
         XCTAssertEqual(sut.tokenHolder.accessToken, nil)
+        XCTAssertTrue(mockSecureStore.didCallDeleteItem)
+        // THEN login flow should be triggered
+        sut.start()
+        XCTAssertTrue(mockSecureStore.didCallStart)
     }
     
     func test_launchOnboardingCoordinator_succeeds() throws {

--- a/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockDefaultsStore.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockDefaultsStore.swift
@@ -3,7 +3,6 @@ import Foundation
 
 class MockDefaultsStore: DefaultsStorable {
     var savedData = [String: Any]()
-    var didCallRemoveObject = false
 
     func set(_ value: Any?, forKey defaultName: String) {
         savedData[defaultName] = value
@@ -14,7 +13,6 @@ class MockDefaultsStore: DefaultsStorable {
     }
     
     func removeObject(forKey defaultName: String) {
-        self.didCallRemoveObject = true
         savedData[defaultName] = nil
     }
 }

--- a/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockDefaultsStore.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockDefaultsStore.swift
@@ -3,7 +3,8 @@ import Foundation
 
 class MockDefaultsStore: DefaultsStorable {
     var savedData = [String: Any]()
-    
+    var didCallRemoveObject = false
+
     func set(_ value: Any?, forKey defaultName: String) {
         savedData[defaultName] = value
     }
@@ -13,6 +14,7 @@ class MockDefaultsStore: DefaultsStorable {
     }
     
     func removeObject(forKey defaultName: String) {
+        self.didCallRemoveObject = true
         savedData[defaultName] = nil
     }
 }

--- a/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockSecureStoreService.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockSecureStoreService.swift
@@ -4,8 +4,6 @@ import SecureStore
 final class MockSecureStoreService: SecureStorable {
     var savedItems = [String: String]()
     var didCallDeleteStore = false
-    var didCallStart = false
-    var didCallDeleteItem = false
 
     var errorFromSaveItem: Error?
     var errorFromReadItem: Error?
@@ -20,16 +18,13 @@ final class MockSecureStoreService: SecureStorable {
     
     func readItem(itemName: String) throws -> String? {
         if let errorFromReadItem {
-            try? deleteItem(itemName: itemName)
-            didCallStart = true
+            throw errorFromReadItem
         } else {
             savedItems[itemName]
         }
-        return savedItems.isEmpty ? nil : savedItems[itemName]
     }
     
     func deleteItem(itemName: String) throws {
-        didCallDeleteItem = true
         savedItems[itemName] = nil
     }
     

--- a/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockSecureStoreService.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockSecureStoreService.swift
@@ -8,7 +8,7 @@ final class MockSecureStoreService: SecureStorable {
     var didCallDeleteItem = false
 
     var errorFromSaveItem: Error?
-    var isErrorFromReadItem = false
+    var errorFromReadItem: Error?
 
     func saveItem(item: String, itemName: String) throws {
         if let errorFromSaveItem {
@@ -19,7 +19,7 @@ final class MockSecureStoreService: SecureStorable {
     }
     
     func readItem(itemName: String) throws -> String? {
-        if isErrorFromReadItem {
+        if let errorFromReadItem {
             try? deleteItem(itemName: itemName)
             didCallStart = true
         } else {

--- a/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockSecureStoreService.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockSecureStoreService.swift
@@ -4,10 +4,12 @@ import SecureStore
 final class MockSecureStoreService: SecureStorable {
     var savedItems = [String: String]()
     var didCallDeleteStore = false
-    
+    var didCallStart = false
+    var didCallDeleteItem = false
+
     var errorFromSaveItem: Error?
-    var errorFromReadItem: Error?
-    
+    var isErrorFromReadItem = false
+
     func saveItem(item: String, itemName: String) throws {
         if let errorFromSaveItem {
             throw errorFromSaveItem
@@ -17,14 +19,17 @@ final class MockSecureStoreService: SecureStorable {
     }
     
     func readItem(itemName: String) throws -> String? {
-        if let errorFromReadItem {
-            throw errorFromReadItem
+        if isErrorFromReadItem {
+            try? deleteItem(itemName: itemName)
+            didCallStart = true
         } else {
             savedItems[itemName]
         }
+        return savedItems.isEmpty ? nil : savedItems[itemName]
     }
     
     func deleteItem(itemName: String) throws {
+        didCallDeleteItem = true
         savedItems[itemName] = nil
     }
     


### PR DESCRIPTION
# DCMAW-7977: User sees sign in page when app fails to retrieve tokens from secure store

This PR redirects a returning user to the signin page should a `SecureStoreError` be thrown when attempting to retrieve tokens

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
