### PR TITLE
feat: implement ga4 schema signin in page

### DIFF
--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-coordination.git",
       "state" : {
-        "revision" : "0c3d0463e702f1446dc75db7a64273c5bdf4475c",
-        "version" : "1.0.3"
+        "revision" : "64cdeb5bd74e87cb28b2a3806774394c0165ca76",
+        "version" : "1.0.2"
       }
     },
     {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-coordination.git",
       "state" : {
-        "revision" : "64cdeb5bd74e87cb28b2a3806774394c0165ca76",
-        "version" : "1.0.2"
+        "revision" : "5adc59f1db3c4b55386c4438418c5ec280f0ae41",
+        "version" : "1.1.0"
       }
     },
     {

--- a/Sources/Analytics/Errors/ErrorAnalytics.swift
+++ b/Sources/Analytics/Errors/ErrorAnalytics.swift
@@ -1,7 +1,7 @@
 import GDSAnalytics
 import Logging
 
-enum ErrorAnalyticsScreen: String, LoggableScreen, NamedScreen {
+enum ErrorAnalyticsScreen: String, ScreenType {
     case generic = "genericErrorScreen"
     case unableToLogin = "unableToLoginErrorScreen"
     case networkConnection = "networkConnectionErrorScreen"

--- a/Sources/Analytics/Onboarding/BiometricEnrollmentAnalyticsScreen.swift
+++ b/Sources/Analytics/Onboarding/BiometricEnrollmentAnalyticsScreen.swift
@@ -1,7 +1,7 @@
 import GDSAnalytics
 import Logging
 
-enum BiometricEnrollmentAnalyticsScreen: String, LoggableScreen, NamedScreen {
+enum BiometricEnrollmentAnalyticsScreen: String, ScreenType {
     case faceIDEnrollment = "faceIDEnrollmentScreen"
     case touchIDEnrollment = "touchIDEnrollmentScreen"
     case unlockScreen = "unlockScreen"

--- a/Sources/Analytics/Onboarding/InformationAnalytics.swift
+++ b/Sources/Analytics/Onboarding/InformationAnalytics.swift
@@ -1,6 +1,6 @@
 import GDSAnalytics
 import Logging
 
-enum InformationAnalyticsScreen: String, LoggableScreen, NamedScreen {
+enum InformationAnalyticsScreen: String, ScreenType {
     case passcode = "passcodeInformationScreen"
 }

--- a/Sources/Analytics/Onboarding/IntroAnalytics.swift
+++ b/Sources/Analytics/Onboarding/IntroAnalytics.swift
@@ -1,6 +1,10 @@
 import GDSAnalytics
 import Logging
 
-enum IntroAnalyticsScreen: String, LoggableScreen, NamedScreen {
+enum IntroAnalyticsScreen: String, ScreenType {
     case welcomeScreen = "introWelcomeScreen"
+}
+
+enum IntroAnalyticsScreenID: String {
+    case welcomeScreen = "30a6b339-75a8-44a2-a79a-e108546419bf"
 }

--- a/Sources/Application/Environment/AppEnvironment.swift
+++ b/Sources/Application/Environment/AppEnvironment.swift
@@ -69,6 +69,10 @@ extension AppEnvironment {
     static var oneLoginRedirect: String {
         return string(for: .redirectURL)
     }
+    
+    static var oneLoginBaseURL: String {
+        return string(for: .baseURL)
+    }
 }
 
 // MARK: - STS Info Plist values as Type properties

--- a/Sources/Application/Environment/AppEnvironment.swift
+++ b/Sources/Application/Environment/AppEnvironment.swift
@@ -63,15 +63,15 @@ extension AppEnvironment {
     }
     
     static var oneLoginClientID: String {
-        return string(for: .oneLoginClientID)
+        string(for: .oneLoginClientID)
     }
     
     static var oneLoginRedirect: String {
-        return string(for: .redirectURL)
+        string(for: .redirectURL)
     }
     
     static var oneLoginBaseURL: String {
-        return string(for: .baseURL)
+        string(for: .baseURL)
     }
 }
 
@@ -89,7 +89,7 @@ extension AppEnvironment {
     static var stsClientID: String {
         return string(for: .stsClientID)
     }
-
+    
     static var isLocaleWelsh: Bool {
         UserDefaults.standard.stringArray(forKey: "AppleLanguages")?.first?.prefix(2) == "cy" ? true : false
     }

--- a/Sources/Extensions/CustomTypes/AnalyticsService+GDS.swift
+++ b/Sources/Extensions/CustomTypes/AnalyticsService+GDS.swift
@@ -21,7 +21,7 @@ extension EventName: LoggableEvent { }
  extension ScreenView: LoggableScreenV2
  where Screen: Logging.ScreenType {
     public var name: String {
-        type.name
+        title
     }
 
     public var type: Logging.ScreenType {

--- a/Sources/Extensions/CustomTypes/AnalyticsService+GDS.swift
+++ b/Sources/Extensions/CustomTypes/AnalyticsService+GDS.swift
@@ -18,13 +18,13 @@ extension AnalyticsService {
 
 extension EventName: LoggableEvent { }
 
- extension ScreenView: LoggableScreenV2
- where Screen: Logging.ScreenType {
+extension ScreenView: LoggableScreenV2
+where Screen: Logging.ScreenType {
     public var name: String {
         title
     }
-
+    
     public var type: Logging.ScreenType {
         self.screen
     }
- }
+}

--- a/Sources/Extensions/CustomTypes/AnalyticsService+GDS.swift
+++ b/Sources/Extensions/CustomTypes/AnalyticsService+GDS.swift
@@ -1,17 +1,30 @@
 import GDSAnalytics
 import Logging
 
+typealias ScreenType = Logging.ScreenType & GDSAnalytics.ScreenType
+
 extension AnalyticsService {
     public func logEvent(_ event: Event) {
         logEvent(event.name,
                  parameters: event.parameters)
     }
     
-    public func trackScreen<View: ScreenViewProtocol>(_ view: View)
-    where View.Screen: LoggableScreen {
-        trackScreen(view.screen,
-                    parameters: view.parameters)
+    public func trackScreen<Screen>(_ screen: Screen)
+    where Screen: ScreenViewProtocol & LoggableScreenV2 {
+        trackScreen(screen,
+                    parameters: screen.parameters)
     }
 }
 
 extension EventName: LoggableEvent { }
+
+ extension ScreenView: LoggableScreenV2
+ where Screen: Logging.ScreenType {
+    public var name: String {
+        type.name
+    }
+
+    public var type: Logging.ScreenType {
+        self.screen
+    }
+ }

--- a/Sources/Login/ViewModels/OneLoginIntroViewModel.swift
+++ b/Sources/Login/ViewModels/OneLoginIntroViewModel.swift
@@ -18,7 +18,7 @@ struct OneLoginIntroViewModel: IntroViewModel, BaseViewModel {
         self.analyticsService = analyticsService
         let event = LinkEvent(textKey: "app_signInButton",
                               linkDomain: AppEnvironment.oneLoginBaseURL,
-                              external: .true)
+                              external: .false)
         introButtonViewModel = AnalyticsButtonViewModel(titleKey: "app_signInButton",
                                                         analyticsService: analyticsService,
                                                         analyticsEvent: event) {

--- a/Sources/Login/ViewModels/OneLoginIntroViewModel.swift
+++ b/Sources/Login/ViewModels/OneLoginIntroViewModel.swift
@@ -16,8 +16,12 @@ struct OneLoginIntroViewModel: IntroViewModel, BaseViewModel {
     init(analyticsService: AnalyticsService,
          signinAction: @escaping () -> Void) {
         self.analyticsService = analyticsService
+        let event = LinkEvent(textKey: "app_signInButton",
+                              linkDomain: AppEnvironment.oneLoginBaseURL,
+                              external: .true)
         introButtonViewModel = AnalyticsButtonViewModel(titleKey: "app_signInButton",
-                                                        analyticsService: analyticsService) {
+                                                        analyticsService: analyticsService,
+                                                        analyticsEvent: event) {
             signinAction()
         }
     }

--- a/Sources/Login/ViewModels/OneLoginIntroViewModel.swift
+++ b/Sources/Login/ViewModels/OneLoginIntroViewModel.swift
@@ -23,7 +23,8 @@ struct OneLoginIntroViewModel: IntroViewModel, BaseViewModel {
     }
     
     func didAppear() {
-        let screen = ScreenView(screen: IntroAnalyticsScreen.welcomeScreen,
+        let screen = ScreenView(id: IntroAnalyticsScreenID.welcomeScreen.rawValue,
+                                screen: IntroAnalyticsScreen.welcomeScreen,
                                 titleKey: title.stringKey)
         analyticsService.trackScreen(screen)
     }

--- a/Sources/Utilities/Analytics/AnalyticsCenter.swift
+++ b/Sources/Utilities/Analytics/AnalyticsCenter.swift
@@ -8,5 +8,15 @@ final class AnalyticsCenter: AnalyticsCentral {
          analyticsPreferenceStore: AnalyticsPreferenceStore) {
         self.analyticsService = analyticsService
         self.analyticsPreferenceStore = analyticsPreferenceStore
+        setAdditionalParameters()
+    }
+    
+    private func setAdditionalParameters() {
+        analyticsService.additionalParameters = [
+            "primary_publishing_organisation": "government digital service - digital identity",
+            "organisation": "<OT1056>",
+            "taxonomy_level1": "one login mobile application",
+            "taxonomy_level2": "login"
+        ]
     }
 }

--- a/Sources/Utilities/Analytics/AnalyticsCenter.swift
+++ b/Sources/Utilities/Analytics/AnalyticsCenter.swift
@@ -2,7 +2,7 @@ import Foundation
 import Logging
 
 final class AnalyticsCenter: AnalyticsCentral {
-    let analyticsService: AnalyticsService
+    private(set) var analyticsService: AnalyticsService
     var analyticsPreferenceStore: AnalyticsPreferenceStore
     
     init(analyticsService: AnalyticsService,
@@ -18,6 +18,7 @@ final class AnalyticsCenter: AnalyticsCentral {
             "organisation": "<OT1056>",
             "taxonomy_level1": "one login mobile application",
             "taxonomy_level2": "login",
+            "taxonomy_level3": "undefined",
             "language": "\(NSLocale.current.identifier.prefix(2))"
         ]
     }

--- a/Sources/Utilities/Analytics/AnalyticsCenter.swift
+++ b/Sources/Utilities/Analytics/AnalyticsCenter.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Logging
 
 final class AnalyticsCenter: AnalyticsCentral {
@@ -16,7 +17,8 @@ final class AnalyticsCenter: AnalyticsCentral {
             "primary_publishing_organisation": "government digital service - digital identity",
             "organisation": "<OT1056>",
             "taxonomy_level1": "one login mobile application",
-            "taxonomy_level2": "login"
+            "taxonomy_level2": "login",
+            "language": "\(NSLocale.current.identifier.prefix(2))"
         ]
     }
 }

--- a/Tests/ConfigTests/BuildConfig/BuildAppEnvironmentTests.swift
+++ b/Tests/ConfigTests/BuildConfig/BuildAppEnvironmentTests.swift
@@ -10,6 +10,7 @@ final class BuildAppEnvironmentTests: XCTestCase {
         XCTAssertEqual(sut.oneLoginClientID, "TEST_CLIENT_ID")
         XCTAssertEqual(sut.stsClientID, "bYrcuRVvnylvEgYSSbBjwXzHrwJ")
         XCTAssertEqual(sut.oneLoginRedirect, "https://mobile.build.account.gov.uk/redirect")
+        XCTAssertEqual(sut.oneLoginBaseURL, "mobile.build.account.gov.uk")
         XCTAssertFalse(sut.callingSTSEnabled)
         XCTAssertFalse(sut.isLocaleWelsh)
     }

--- a/Tests/ConfigTests/StagingConfig/StagingAppEnvironmentTests.swift
+++ b/Tests/ConfigTests/StagingConfig/StagingAppEnvironmentTests.swift
@@ -10,6 +10,7 @@ final class StagingAppEnvironmentTests: XCTestCase {
         XCTAssertEqual(sut.oneLoginClientID, "sdJChz1oGajIz0O0tdPdh0CA2zW")
         XCTAssertEqual(sut.stsClientID, "ctQpngJQrFFCrppZtYQFFoklHaq")
         XCTAssertEqual(sut.oneLoginRedirect, "https://mobile.staging.account.gov.uk/redirect")
+        XCTAssertEqual(sut.oneLoginBaseURL, "mobile.staging.account.gov.uk")
         XCTAssertFalse(sut.callingSTSEnabled)
         XCTAssertFalse(sut.isLocaleWelsh)
     }

--- a/Tests/UnitTests/Errors/GenericErrorViewModelTests.swift
+++ b/Tests/UnitTests/Errors/GenericErrorViewModelTests.swift
@@ -50,7 +50,7 @@ extension GenericErrorViewModelTests {
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 1)
         let screen = ScreenView(screen: ErrorAnalyticsScreen.generic,
                                 titleKey: "app_somethingWentWrongErrorTitle")
-        XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.screen.name])
+        XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
     }
 }

--- a/Tests/UnitTests/Errors/NetworkConnectionErrorViewModelTests.swift
+++ b/Tests/UnitTests/Errors/NetworkConnectionErrorViewModelTests.swift
@@ -50,7 +50,7 @@ extension NetworkConnectionErrorViewModelTests {
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 1)
         let screen = ScreenView(screen: ErrorAnalyticsScreen.networkConnection,
                                 titleKey: "app_networkErrorTitle")
-        XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.screen.name])
+        XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
     }
 }

--- a/Tests/UnitTests/Errors/UnableToLoginErrorViewModelTests.swift
+++ b/Tests/UnitTests/Errors/UnableToLoginErrorViewModelTests.swift
@@ -50,7 +50,7 @@ extension UnableToLoginErrorViewModelTests {
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 1)
         let screen = ScreenView(screen: ErrorAnalyticsScreen.unableToLogin,
                                 titleKey: "app_signInErrorTitle")
-        XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.screen.name])
+        XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
     }
 }

--- a/Tests/UnitTests/Login/ViewModels/FaceIDEnrollmentViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/FaceIDEnrollmentViewModelTests.swift
@@ -67,7 +67,7 @@ extension FaceIDEnrollmentViewModelTests {
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 1)
         let screen = ScreenView(screen: BiometricEnrollmentAnalyticsScreen.faceIDEnrollment,
                                 titleKey: "app_enableFaceIDTitle")
-        XCTAssertEqual(mockAnalyticsService.screensVisited, [ screen.screen.name])
+        XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
     }
 }

