### PR TITLE
chore: updates copy to not translate brand names (e.g. Face ID / Touch ID) AND updates CTA text

### DIFF
--- a/Sources/Login/ViewModels/FaceIDEnrollmentViewModel.swift
+++ b/Sources/Login/ViewModels/FaceIDEnrollmentViewModel.swift
@@ -25,7 +25,7 @@ struct FaceIDEnrollmentViewModel: GDSInformationViewModel, BaseViewModel {
                                                                analyticsService: analyticsService) {
             primaryButtonAction()
         }
-        self.secondaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "app_usePasscodeButton",
+        self.secondaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "app_maybeLaterButton",
                                                                  icon: nil,
                                                                  analyticsService: analyticsService) {
             secondaryButtonAction()

--- a/Sources/Login/ViewModels/TouchIDEnrollmentViewModel.swift
+++ b/Sources/Login/ViewModels/TouchIDEnrollmentViewModel.swift
@@ -25,7 +25,7 @@ struct TouchIDEnrollmentViewModel: GDSInformationViewModel, BaseViewModel {
                                                                analyticsService: analyticsService) {
             primaryButtonAction()
         }
-        self.secondaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "app_usePasscodeButton",
+        self.secondaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "app_maybeLaterButton",
                                                                  icon: nil,
                                                                  analyticsService: analyticsService) {
             secondaryButtonAction()

--- a/Sources/Resources/cy-GB.lproj/InfoPlist.strings
+++ b/Sources/Resources/cy-GB.lproj/InfoPlist.strings
@@ -1,2 +1,2 @@
 // MARK: Face ID enrollment prompt
-"NSFaceIDUsageDescription" = "Nid yw eich ID Wyneb yn cael ei rannu â GOV.UK One Login.";
+"NSFaceIDUsageDescription" = "Nid yw eich Face ID yn cael ei rannu gyda GOV.UK One Login.";

--- a/Sources/Resources/cy-GB.lproj/Localizable.strings
+++ b/Sources/Resources/cy-GB.lproj/Localizable.strings
@@ -11,7 +11,7 @@
 
 "app_disagreeButton" = "Anghytuno";
 
-"app_usePasscodeButton" = "Defnyddio god mynediad";
+"app_maybeLaterButton" = "Efallai nes ymlaen";
 
 "app_enterPasscodeButton" = "Rhowch god mynediad";
 
@@ -63,23 +63,23 @@
 
 
 // MARK: Face ID enrollment screen
-"app_enableFaceIDTitle" = "Defnyddiwch ID Wyneb i fewngofnodi";
+"app_enableFaceIDTitle" = "Defnyddio Face ID i fewngofnodi";
 
-"app_enableFaceIDBody" = "Ychwanegwch haen o ddiogelwch a mewngofnodi gyda'ch wyneb neu olion bysedd yn hytrach na'ch cyfeiriad e-bost a chyfrinair. Nid yw eich biometreg yn cael ei rannu â GOV.UK One Login.\n\nOs nad ydych am ddefnyddio biometreg, gallwch fewngofnodi gyda'ch cod mynediad neu batrwm ffôn yn lle hynny.";
+"app_enableFaceIDBody" = "Mewngofnodi gyda'ch wyneb yn hytrach na'ch cyfeiriad e-bost a'ch cyfrinair. Nid yw eich Face ID yn cael ei rannu gyda GOV.UK One Login.";
 
-"app_enableFaceIDFootnote" = "Os ydych yn defnyddio ID Wyneb, bydd unrhyw un sydd â ID Wyneb wedi'i arbed ar eich ffôn yn gallu mewngofnodi i'r ap hwn.";
+"app_enableFaceIDFootnote" = "Os ydych yn defnyddio Face ID, gall unrhyw un gyda Face ID wedi'i arbed i'ch ffôn mewngofnoi i'r ap hwn.";
 
-"app_enableFaceIDButton" = "Defnyddip ID Wyneb";
+"app_enableFaceIDButton" = "Defnyddio Face ID";
 
 
 // MARK: Touch ID enrollment screen
-"app_enableTouchIDTitle" = "Defnyddiwch ID Cyffwrdd i fewngofnodi";
+"app_enableTouchIDTitle" = "Defnyddio Touch ID i fewngofnodi";
 
-"app_enableTouchIDBody" = "Ychwanegwch haen o ddiogelwch a mewngofnodi gyda'ch wyneb yn hytrach na'ch cyfeiriad e-bost a cyfrinair. Nid yw eich ID Cyffwrdd yn cael ei rannu â GOV.UK One Login.\n\nOs nad ydych am ddefnyddio ID Cyffwrdd, gallwch fewngofnodi gyda'ch cod mynediad eich ffôn yn lle hynny.";
+"app_enableTouchIDBody" = "Mewngofnodi gyda'ch olion bysedd yn hytrach na'ch cyfeiriad e-bost a chyfrinair. Nid yw eich Touch ID yn cael ei rannu â GOV.UK One Login.";
 
-"app_enableTouchIDFootnote" = "Os ydych yn defnyddio ID Cyffwrdd, bydd unrhyw un sydd â ID Cyffwrdd wedi'i arbed ar eich ffôn yn gallu mewngofnodi i'r ap hwn.";
+"app_enableTouchIDFootnote" = "Os ydych yn defnyddio Touch ID, gall unrhyw un gyda Touch ID wedi'i arbed i'ch ffôn mewngofnoi i'r ap hwn.";
 
-"app_enableTouchIDEnableButton" = "Defnyddio ID Cyffwrdd";
+"app_enableTouchIDEnableButton" = "Defnyddio Touch ID";
 
 
 // MARK: Unlock screen

--- a/Sources/Resources/en.lproj/Localizable.strings
+++ b/Sources/Resources/en.lproj/Localizable.strings
@@ -11,7 +11,7 @@
 
 "app_disagreeButton" = "Disagree";
 
-"app_usePasscodeButton" = "Use passcode";
+"app_maybeLaterButton" = "Maybe later";
 
 "app_enterPasscodeButton" = "Enter passcode";
 
@@ -65,7 +65,7 @@
 // MARK: Face ID enrollment screen
 "app_enableFaceIDTitle" = "Use Face ID to sign in";
 
-"app_enableFaceIDBody" = "Add a layer of security and sign in with your face instead of your email address and password. Your Face ID is not shared with GOV.UK One Login.\n\nIf you do not want to use Face ID, you can sign in with your phone passcode instead.";
+"app_enableFaceIDBody" = "Sign in with your face instead of your email address and password. Your Face ID is not shared with GOV.UK One Login.";
 
 "app_enableFaceIDFootnote" = "If you use Face ID, anyone with a Face ID saved to your phone will be able to sign in to this app.";
 
@@ -75,7 +75,7 @@
 // MARK: Touch ID enrollment screen
 "app_enableTouchIDTitle" = "Use Touch ID to sign in";
 
-"app_enableTouchIDBody" = "Add a layer of security and sign in with your face instead of your email address and password. Your Touch ID is not shared with GOV.UK One Login.\n\nIf you do not want to use Touch ID, you can sign in with your phone passcode instead.";
+"app_enableTouchIDBody" = "Sign in with your fingerprint instead of your email address and password. Your Touch ID is not shared with GOV.UK One Login.";
 
 "app_enableTouchIDFootnote" = "If you use Touch ID, anyone with a Touch ID saved to your phone will be able to sign in to this app.";
 

--- a/Tests/UnitTests/Login/ViewModels/FaceIDEnrollmentViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/FaceIDEnrollmentViewModelTests.swift
@@ -55,7 +55,7 @@ extension FaceIDEnrollmentViewModelTests {
         sut.secondaryButtonViewModel?.action()
         XCTAssertTrue(didCallSecondaryButtonAction)
         XCTAssertEqual(mockAnalyticsService.eventsLogged.count, 1)
-        let event = ButtonEvent(textKey: "app_usePasscodeButton")
+        let event = ButtonEvent(textKey: "app_maybeLaterButton")
         XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["text"], event.parameters["text"])
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["type"], event.parameters["type"])

