### PR TITLE
feat: dcmaw-8421. Implement ga4 schema network connection error page

### DIFF
--- a/Sources/Analytics/Errors/ErrorAnalytics.swift
+++ b/Sources/Analytics/Errors/ErrorAnalytics.swift
@@ -9,4 +9,5 @@ enum ErrorAnalyticsScreen: String, ScreenType {
 
 enum ErrorAnalyticsScreenID: String {
     case generic = "f275a786-7366-4ef5-b24b-9e514d324403"
+    case networkConnection = "80606f36-f6aa-4f49-aaa8-ff7d3cdeb16f"
 }

--- a/Sources/Errors/NetworkConnectionErrorViewModel.swift
+++ b/Sources/Errors/NetworkConnectionErrorViewModel.swift
@@ -22,8 +22,10 @@ struct NetworkConnectionErrorViewModel: GDSErrorViewModel, BaseViewModel {
     }
     
     func didAppear() {
-        let screen = ScreenView(screen: ErrorAnalyticsScreen.networkConnection,
-                                titleKey: title.stringKey)
+        let screen = ErrorScreenView(id: ErrorAnalyticsScreenID.networkConnection.rawValue,
+                                     screen: ErrorAnalyticsScreen.networkConnection,
+                                     titleKey: title.stringKey,
+                                     reason: "network connection error")
         analyticsService.trackScreen(screen)
     }
     

--- a/Tests/UnitTests/Errors/GenericErrorViewModelTests.swift
+++ b/Tests/UnitTests/Errors/GenericErrorViewModelTests.swift
@@ -59,7 +59,7 @@ extension GenericErrorViewModelTests {
         let screen = ErrorScreenView(id: ErrorAnalyticsScreenID.generic.rawValue,
                                      screen: ErrorAnalyticsScreen.generic,
                                      titleKey: "app_somethingWentWrongErrorTitle",
-                                     reason: "reason")
+                                     reason: sut.errorDescription)
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"],

--- a/Tests/UnitTests/Errors/GenericErrorViewModelTests.swift
+++ b/Tests/UnitTests/Errors/GenericErrorViewModelTests.swift
@@ -64,7 +64,7 @@ extension GenericErrorViewModelTests {
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"],
                        screen.parameters["screen_id"])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["generic error"],
-                       screen.parameters["generic error"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["reason"],
+                       screen.parameters["reason"])
     }
 }

--- a/Tests/UnitTests/Errors/NetworkConnectionErrorViewModelTests.swift
+++ b/Tests/UnitTests/Errors/NetworkConnectionErrorViewModelTests.swift
@@ -48,9 +48,13 @@ extension NetworkConnectionErrorViewModelTests {
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 0)
         sut.didAppear()
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 1)
-        let screen = ScreenView(screen: ErrorAnalyticsScreen.networkConnection,
-                                titleKey: "app_networkErrorTitle")
+        let screen = ErrorScreenView(id: ErrorAnalyticsScreenID.networkConnection.rawValue,
+                                     screen: ErrorAnalyticsScreen.networkConnection,
+                                     titleKey: "app_networkErrorTitle",
+                                     reason: "network connection error")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"], screen.parameters["screen_id"])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["reason"], screen.parameters["reason"])
     }
 }


### PR DESCRIPTION
# DCMAW-8421: iOS | Implement GA4 schema on the Network Connection error page

Updated to GA4 schema.  This involved replacing ScreenView with ErrorScreenView so we could pass a reason, as well as adding the designated screen id

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~~- [ ] Met all accessibility requirements?~~
    ~~- [ ] Checked dynamic type sizes are applied~~
    ~~- [ ] Checked VoiceOver can navigate your new code~~
    ~~- [ ] Checked a user can navigate only using a keyboard around your new code~~ 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
