### PR TITLE
feat: implement ga4 schema on splash page

### DIFF
--- a/Sources/Analytics/Onboarding/IntroAnalytics.swift
+++ b/Sources/Analytics/Onboarding/IntroAnalytics.swift
@@ -3,8 +3,10 @@ import Logging
 
 enum IntroAnalyticsScreen: String, ScreenType {
     case welcomeScreen = "introWelcomeScreen"
+    case splashScreen = "splashScreen"
 }
 
 enum IntroAnalyticsScreenID: String {
     case welcomeScreen = "30a6b339-75a8-44a2-a79a-e108546419bf"
+    case splashScreen = "3e95fe16-7ba7-4f46-a22e-4ae17112debf"
 }

--- a/Sources/Application/SceneDelegate.swift
+++ b/Sources/Application/SceneDelegate.swift
@@ -1,6 +1,5 @@
 import Authentication
 import GAnalytics
-import GDSAnalytics
 import LocalAuthentication
 import Logging
 import SecureStore
@@ -58,12 +57,5 @@ class SceneDelegate: UIResponder,
         } else {
             shouldCallSceneWillEnterForeground = true
         }
-    }
-    
-    private func trackSplashScreen(_ analyticsService: AnalyticsService) {
-        let screen = ScreenView(id: IntroAnalyticsScreenID.splashScreen.rawValue,
-                                screen: IntroAnalyticsScreen.splashScreen,
-                                titleKey: "one login splash screen")
-        analyticsService.trackScreen(screen)
     }
 }

--- a/Sources/Application/SceneDelegate.swift
+++ b/Sources/Application/SceneDelegate.swift
@@ -1,5 +1,6 @@
 import Authentication
 import GAnalytics
+import GDSAnalytics
 import LocalAuthentication
 import Logging
 import SecureStore
@@ -43,6 +44,7 @@ class SceneDelegate: UIResponder,
                                       userStore: userStore)
         windowManager.appWindow.rootViewController = tabController
         windowManager.appWindow.makeKeyAndVisible()
+        trackSplashScreen(analyticsCenter.analyticsService)
         coordinator?.start()
     }
     
@@ -56,5 +58,12 @@ class SceneDelegate: UIResponder,
         } else {
             shouldCallSceneWillEnterForeground = true
         }
+    }
+    
+    private func trackSplashScreen(_ analyticsService: AnalyticsService) {
+        let screen = ScreenView(id: IntroAnalyticsScreenID.splashScreen.rawValue,
+                                screen: IntroAnalyticsScreen.splashScreen,
+                                titleKey: "one login splash screen")
+        analyticsService.trackScreen(screen)
     }
 }

--- a/Sources/Application/SceneLifecycle.swift
+++ b/Sources/Application/SceneLifecycle.swift
@@ -1,4 +1,5 @@
 import GAnalytics
+import GDSAnalytics
 import Logging
 import UIKit
 
@@ -20,5 +21,12 @@ extension SceneLifecycle {
         coordinator?.evaluateRevisit {
             windowManager?.hideUnlockWindow()
         }
+    }
+    
+    func trackSplashScreen(_ analyticsService: AnalyticsService) {
+        let screen = ScreenView(id: IntroAnalyticsScreenID.splashScreen.rawValue,
+                                screen: IntroAnalyticsScreen.splashScreen,
+                                titleKey: "one login splash screen")
+        analyticsService.trackScreen(screen)
     }
 }

--- a/Tests/UnitTests/Application/SceneLifecycleTests.swift
+++ b/Tests/UnitTests/Application/SceneLifecycleTests.swift
@@ -1,3 +1,4 @@
+import GDSAnalytics
 @testable import OneLogin
 import XCTest
 
@@ -58,5 +59,18 @@ extension SceneLifecycleTests {
     func test_promptToUnlock() throws {
         sut.promptToUnlock()
         XCTAssertTrue(mockWindowManager.hideUnlockWindowCalled)
+    }
+    
+    func test_splashscreen_analytics() throws {
+        XCTAssertEqual(mockAnalyticsService.screensVisited.count, 0)
+        sut.trackSplashScreen(mockAnalyticsCenter.analyticsService)
+        XCTAssertEqual(mockAnalyticsService.screensVisited.count, 1)
+        let screen = ScreenView(id: IntroAnalyticsScreenID.splashScreen.rawValue,
+                                screen: IntroAnalyticsScreen.splashScreen,
+                                titleKey: "one login splash screen")
+        XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"], screen.parameters["screen_id"])
+
     }
 }


### PR DESCRIPTION
# DCMAW-8363: iOS | Implement GA4 schema on the Splash page

Add GA4 analytics for splash screen.  Since we don't have access to the splash screens viewController, send the screen
tracking event after app launch event but before intro screen tracking event.
# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~~- [ ] Met all accessibility requirements?~~
    ~~- [ ] Checked dynamic type sizes are applied~~
    ~~- [ ] Checked VoiceOver can navigate your new code~~
    ~~- [ ] Checked a user can navigate only using a keyboard around your new code~~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