--- a/Tests/UnitTests/Login/ViewModels/TouchIDEnrollmentViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/TouchIDEnrollmentViewModelTests.swift
@@ -55,7 +55,7 @@ extension TouchIDEnrollmentViewModelTests {
         sut.secondaryButtonViewModel?.action()
         XCTAssertTrue(didCallSecondaryButtonAction)
         XCTAssertEqual(mockAnalyticsService.eventsLogged.count, 1)
-        let event = ButtonEvent(textKey: "app_usePasscodeButton")
+        let event = ButtonEvent(textKey: "app_maybeLaterButton")
         XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["text"], event.parameters["text"])
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["type"], event.parameters["type"])

--- a/Tests/UnitTests/Resources/LocalizedEnglishStringTests.swift
+++ b/Tests/UnitTests/Resources/LocalizedEnglishStringTests.swift
@@ -17,8 +17,8 @@ final class LocalizedEnglishStringTests: XCTestCase {
                        "Agree")
         XCTAssertEqual("app_disagreeButton".getEnglishString(),
                        "Disagree")
-        XCTAssertEqual("app_usePasscodeButton".getEnglishString(),
-                       "Use passcode")
+        XCTAssertEqual("app_maybeLaterButton".getEnglishString(),
+                       "Maybe later")
         XCTAssertEqual("app_enterPasscodeButton".getEnglishString(),
                        "Enter passcode")
     }