--- a/Tests/UnitTests/Login/ViewModels/OneLoginIntroViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/OneLoginIntroViewModelTests.swift
@@ -39,10 +39,12 @@ extension OneLoginIntroViewModelTests {
         sut.introButtonViewModel.action()
         XCTAssertTrue(didCallButtonAction)
         XCTAssertEqual(mockAnalyticsService.eventsLogged.count, 1)
-        let event = ButtonEvent(textKey: "app_signInButton")
+        let event = LinkEvent(textKey: "app_signInButton", linkDomain: AppEnvironment.oneLoginBaseURL, external: .true)
         XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["text"], event.parameters["text"])
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["type"], event.parameters["type"])
+        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["link_domain"], event.parameters["link_domain"])
+        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["external"], event.parameters["external"])
     }
     
     func test_didAppear() throws {

--- a/Tests/UnitTests/Login/ViewModels/OneLoginIntroViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/OneLoginIntroViewModelTests.swift
@@ -41,7 +41,7 @@ extension OneLoginIntroViewModelTests {
         XCTAssertEqual(mockAnalyticsService.eventsLogged.count, 1)
         let event = LinkEvent(textKey: "app_signInButton",
                               linkDomain: AppEnvironment.oneLoginBaseURL,
-                              external: .true)
+                              external: .false)
         XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["text"], event.parameters["text"])
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["type"], event.parameters["type"])

