### PR TITLE
feat: implement GA4 schema on the generic error page

### DIFF
--- a/Sources/Analytics/Errors/ErrorAnalytics.swift
+++ b/Sources/Analytics/Errors/ErrorAnalytics.swift
@@ -6,3 +6,7 @@ enum ErrorAnalyticsScreen: String, ScreenType {
     case unableToLogin = "unableToLoginErrorScreen"
     case networkConnection = "networkConnectionErrorScreen"
 }
+
+enum ErrorAnalyticsScreenID: String {
+    case generic = "f275a786-7366-4ef5-b24b-9e514d324403"
+}

--- a/Sources/Errors/GenericErrorViewModel.swift
+++ b/Sources/Errors/GenericErrorViewModel.swift
@@ -9,12 +9,16 @@ struct GenericErrorViewModel: GDSErrorViewModel, BaseViewModel {
     let primaryButtonViewModel: ButtonViewModel
     let secondaryButtonViewModel: ButtonViewModel? = nil
     let analyticsService: AnalyticsService
-    
+
     let rightBarButtonTitle: GDSLocalisedString? = nil
     let backButtonIsHidden: Bool = true
-    
-    init(analyticsService: AnalyticsService, action: @escaping () -> Void) {
+    let errorDescription: String
+
+    init(errorDescription: String,
+         analyticsService: AnalyticsService,
+         action: @escaping () -> Void) {
         self.analyticsService = analyticsService
+        self.errorDescription = errorDescription
         let event = LinkEvent(textKey: "app_closeButton",
                               linkDomain: AppEnvironment.oneLoginBaseURL,
                               external: .false)
@@ -28,7 +32,7 @@ struct GenericErrorViewModel: GDSErrorViewModel, BaseViewModel {
     func didAppear() {
         let screen = ErrorScreenView(id: ErrorAnalyticsScreenID.generic.rawValue,
                                      screen: ErrorAnalyticsScreen.generic,
-                                     titleKey: title.stringKey, reason: "Generic error")
+                                     titleKey: title.stringKey, reason: errorDescription)
         analyticsService.trackScreen(screen)
     }
     

--- a/Sources/Errors/GenericErrorViewModel.swift
+++ b/Sources/Errors/GenericErrorViewModel.swift
@@ -15,15 +15,20 @@ struct GenericErrorViewModel: GDSErrorViewModel, BaseViewModel {
     
     init(analyticsService: AnalyticsService, action: @escaping () -> Void) {
         self.analyticsService = analyticsService
+        let event = LinkEvent(textKey: "app_closeButton",
+                              linkDomain: AppEnvironment.oneLoginBaseURL,
+                              external: .false)
         self.primaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "app_closeButton",
-                                                               analyticsService: analyticsService) {
+                                                               analyticsService: analyticsService,
+                                                               analyticsEvent: event) {
             action()
         }
     }
     
     func didAppear() {
-        let screen = ScreenView(screen: ErrorAnalyticsScreen.generic,
-                                titleKey: title.stringKey)
+        let screen = ErrorScreenView(id: ErrorAnalyticsScreenID.generic.rawValue,
+                                     screen: ErrorAnalyticsScreen.generic,
+                                     titleKey: title.stringKey, reason: "Generic error")
         analyticsService.trackScreen(screen)
     }
     

--- a/Sources/Extensions/CustomTypes/AnalyticsService+GDS.swift
+++ b/Sources/Extensions/CustomTypes/AnalyticsService+GDS.swift
@@ -28,3 +28,14 @@ where Screen: Logging.ScreenType {
         self.screen
     }
 }
+
+extension ErrorScreenView: LoggableScreenV2
+where Screen: Logging.ScreenType {
+    public var name: String {
+        title
+    }
+
+    public var type: Logging.ScreenType {
+        self.screen
+    }
+}

--- a/Sources/Login/AuthenticationCoordinator.swift
+++ b/Sources/Login/AuthenticationCoordinator.swift
@@ -53,7 +53,8 @@ final class AuthenticationCoordinator: NSObject,
                 finish()
             } catch {
                 let genericErrorScreen = errorPresenter
-                    .createGenericError(analyticsService: analyticsService) { [unowned self] in
+                    .createGenericError(errorDescription: error.localizedDescription,
+                                        analyticsService: analyticsService) { [unowned self] in
                         root.popViewController(animated: true)
                         finish()
                     }
@@ -68,7 +69,8 @@ final class AuthenticationCoordinator: NSObject,
             try session.finalise(redirectURL: url)
         } catch {
             let genericErrorScreen = errorPresenter
-                .createGenericError(analyticsService: analyticsService) { [unowned self] in
+                .createGenericError(errorDescription: error.localizedDescription,
+                                    analyticsService: analyticsService) { [unowned self] in
                     root.popViewController(animated: true)
                     finish()
                 }

--- a/Sources/Utilities/Factories/ErrorPresenter.swift
+++ b/Sources/Utilities/Factories/ErrorPresenter.swift
@@ -2,9 +2,11 @@ import GDSCommon
 import Logging
 
 final class ErrorPresenter {
-    static func createGenericError(analyticsService: AnalyticsService,
+    static func createGenericError(errorDescription: String,
+                                   analyticsService: AnalyticsService,
                                    action: @escaping () -> Void) -> GDSErrorViewController {
-        let viewModel = GenericErrorViewModel(analyticsService: analyticsService) {
+        let viewModel = GenericErrorViewModel(errorDescription: errorDescription,
+                                              analyticsService: analyticsService) {
             action()
         }
         return GDSErrorViewController(viewModel: viewModel)

--- a/Tests/UnitTests/Errors/GenericErrorViewModelTests.swift
+++ b/Tests/UnitTests/Errors/GenericErrorViewModelTests.swift
@@ -38,19 +38,28 @@ extension GenericErrorViewModelTests {
         sut.primaryButtonViewModel.action()
         XCTAssertTrue(didCallButtonAction)
         XCTAssertEqual(mockAnalyticsService.eventsLogged.count, 1)
-        let event = ButtonEvent(textKey: "app_closeButton")
+        let event = LinkEvent(textKey: "app_closeButton",
+                              linkDomain: AppEnvironment.oneLoginBaseURL,
+                              external: .false)
         XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["text"], event.parameters["text"])
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["type"], event.parameters["type"])
+        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["link_domain"],
+                       event.parameters["link_domain"])
+        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["external"],
+                       event.parameters["external"])
     }
     
     func test_didAppear() throws {
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 0)
         sut.didAppear()
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 1)
-        let screen = ScreenView(screen: ErrorAnalyticsScreen.generic,
+        let screen = ScreenView(id: ErrorAnalyticsScreenID.generic.rawValue,
+                                screen: ErrorAnalyticsScreen.generic,
                                 titleKey: "app_somethingWentWrongErrorTitle")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"],
+                       screen.parameters["screen_id"])
     }
 }

--- a/Tests/UnitTests/Errors/GenericErrorViewModelTests.swift
+++ b/Tests/UnitTests/Errors/GenericErrorViewModelTests.swift
@@ -54,12 +54,15 @@ extension GenericErrorViewModelTests {
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 0)
         sut.didAppear()
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 1)
-        let screen = ScreenView(id: ErrorAnalyticsScreenID.generic.rawValue,
-                                screen: ErrorAnalyticsScreen.generic,
-                                titleKey: "app_somethingWentWrongErrorTitle")
+        let screen = ErrorScreenView(id: ErrorAnalyticsScreenID.generic.rawValue,
+                                     screen: ErrorAnalyticsScreen.generic,
+                                     titleKey: "app_somethingWentWrongErrorTitle",
+                                     reason: "reason")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"],
                        screen.parameters["screen_id"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["generic error"],
+                       screen.parameters["generic error"])
     }
 }