@@ -78,7 +78,7 @@ final class LocalizedEnglishStringTests: XCTestCase {
         XCTAssertEqual("app_enableFaceIDTitle".getEnglishString(),
                        "Use Face ID to sign in")
         XCTAssertEqual("app_enableFaceIDBody".getEnglishString(),
-                       "Add a layer of security and sign in with your face instead of your email address and password. Your Face ID is not shared with GOV.UK One Login.\n\nIf you do not want to use Face ID, you can sign in with your phone passcode instead.")
+                       "Sign in with your face instead of your email address and password. Your Face ID is not shared with GOV.UK One Login.")
         XCTAssertEqual("app_enableFaceIDFootnote".getEnglishString(),
                        "If you use Face ID, anyone with a Face ID saved to your phone will be able to sign in to this app.")
         XCTAssertEqual("app_enableFaceIDButton".getEnglishString(),
@@ -89,7 +89,7 @@ final class LocalizedEnglishStringTests: XCTestCase {
         XCTAssertEqual("app_enableTouchIDTitle".getEnglishString(),
                        "Use Touch ID to sign in")
         XCTAssertEqual("app_enableTouchIDBody".getEnglishString(),
-                       "Add a layer of security and sign in with your face instead of your email address and password. Your Touch ID is not shared with GOV.UK One Login.\n\nIf you do not want to use Touch ID, you can sign in with your phone passcode instead.")
+                       "Sign in with your fingerprint instead of your email address and password. Your Touch ID is not shared with GOV.UK One Login.")
         XCTAssertEqual("app_enableTouchIDFootnote".getEnglishString(),
                        "If you use Touch ID, anyone with a Touch ID saved to your phone will be able to sign in to this app.")
         XCTAssertEqual("app_enableTouchIDEnableButton".getEnglishString(),

--- a/Tests/UnitTests/Resources/LocalizedWelshStringTests.swift
+++ b/Tests/UnitTests/Resources/LocalizedWelshStringTests.swift
@@ -17,8 +17,8 @@ final class LocalizedWelshStringTests: XCTestCase {
                        "Cytuno")
         XCTAssertEqual("app_disagreeButton".getWelshString(),
                        "Anghytuno")
-        XCTAssertEqual("app_usePasscodeButton".getWelshString(),
-                       "Defnyddio god mynediad")
+        XCTAssertEqual("app_maybeLaterButton".getWelshString(),
+                       "Efallai nes ymlaen")
         XCTAssertEqual("app_enterPasscodeButton".getWelshString(),
                        "Rhowch god mynediad")
     }
@@ -76,24 +76,24 @@ final class LocalizedWelshStringTests: XCTestCase {
     
     func test_faceIDEnrollmentScreen_keys() throws {
         XCTAssertEqual("app_enableFaceIDTitle".getWelshString(),
-                       "Defnyddiwch ID Wyneb i fewngofnodi")
+                       "Defnyddio Face ID i fewngofnodi")
         XCTAssertEqual("app_enableFaceIDBody".getWelshString(),
-                       "Ychwanegwch haen o ddiogelwch a mewngofnodi gyda'ch wyneb neu olion bysedd yn hytrach na'ch cyfeiriad e-bost a chyfrinair. Nid yw eich biometreg yn cael ei rannu â GOV.UK One Login.\n\nOs nad ydych am ddefnyddio biometreg, gallwch fewngofnodi gyda'ch cod mynediad neu batrwm ffôn yn lle hynny.")
+                       "Mewngofnodi gyda'ch wyneb yn hytrach na'ch cyfeiriad e-bost a'ch cyfrinair. Nid yw eich Face ID yn cael ei rannu gyda GOV.UK One Login.")
         XCTAssertEqual("app_enableFaceIDFootnote".getWelshString(),
-                       "Os ydych yn defnyddio ID Wyneb, bydd unrhyw un sydd â ID Wyneb wedi'i arbed ar eich ffôn yn gallu mewngofnodi i'r ap hwn.")
+                       "Os ydych yn defnyddio Face ID, gall unrhyw un gyda Face ID wedi'i arbed i'ch ffôn mewngofnoi i'r ap hwn.")
         XCTAssertEqual("app_enableFaceIDButton".getWelshString(),
-                       "Defnyddip ID Wyneb")
+                       "Defnyddio Face ID")
     }
     
     func test_touchIDEnrollmentScreen_keys() throws {
         XCTAssertEqual("app_enableTouchIDTitle".getWelshString(),
-                       "Defnyddiwch ID Cyffwrdd i fewngofnodi")
+                       "Defnyddio Touch ID i fewngofnodi")
         XCTAssertEqual("app_enableTouchIDBody".getWelshString(),
-                       "Ychwanegwch haen o ddiogelwch a mewngofnodi gyda'ch wyneb yn hytrach na'ch cyfeiriad e-bost a cyfrinair. Nid yw eich ID Cyffwrdd yn cael ei rannu â GOV.UK One Login.\n\nOs nad ydych am ddefnyddio ID Cyffwrdd, gallwch fewngofnodi gyda'ch cod mynediad eich ffôn yn lle hynny.")
+                       "Mewngofnodi gyda'ch olion bysedd yn hytrach na'ch cyfeiriad e-bost a chyfrinair. Nid yw eich Touch ID yn cael ei rannu â GOV.UK One Login.")
         XCTAssertEqual("app_enableTouchIDFootnote".getWelshString(),
-                       "Os ydych yn defnyddio ID Cyffwrdd, bydd unrhyw un sydd â ID Cyffwrdd wedi'i arbed ar eich ffôn yn gallu mewngofnodi i'r ap hwn.")
+                       "Os ydych yn defnyddio Touch ID, gall unrhyw un gyda Touch ID wedi'i arbed i'ch ffôn mewngofnoi i'r ap hwn.")
         XCTAssertEqual("app_enableTouchIDEnableButton".getWelshString(),
-                       "Defnyddio ID Cyffwrdd")
+                       "Defnyddio Touch ID")
     }
 
     func test_unlockScreenKeys() {


### PR DESCRIPTION
# DCMAW-8374 - Update copy to not translate brand names (e.g. Face ID / Touch ID) AND update CTA text

This PR updates the Welsh copy for Face and Touch ID to not be translated. It also updates some English and Welsh copy for the Face/Touch ID enrolment body text and changes the 'use passcode' copy to 'maybe later'. 

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