--- a/Tests/UnitTests/Login/ViewModels/OneLoginIntroViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/OneLoginIntroViewModelTests.swift
@@ -49,9 +49,11 @@ extension OneLoginIntroViewModelTests {
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 0)
         sut.didAppear()
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 1)
-        let screen = ScreenView(screen: IntroAnalyticsScreen.welcomeScreen,
+        let screen = ScreenView(id: IntroAnalyticsScreenID.welcomeScreen.rawValue,
+                                screen: IntroAnalyticsScreen.welcomeScreen,
                                 titleKey: "app_signInTitle")
-        XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.screen.name])
+        XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"], "30a6b339-75a8-44a2-a79a-e108546419bf")
     }
 }

--- a/Tests/UnitTests/Login/ViewModels/OneLoginIntroViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/OneLoginIntroViewModelTests.swift
@@ -39,7 +39,9 @@ extension OneLoginIntroViewModelTests {
         sut.introButtonViewModel.action()
         XCTAssertTrue(didCallButtonAction)
         XCTAssertEqual(mockAnalyticsService.eventsLogged.count, 1)
-        let event = LinkEvent(textKey: "app_signInButton", linkDomain: AppEnvironment.oneLoginBaseURL, external: .true)
+        let event = LinkEvent(textKey: "app_signInButton",
+                              linkDomain: AppEnvironment.oneLoginBaseURL,
+                              external: .true)
         XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["text"], event.parameters["text"])
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["type"], event.parameters["type"])
@@ -56,6 +58,6 @@ extension OneLoginIntroViewModelTests {
                                 titleKey: "app_signInTitle")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"], "30a6b339-75a8-44a2-a79a-e108546419bf")
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"], screen.parameters["screen_id"])
     }
 }

