### PR TITLE
fix: allow storage of private keys when no biometrics are enrolled

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -2222,7 +2222,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/govuk-one-login/mobile-ios-secure-store";
 			requirement = {
-				branch = main;
+				branch = "feature/dcmaw-6051-enable-user-presence-access";
 				kind = branch;
 			};
 		};

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -2222,7 +2222,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/govuk-one-login/mobile-ios-secure-store";
 			requirement = {
-				branch = "feature/dcmaw-6051-enable-user-presence-access";
+				branch = main;
 				kind = branch;
 			};
 		};

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-secure-store",
       "state" : {
-        "branch" : "feature/dcmaw-6051-enable-user-presence-access",
-        "revision" : "8efe3f0ffd36a8d4d5c0e1709a5d01802fbfb548"
+        "branch" : "main",
+        "revision" : "32c462a63aeb3fee8cfeae886a0dc20e4c3ef2f5"
       }
     },
     {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-secure-store",
       "state" : {
-        "branch" : "main",
-        "revision" : "ebbaeb4bd1826e692df42070516d884082da5804"
+        "branch" : "feature/dcmaw-6051-enable-user-presence-access",
+        "revision" : "8efe3f0ffd36a8d4d5c0e1709a5d01802fbfb548"
       }
     },
     {

--- a/Sources/Login/EnrolmentCoordinator.swift
+++ b/Sources/Login/EnrolmentCoordinator.swift
@@ -33,6 +33,10 @@ final class EnrolmentCoordinator: NSObject,
         } else if !canUseLocalAuth(.deviceOwnerAuthentication) {
             showPasscodeInfo()
         } else {
+            // Due to a possible Apple bug, .currentBiometricsOrPasscode does not allow creation of private
+            // keys in the secure enclave if no biometrics are registered on the device.  Hence the store
+            // needs to be recreated with access controls that allow it
+            userStore.refreshStorage(accessControlLevel: .anyBiometricsOrPasscode)
             storeAccessTokenInfo()
             finish()
         }

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -40,7 +40,7 @@ final class LoginCoordinator: NSObject,
         if userStore.returningAuthenticatedUser {
             returningUserFlow()
         } else {
-            userStore.refreshStorage()
+            userStore.refreshStorage(accessControlLevel: .currentBiometricsOrPasscode)
             firstTimeUserFlow()
         }
     }
@@ -61,7 +61,7 @@ final class LoginCoordinator: NSObject,
         } catch SecureStoreError.unableToRetrieveFromUserDefaults,
                 SecureStoreError.cantInitialiseData,
                 SecureStoreError.cantRetrieveKey {
-            userStore.refreshStorage()
+            userStore.refreshStorage(accessControlLevel: .currentBiometricsOrPasscode)
             start()
         } catch {
             print("Local Authentication error: \(error)")

--- a/Sources/Utilities/Storage/UserStorable.swift
+++ b/Sources/Utilities/Storage/UserStorable.swift
@@ -5,7 +5,7 @@ protocol UserStorable {
     var secureStoreService: SecureStorable { get set }
     var defaultsStore: DefaultsStorable { get }
     
-    func refreshStorage()
+    func refreshStorage(accessControlLevel: SecureStorageConfiguration.AccessControlLevel)
 }
 
 extension UserStorable {

--- a/Sources/Utilities/Storage/UserStorage.swift
+++ b/Sources/Utilities/Storage/UserStorage.swift
@@ -11,7 +11,7 @@ final class UserStorage: UserStorable {
         self.defaultsStore = defaultsStore
     }
     
-    func refreshStorage() {
+    func refreshStorage(accessControlLevel: SecureStorageConfiguration.AccessControlLevel) {
         do {
             try clearTokenInfo()
             try secureStoreService.delete()
@@ -19,7 +19,7 @@ final class UserStorage: UserStorable {
             print("Deleting Secure Store error: \(error)")
         }
         secureStoreService = SecureStoreService(configuration: .init(id: .oneLoginTokens,
-                                                                     accessControlLevel: .currentBiometricsOrPasscode,
+                                                                     accessControlLevel: accessControlLevel,
                                                                      localAuthStrings: LAContext().contextStrings))
     }
 }

--- a/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockUserStore.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockUserStore.swift
@@ -12,5 +12,5 @@ class MockUserStore: UserStorable {
         self.defaultsStore = defaultsStore
     }
     
-    func refreshStorage() { }
+    func refreshStorage(accessControlLevel: SecureStorageConfiguration.AccessControlLevel) { }
 }


### PR DESCRIPTION
# DCMAW-6051: iOS | Allow storage of private keys when no biometrics are enrolled

In the case that a user has a passcode set on their phone, but no biometrics enrolled, ensure that a private encryption key can be created and saved to the secure enclave. 
This particular change was necessary due to a possible Apple bug wherein our access controls for the keychain were not being honoured when creating keys if no biometrics were enrolled.  Thus we reinitialize the SecureStorage with appropriate controls in that case.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