--- a/Tests/UnitTests/Errors/GenericErrorViewModelTests.swift
+++ b/Tests/UnitTests/Errors/GenericErrorViewModelTests.swift
@@ -11,7 +11,8 @@ final class GenericErrorViewModelTests: XCTestCase {
         super.setUp()
         
         mockAnalyticsService = MockAnalyticsService()
-        sut = GenericErrorViewModel(analyticsService: mockAnalyticsService) {
+        sut = GenericErrorViewModel(errorDescription: "error description",
+                                    analyticsService: mockAnalyticsService) {
             self.didCallButtonAction = true
         }
     }
@@ -30,6 +31,7 @@ extension GenericErrorViewModelTests {
         XCTAssertEqual(sut.image, "exclamationmark.circle")
         XCTAssertEqual(sut.title.stringKey, "app_somethingWentWrongErrorTitle")
         XCTAssertEqual(sut.body.stringKey, "app_somethingWentWrongErrorBody")
+        XCTAssertEqual(sut.errorDescription, "error description")
     }
     
     func test_button_action() throws {

--- a/Tests/UnitTests/Mocks/Sessions+Services/Analytics/MockAnalyticsService.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Analytics/MockAnalyticsService.swift
@@ -29,10 +29,14 @@ final class MockAnalyticsService: AnalyticsService {
     func trackScreen(_ screen: Logging.LoggableScreenV2, parameters: [String: Any]) {
         screensVisited.append(screen.name)
         
-        guard let parameters = parameters as? [String: String] else {
+        guard var parameters = parameters as? [String: String] else {
             XCTFail("Non-string parameters were logged")
             return
         }
+
+        parameters["AnalyticsParameterScreenClass"] = screen.type.name
+        parameters["AnalyticsParameterScreenName"] = screen.name
+        
         screenParamsLogged = parameters
     }
     

--- a/Tests/UnitTests/Utilities/ErrorPresenterTests.swift
+++ b/Tests/UnitTests/Utilities/ErrorPresenterTests.swift
@@ -23,7 +23,8 @@ final class ErrorPresenterTests: XCTestCase {
 
 extension ErrorPresenterTests {
     func test_genericError_callsAction() throws {
-        let introView = sut.createGenericError(analyticsService: mockAnalyticsService) {
+        let introView = sut.createGenericError(errorDescription: "error description",
+                                               analyticsService: mockAnalyticsService) {
             self.didCallAction = true
         }
         let introButton: UIButton = try XCTUnwrap(introView.view[child: "error-primary-button"])


### PR DESCRIPTION
# DCMAW-8415: Implement GA4 schema on the generic error page

This logs and sends the screenErrorView and tracks the button event for GA4 for the generic error page.

![Screenshot 2024-04-10 at 12 14 23](https://github.com/govuk-one-login/mobile-ios-one-login-app/assets/117986969/2c64dd8a-a594-4316-a4d5-5971f5a57e09)

![Screenshot 2024-04-10 at 12 16 11](https://github.com/govuk-one-login/mobile-ios-one-login-app/assets/117986969/0e1d63c0-77c9-498f-a592-886ce6414ba4)

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- ~~[ ] Met all accessibility requirements?~~
    - ~~[ ] Checked dynamic type sizes are applied~~
    - ~~[ ] Checked VoiceOver can navigate your new code~~
    - ~~[ ] Checked a user can navigate only using a keyboard around your new code~~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
