### PR TITLE
feat:  add GA4 analytics (screen_id) to face id enrollment screen

### DIFF
--- a/Sources/Analytics/Onboarding/BiometricEnrollmentAnalyticsScreen.swift
+++ b/Sources/Analytics/Onboarding/BiometricEnrollmentAnalyticsScreen.swift
@@ -8,5 +8,6 @@ enum BiometricEnrollmentAnalyticsScreen: String, ScreenType {
 }
 
 enum BiometricEnrollmentAnalyticsScreenID: String {
+    case faceIDEnrollment = "7590abba-f48b-4790-be64-f6ffc3dd35e2"
     case touchIDEnrollment = "cc1db40a-2a5a-43fe-a1fe-fc85b55fdcab"
 }

--- a/Sources/Login/ViewModels/FaceIDEnrollmentViewModel.swift
+++ b/Sources/Login/ViewModels/FaceIDEnrollmentViewModel.swift
@@ -34,7 +34,8 @@ struct FaceIDEnrollmentViewModel: GDSInformationViewModel, BaseViewModel {
     
     
     func didAppear() {
-        let screen = ScreenView(screen: BiometricEnrollmentAnalyticsScreen.faceIDEnrollment,
+        let screen = ScreenView(id: BiometricEnrollmentAnalyticsScreenID.faceIDEnrollment.rawValue,
+                                screen: BiometricEnrollmentAnalyticsScreen.faceIDEnrollment,
                                 titleKey: title.stringKey)
         analyticsService.trackScreen(screen)
     }

--- a/Tests/UnitTests/Login/ViewModels/FaceIDEnrollmentViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/FaceIDEnrollmentViewModelTests.swift
@@ -65,9 +65,11 @@ extension FaceIDEnrollmentViewModelTests {
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 0)
         sut.didAppear()
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 1)
-        let screen = ScreenView(screen: BiometricEnrollmentAnalyticsScreen.faceIDEnrollment,
+        let screen = ScreenView(id: BiometricEnrollmentAnalyticsScreenID.faceIDEnrollment.rawValue,
+                                screen: BiometricEnrollmentAnalyticsScreen.faceIDEnrollment,
                                 titleKey: "app_enableFaceIDTitle")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"], screen.parameters["screen_id"])
     }
 }


### PR DESCRIPTION
# DCMAW-8392: iOS | Implement GA4 schema on the Face ID opt-in page

Add GA4 analytics and screen_id to face-id opt in screen

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~~- [ ] Met all accessibility requirements?~~
    ~~- [ ] Checked dynamic type sizes are applied~~
    ~~- [ ] Checked VoiceOver can navigate your new code~~
    ~~- [ ] Checked a user can navigate only using a keyboard around your new code~~ 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