--- a/Tests/UnitTests/Login/ViewModels/PasscodeInformationViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/PasscodeInformationViewModelTests.swift
@@ -50,7 +50,7 @@ extension PasscodeInformationViewModelTests {
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 1)
         let screen = ScreenView(screen: InformationAnalyticsScreen.passcode,
                                 titleKey: "app_noPasscodeSetupTitle")
-        XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.screen.name])
+        XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
     }
 }

--- a/Tests/UnitTests/Login/ViewModels/TouchIDEnrollmentViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/TouchIDEnrollmentViewModelTests.swift
@@ -65,7 +65,8 @@ extension TouchIDEnrollmentViewModelTests {
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 0)
         sut.didAppear()
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 1)
-        let screen = ScreenView(screen: BiometricEnrollmentAnalyticsScreen.touchIDEnrollment, titleKey: "app_enableTouchIDTitle")
+        let screen = ScreenView(screen: BiometricEnrollmentAnalyticsScreen.touchIDEnrollment,
+                                titleKey: "app_enableTouchIDTitle")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
     }

--- a/Tests/UnitTests/Login/ViewModels/TouchIDEnrollmentViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/TouchIDEnrollmentViewModelTests.swift
@@ -66,7 +66,7 @@ extension TouchIDEnrollmentViewModelTests {
         sut.didAppear()
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 1)
         let screen = ScreenView(screen: BiometricEnrollmentAnalyticsScreen.touchIDEnrollment, titleKey: "app_enableTouchIDTitle")
-        XCTAssertEqual(mockAnalyticsService.screensVisited, [ screen.screen.name])
+        XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
     }
 }

--- a/Tests/UnitTests/Login/ViewModels/UnlockScreenViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/UnlockScreenViewModelTests.swift
@@ -46,7 +46,7 @@ extension UnlockScreenViewModelTests {
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 1)
         let screen = ScreenView(screen: BiometricEnrollmentAnalyticsScreen.unlockScreen,
                                 titleKey: "unlock screen")
-        XCTAssertEqual(mockAnalyticsService.screensVisited, [ screen.screen.name])
+        XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
     }
 }


### PR DESCRIPTION
# iOS | Implement GA4 schema on the Sign in page

Add new required parameters to all analytics.   Update to use LoggableScreenV2, and add new screen_id parameter to Sing In page.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
