### PR TITLE
feat: initial implementation of GA4 for screen

### DIFF
--- a/Sources/Analytics/Onboarding/InformationAnalytics.swift
+++ b/Sources/Analytics/Onboarding/InformationAnalytics.swift
@@ -4,3 +4,7 @@ import Logging
 enum InformationAnalyticsScreen: String, ScreenType {
     case passcode = "passcodeInformationScreen"
 }
+
+enum InformationAnalyticsScreenID: String {
+    case passcodeInfoScreen = "7412b60c-8f06-4d6c-9ecc-57769516ebac"
+}

--- a/Sources/Login/ViewModels/PasscodeInformationViewModel.swift
+++ b/Sources/Login/ViewModels/PasscodeInformationViewModel.swift
@@ -20,14 +20,19 @@ struct PasscodeInformationViewModel: GDSInformationViewModel, BaseViewModel {
     
     init(analyticsService: AnalyticsService, action: @escaping () -> Void) {
         self.analyticsService = analyticsService
+        let event = LinkEvent(textKey: "app_continueButton",
+                              linkDomain: AppEnvironment.oneLoginBaseURL,
+                              external: .false)
         self.primaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "app_continueButton",
-                                                               analyticsService: analyticsService) {
+                                                               analyticsService: analyticsService,
+                                                               analyticsEvent: event) {
             action()
         }
     }
     
     func didAppear() {
-        let screen = ScreenView(screen: InformationAnalyticsScreen.passcode,
+        let screen = ScreenView(id: InformationAnalyticsScreenID.passcodeInfoScreen.rawValue,
+                                screen: InformationAnalyticsScreen.passcode,
                                 titleKey: title.stringKey)
         analyticsService.trackScreen(screen)
     }

--- a/Sources/Utilities/Analytics/AnalyticsCenter.swift
+++ b/Sources/Utilities/Analytics/AnalyticsCenter.swift
@@ -14,6 +14,7 @@ final class AnalyticsCenter: AnalyticsCentral {
     
     private func setAdditionalParameters() {
         analyticsService.additionalParameters = [
+            "saved_doc_type": "undefined",
             "primary_publishing_organisation": "government digital service - digital identity",
             "organisation": "<OT1056>",
             "taxonomy_level1": "one login mobile application",

--- a/Tests/UnitTests/Login/ViewModels/PasscodeInformationViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/PasscodeInformationViewModelTests.swift
@@ -38,19 +38,31 @@ extension PasscodeInformationViewModelTests {
         sut.primaryButtonViewModel.action()
         XCTAssertTrue(didCallButtonAction)
         XCTAssertEqual(mockAnalyticsService.eventsLogged.count, 1)
-        let event = ButtonEvent(textKey: "app_continueButton")
+        let event = LinkEvent(textKey: "app_continueButton",
+                              linkDomain: AppEnvironment.oneLoginBaseURL,
+                              external: .false)
         XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
-        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["text"], event.parameters["text"])
-        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["type"], event.parameters["type"])
+        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["text"],
+                       event.parameters["text"])
+        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["type"],
+                       event.parameters["type"])
+        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["link_domain"],
+                       event.parameters["link_domain"])
+        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["external"],
+                       event.parameters["external"])
     }
     
     func test_didAppear() throws {
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 0)
         sut.didAppear()
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 1)
-        let screen = ScreenView(screen: InformationAnalyticsScreen.passcode,
+        let screen = ScreenView(id: InformationAnalyticsScreenID.passcodeInfoScreen.rawValue,
+                                screen: InformationAnalyticsScreen.passcode,
                                 titleKey: "app_noPasscodeSetupTitle")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"],
+                       screen.parameters["title"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"],
+                       screen.parameters["screen_id"])
     }
 }


### PR DESCRIPTION
# DCMAW-8382: Implement GA4 schema on the passcode information page

This adds GA4 analytics to the passcode information screen, when users do not have a passcode on their device 

![Screenshot 2024-04-09 at 15 25 18](https://github.com/govuk-one-login/mobile-ios-one-login-app/assets/117986969/794873cf-85a7-4298-a6d8-22d952822dbb)

https://github.com/govuk-one-login/mobile-ios-one-login-app/assets/117986969/a30817b6-819b-4c5d-ad8b-e09acc01d034

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- ~~[ ] Met all accessibility requirements?~~
    - ~~[ ] Checked dynamic type sizes are applied~~
    - ~~[ ] Checked VoiceOver can navigate your new code~~
    - ~~[ ] Checked a user can navigate only using a keyboard around your new code~~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
