### PR TITLE
feat: implement GA4 schema on the Unlock page

### DIFF
--- a/Sources/Analytics/Onboarding/BiometricEnrollmentAnalyticsScreen.swift
+++ b/Sources/Analytics/Onboarding/BiometricEnrollmentAnalyticsScreen.swift
@@ -10,4 +10,5 @@ enum BiometricEnrollmentAnalyticsScreen: String, ScreenType {
 enum BiometricEnrollmentAnalyticsScreenID: String {
     case faceIDEnrollment = "7590abba-f48b-4790-be64-f6ffc3dd35e2"
     case touchIDEnrollment = "cc1db40a-2a5a-43fe-a1fe-fc85b55fdcab"
+    case unlockScreen = "d61fcd23-cbcf-4df6-8e9c-d0dec956dbe1"
 }

--- a/Sources/Application/SceneLifecycle.swift
+++ b/Sources/Application/SceneLifecycle.swift
@@ -1,4 +1,5 @@
 import GAnalytics
+import GDSAnalytics
 import Logging
 import UIKit
 
@@ -18,6 +19,10 @@ extension SceneLifecycle {
     
     func promptToUnlock() {
         coordinator?.evaluateRevisit {
+            let screen = ScreenView(id: BiometricEnrollmentAnalyticsScreenID.unlockScreen.rawValue,
+                                    screen: BiometricEnrollmentAnalyticsScreen.unlockScreen,
+                                    titleKey: "one login unlock screen")
+            analyticsService.trackScreen(screen)
             windowManager?.hideUnlockWindow()
         }
     }

--- a/Sources/Screens/Unlock/UnlockScreenViewModel.swift
+++ b/Sources/Screens/Unlock/UnlockScreenViewModel.swift
@@ -20,10 +20,7 @@ struct UnlockScreenViewModel: BaseViewModel {
     }
 
     func didAppear() {
-        let screen = ScreenView(id: BiometricEnrollmentAnalyticsScreenID.unlockScreen.rawValue,
-                                screen: BiometricEnrollmentAnalyticsScreen.unlockScreen,
-                                titleKey: "one login unlock screen")
-        analyticsService.trackScreen(screen)
+
     }
     
     func didDismiss() {

--- a/Sources/Screens/Unlock/UnlockScreenViewModel.swift
+++ b/Sources/Screens/Unlock/UnlockScreenViewModel.swift
@@ -20,7 +20,9 @@ struct UnlockScreenViewModel: BaseViewModel {
     }
 
     func didAppear() {
-
+        // ScreenView is being sent in SceneLifecycle.promptToUnlock
+        // so that sending the app to the background and resuming doesn't
+        // break the journey and sends to GA4
     }
     
     func didDismiss() {

--- a/Sources/Screens/Unlock/UnlockScreenViewModel.swift
+++ b/Sources/Screens/Unlock/UnlockScreenViewModel.swift
@@ -20,7 +20,9 @@ struct UnlockScreenViewModel: BaseViewModel {
     }
 
     func didAppear() {
-        let screen = ScreenView(screen: BiometricEnrollmentAnalyticsScreen.unlockScreen, titleKey: "unlock screen")
+        let screen = ScreenView(id: BiometricEnrollmentAnalyticsScreenID.unlockScreen.rawValue,
+                                screen: BiometricEnrollmentAnalyticsScreen.unlockScreen,
+                                titleKey: "one login unlock screen")
         analyticsService.trackScreen(screen)
     }
     

--- a/Tests/UnitTests/Application/SceneLifecycleTests.swift
+++ b/Tests/UnitTests/Application/SceneLifecycleTests.swift
@@ -1,3 +1,4 @@
+import GDSAnalytics
 @testable import OneLogin
 import XCTest
 
@@ -56,7 +57,15 @@ extension SceneLifecycleTests {
     }
     
     func test_promptToUnlock() throws {
+        XCTAssertEqual(mockAnalyticsService.screensVisited.count, 0)
         sut.promptToUnlock()
+        XCTAssertEqual(mockAnalyticsService.screensVisited.count, 1)
+        let screen = ScreenView(id: BiometricEnrollmentAnalyticsScreenID.unlockScreen.rawValue,
+                                screen: BiometricEnrollmentAnalyticsScreen.unlockScreen,
+                                titleKey: "one login unlock screen")
+        XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"], screen.parameters["screen_id"])
         XCTAssertTrue(mockWindowManager.hideUnlockWindowCalled)
     }
 }

--- a/Tests/UnitTests/Login/ViewModels/UnlockScreenViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/UnlockScreenViewModelTests.swift
@@ -44,9 +44,11 @@ extension UnlockScreenViewModelTests {
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 0)
         sut.didAppear()
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 1)
-        let screen = ScreenView(screen: BiometricEnrollmentAnalyticsScreen.unlockScreen,
-                                titleKey: "unlock screen")
+        let screen = ScreenView(id: BiometricEnrollmentAnalyticsScreenID.unlockScreen.rawValue,
+                                screen: BiometricEnrollmentAnalyticsScreen.unlockScreen,
+                                titleKey: "one login unlock screen")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"], screen.parameters["screen_id"])
     }
 }

--- a/Tests/UnitTests/Login/ViewModels/UnlockScreenViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/UnlockScreenViewModelTests.swift
@@ -39,10 +39,4 @@ extension UnlockScreenViewModelTests {
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["text"], event.parameters["text"])
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["type"], event.parameters["type"])
     }
-
-    func test_didAppear() throws {
-        XCTAssertEqual(mockAnalyticsService.screensVisited.count, 0)
-        sut.didAppear()
-        XCTAssertEqual(mockAnalyticsService.screensVisited.count, 0)
-    }
 }

--- a/Tests/UnitTests/Login/ViewModels/UnlockScreenViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/UnlockScreenViewModelTests.swift
@@ -43,12 +43,6 @@ extension UnlockScreenViewModelTests {
     func test_didAppear() throws {
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 0)
         sut.didAppear()
-        XCTAssertEqual(mockAnalyticsService.screensVisited.count, 1)
-        let screen = ScreenView(id: BiometricEnrollmentAnalyticsScreenID.unlockScreen.rawValue,
-                                screen: BiometricEnrollmentAnalyticsScreen.unlockScreen,
-                                titleKey: "one login unlock screen")
-        XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"], screen.parameters["screen_id"])
+        XCTAssertEqual(mockAnalyticsService.screensVisited.count, 0)
     }
 }


### PR DESCRIPTION
# DCMAW-8394: Implement GA4 schema on the Unlock page

This adds the GA4 schema to the unlock screen and `trackEvent` for the unlock button

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] ~~Met all accessibility requirements?~~
    - [ ] ~~Checked dynamic type sizes are applied~~
    - [ ] ~~Checked VoiceOver can navigate your new code~~
    - [ ] ~~Checked a user can navigate only using a keyboard around your new code~~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
