### PR TITLE
feat:  Implement GA4 schema on the Touch ID opt-in page

### DIFF
--- a/Sources/Analytics/Onboarding/BiometricEnrollmentAnalyticsScreen.swift
+++ b/Sources/Analytics/Onboarding/BiometricEnrollmentAnalyticsScreen.swift
@@ -6,3 +6,7 @@ enum BiometricEnrollmentAnalyticsScreen: String, ScreenType {
     case touchIDEnrollment = "touchIDEnrollmentScreen"
     case unlockScreen = "unlockScreen"
 }
+
+enum BiometricEnrollmentAnalyticsScreenID: String {
+    case touchIDEnrollment = "cc1db40a-2a5a-43fe-a1fe-fc85b55fdcab"
+}

--- a/Sources/Login/ViewModels/TouchIDEnrollmentViewModel.swift
+++ b/Sources/Login/ViewModels/TouchIDEnrollmentViewModel.swift
@@ -34,7 +34,8 @@ struct TouchIDEnrollmentViewModel: GDSInformationViewModel, BaseViewModel {
     
     
     func didAppear() {
-        let screen = ScreenView(screen: BiometricEnrollmentAnalyticsScreen.touchIDEnrollment,
+        let screen = ScreenView(id: BiometricEnrollmentAnalyticsScreenID.touchIDEnrollment.rawValue,
+                                screen: BiometricEnrollmentAnalyticsScreen.touchIDEnrollment,
                                 titleKey: title.stringKey)
         analyticsService.trackScreen(screen)
     }

--- a/Tests/UnitTests/Login/ViewModels/TouchIDEnrollmentViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/TouchIDEnrollmentViewModelTests.swift
@@ -65,9 +65,12 @@ extension TouchIDEnrollmentViewModelTests {
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 0)
         sut.didAppear()
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 1)
-        let screen = ScreenView(screen: BiometricEnrollmentAnalyticsScreen.touchIDEnrollment,
+        let screen = ScreenView(id: BiometricEnrollmentAnalyticsScreenID.touchIDEnrollment.rawValue,
+                                screen: BiometricEnrollmentAnalyticsScreen.touchIDEnrollment,
                                 titleKey: "app_enableTouchIDTitle")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"],
+                       screen.parameters["screen_id"])
     }
 }


### PR DESCRIPTION
# DCMAW-8393: iOS | Implement GA4 schema on the Touch ID opt-in page

Add GA4 analytics and screen_id to touch-id opt in screen

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~~- [ ] Met all accessibility requirements?~~
~~- [ ] Checked dynamic type sizes are applied~~
~~- [ ] Checked VoiceOver can navigate your new code~~
~~- [ ] Checked a user can navigate only using a keyboard around your new code~~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
