### PR TITLE
feat: initialise NetworkClient on login flow completion

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -115,6 +115,8 @@
 		C8C343A62B9233FC00E92FB9 /* AnalyticsCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C343A42B9232B900E92FB9 /* AnalyticsCenter.swift */; };
 		C8C343A72B92340000E92FB9 /* AnalyticsCentral.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C343A22B92315B00E92FB9 /* AnalyticsCentral.swift */; };
 		C8C343A92B923DB300E92FB9 /* StandardButtonViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C343A82B923DB300E92FB9 /* StandardButtonViewModel.swift */; };
+		C8C6665A2BCFDBDE00CF249B /* TokenHolderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C666592BCFDBDE00CF249B /* TokenHolderTests.swift */; };
+		C8C6665E2BD007BD00CF249B /* OutdatedTokenResponse.json in Resources */ = {isa = PBXBuildFile; fileRef = C8C6665D2BD007BD00CF249B /* OutdatedTokenResponse.json */; };
 		C8E6A3E82BBC0536005015AF /* WindowManagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E6A3E72BBC0536005015AF /* WindowManagement.swift */; };
 		C8E6A3EB2BBC05FA005015AF /* MockSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E6A3EA2BBC05FA005015AF /* MockSceneDelegate.swift */; };
 		C8E6A3ED2BBC0674005015AF /* MockWindowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E6A3EC2BBC0674005015AF /* MockWindowManager.swift */; };
@@ -273,6 +275,8 @@
 		C8C343A42B9232B900E92FB9 /* AnalyticsCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsCenter.swift; sourceTree = "<group>"; };
 		C8C343A82B923DB300E92FB9 /* StandardButtonViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandardButtonViewModel.swift; sourceTree = "<group>"; };
 		C8C57CE32B0237620010D395 /* OneLoginUI.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = OneLoginUI.xctestplan; sourceTree = "<group>"; };
+		C8C666592BCFDBDE00CF249B /* TokenHolderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenHolderTests.swift; sourceTree = "<group>"; };
+		C8C6665D2BD007BD00CF249B /* OutdatedTokenResponse.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = OutdatedTokenResponse.json; sourceTree = "<group>"; };
 		C8E6A3E72BBC0536005015AF /* WindowManagement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowManagement.swift; sourceTree = "<group>"; };
 		C8E6A3EA2BBC05FA005015AF /* MockSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSceneDelegate.swift; sourceTree = "<group>"; };
 		C8E6A3EC2BBC0674005015AF /* MockWindowManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWindowManager.swift; sourceTree = "<group>"; };
@@ -383,6 +387,7 @@
 			children = (
 				C85DF8432AEBFDCC0064F68E /* Sessions+Services */,
 				C85DF8442AEBFDF00064F68E /* ReturnTypes */,
+				C8C6665D2BD007BD00CF249B /* OutdatedTokenResponse.json */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -553,6 +558,7 @@
 				C851FFA32BADAAB600A7B73D /* SceneLifecycleTests.swift */,
 				C8E6A3EE2BBC1181005015AF /* WindowManagerTests.swift */,
 				219602012A976305008F3427 /* MainCoordinatorTests.swift */,
+				C8C666592BCFDBDE00CF249B /* TokenHolderTests.swift */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -1125,6 +1131,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C8C6665E2BD007BD00CF249B /* OutdatedTokenResponse.json in Resources */,
 				C8520C222AE2B642006790C1 /* TokenResponse.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1307,6 +1314,7 @@
 				C8A6385A2B5994B700656A26 /* MockNetworkMonitor.swift in Sources */,
 				410464F62B29D078000E7CB2 /* UnableToLoginErrorViewModelTests.swift in Sources */,
 				C851FFA42BADAAB600A7B73D /* SceneLifecycleTests.swift in Sources */,
+				C8C6665A2BCFDBDE00CF249B /* TokenHolderTests.swift in Sources */,
 				41C8E42F2B72920F0063B8A3 /* FaceIDEnrollmentViewModelTests.swift in Sources */,
 				C8454A8F2B99D1BC000F9ED0 /* LoginCoordinatorTests.swift in Sources */,
 				C82F950F2B9F0CCA00A90A6A /* UnlockScreenViewControllerTests.swift in Sources */,

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -2246,8 +2246,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/govuk-one-login/mobile-ios-authentication.git";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
 			};
 		};
 		C8A13CA72AFBD0CC00FCBD36 /* XCRemoteSwiftPackageReference "mobile-ios-logging" */ = {

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -2239,8 +2239,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/govuk-one-login/mobile-ios-networking";
 			requirement = {
-				branch = "feature/dcmaw-8621-network-client-service-token-enhancement";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
 			};
 		};
 		C8A13C9D2AFBD05700FCBD36 /* XCRemoteSwiftPackageReference "mobile-ios-common" */ = {

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -1087,6 +1087,7 @@
 				C8A13CA72AFBD0CC00FCBD36 /* XCRemoteSwiftPackageReference "mobile-ios-logging" */,
 				C8A13CAE2AFBD0F100FCBD36 /* XCRemoteSwiftPackageReference "mobile-ios-coordination" */,
 				C8BADD1E2B8638BA00385FE7 /* XCRemoteSwiftPackageReference "mobile-ios-secure-store" */,
+				C844A6942BCD2684000538A9 /* XCRemoteSwiftPackageReference "mobile-ios-networking" */,
 			);
 			productRefGroup = 219601E82A976302008F3427 /* Products */;
 			projectDirPath = "";
@@ -2234,6 +2235,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		C844A6942BCD2684000538A9 /* XCRemoteSwiftPackageReference "mobile-ios-networking" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/govuk-one-login/mobile-ios-networking";
+			requirement = {
+				branch = "feature/dcmaw-8621-network-client-service-token-enhancement";
+				kind = branch;
+			};
+		};
 		C8A13C9D2AFBD05700FCBD36 /* XCRemoteSwiftPackageReference "mobile-ios-common" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/govuk-one-login/mobile-ios-common.git";

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-authentication.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "99e8d600b6ad5875b0ad29243060ef9c4de02615"
+        "revision" : "295a8facc6809f0e6555f15490ea7f120287458e",
+        "version" : "1.1.1"
       }
     },
     {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -138,7 +138,7 @@
     {
       "identity" : "mobile-ios-networking",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/govuk-one-login/mobile-ios-networking.git",
+      "location" : "https://github.com/govuk-one-login/mobile-ios-networking",
       "state" : {
         "revision" : "cc911207347074bbd0d277440124a4864c5c5d79",
         "version" : "2.2.0"

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-authentication.git",
       "state" : {
-        "revision" : "295a8facc6809f0e6555f15490ea7f120287458e",
-        "version" : "1.1.1"
+        "revision" : "99e8d600b6ad5875b0ad29243060ef9c4de02615",
+        "version" : "1.1.3"
       }
     },
     {
@@ -138,7 +138,7 @@
     {
       "identity" : "mobile-ios-networking",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/govuk-one-login/mobile-ios-networking",
+      "location" : "https://github.com/govuk-one-login/mobile-ios-networking.git",
       "state" : {
         "revision" : "cc911207347074bbd0d277440124a4864c5c5d79",
         "version" : "2.2.0"

--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -95,7 +95,7 @@ extension MainCoordinator: ParentCoordinator {
         switch child {
         case _ as LoginCoordinator:
             homeCoordinator?.updateToken(accessToken: tokenHolder.accessToken)
-            networkClient = NetworkClient(authenticationProvider: tokenHolder.tokenResponse)
+            networkClient = NetworkClient(authenticationProvider: tokenHolder)
         default:
             break
         }

--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -1,4 +1,5 @@
 import Coordination
+import Networking
 import SecureStore
 import UIKit
 
@@ -11,6 +12,7 @@ final class MainCoordinator: NSObject,
     var childCoordinators = [ChildCoordinator]()
     let userStore: UserStorable
     let tokenHolder = TokenHolder()
+    var networkClient: NetworkClient?
     private weak var loginCoordinator: LoginCoordinator?
     private weak var homeCoordinator: HomeCoordinator?
     
@@ -93,6 +95,7 @@ extension MainCoordinator: ParentCoordinator {
         switch child {
         case _ as LoginCoordinator:
             homeCoordinator?.updateToken(accessToken: tokenHolder.accessToken)
+            networkClient = NetworkClient(authenticationProvider: tokenHolder.tokenResponse)
         default:
             break
         }

--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -64,26 +64,26 @@ final class MainCoordinator: NSObject,
 }
 
 extension MainCoordinator {
-    func addTabs() {
+    private func addTabs() {
         addHomeTab()
         addWalletTab()
         addProfileTab()
     }
     
-    func addHomeTab() {
+    private func addHomeTab() {
         let hc = HomeCoordinator()
         hc.root.tabBarItem = UITabBarItem(title: "Home", image: UIImage(systemName: "house"), tag: 0)
         addTab(hc)
         homeCoordinator = hc
     }
     
-    func addWalletTab() {
+    private func addWalletTab() {
         let wc = WalletCoordinator()
         wc.root.tabBarItem = UITabBarItem(title: "Wallet", image: UIImage(systemName: "wallet.pass"), tag: 1)
         addTab(wc)
     }
     
-    func addProfileTab() {
+    private func addProfileTab() {
         let pc = ProfileCoordinator()
         pc.root.tabBarItem = UITabBarItem(title: "Profile", image: UIImage(systemName: "person.crop.circle"), tag: 2)
         addTab(pc)

--- a/Sources/Application/TokenHolder.swift
+++ b/Sources/Application/TokenHolder.swift
@@ -1,12 +1,21 @@
 import Authentication
 import Networking
 
+enum TokenError: Error {
+    case bearerNotPresent
+}
+
 class TokenHolder: AuthenticationProvider {
     var tokenResponse: TokenResponse?
     var accessToken: String?
     
     var bearerToken: String {
-        accessToken ?? ""
+        get throws {
+            guard let accessToken else {
+                throw TokenError.bearerNotPresent
+            }
+            return accessToken
+        }
     }
     
     var validAccessToken: Bool {

--- a/Sources/Application/TokenHolder.swift
+++ b/Sources/Application/TokenHolder.swift
@@ -1,8 +1,13 @@
 import Authentication
+import Networking
 
-class TokenHolder {
+class TokenHolder: AuthenticationProvider {
     var tokenResponse: TokenResponse?
     var accessToken: String?
+    
+    var bearerToken: String {
+        accessToken ?? ""
+    }
     
     var validAccessToken: Bool {
         tokenResponse?.expiryDate.timeIntervalSinceNow.sign == .plus

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -62,6 +62,7 @@ final class LoginCoordinator: NSObject,
                 SecureStoreError.cantInitialiseData,
                 SecureStoreError.cantRetrieveKey {
             userStore.refreshStorage(accessControlLevel: .currentBiometricsOrPasscode)
+            windowManager.hideUnlockWindow()
             start()
         } catch {
             print("Local Authentication error: \(error)")

--- a/Tests/UnitTests/Application/MainCoordinatorTests.swift
+++ b/Tests/UnitTests/Application/MainCoordinatorTests.swift
@@ -56,11 +56,14 @@ final class MainCoordinatorTests: XCTestCase {
 
 extension MainCoordinatorTests {
     func test_launchLoginCoordinator() throws {
-        // WHEN the LoginCoordinator is started
+        // WHEN the MainCoordinator is started
         sut.start()
-        // THEN the LoginCoordinator should have an LoginCoordinator as it's only child coordinator
+        // THEN the MainCoordinator should have child coordinators
         XCTAssertEqual(sut.childCoordinators.count, 4)
-        XCTAssertTrue(sut.childCoordinators.last is LoginCoordinator)
+        XCTAssertTrue(sut.childCoordinators[0] is HomeCoordinator)
+        XCTAssertTrue(sut.childCoordinators[1] is WalletCoordinator)
+        XCTAssertTrue(sut.childCoordinators[2] is ProfileCoordinator)
+        XCTAssertTrue(sut.childCoordinators[3] is LoginCoordinator)
     }
     
     func test_evaluateRevisit_returningAuthenticatedUser() throws {
@@ -92,28 +95,9 @@ extension MainCoordinatorTests {
         XCTAssertTrue(evaluateRevisitActionCalled)
     }
     
-    func test_addTabs_succeeds() throws {
-        // GIVEN the token holder's access token has is not nil
-        sut.tokenHolder.accessToken = "testAccessToken"
-        // WHEN the LoginCoordinator's launchTokenCoordinator method is called
-        sut.addTabs()
-        // THEN the Token Coordinator should be launched
-        XCTAssertEqual(sut.childCoordinators.count, 3)
-        XCTAssertTrue(sut.childCoordinators[0] is HomeCoordinator)
-    }
-    
-    func test_launchTokenCoorindator_fails() throws {
-        // GIVEN the token holder's access token has is nil
-        sut.addTabs()
-        // WHEN the LoginCoordinator's launchTokenCoordinator method is called
-        // THEN the Token Coordinator should not be launched
-        XCTAssertEqual(sut.childCoordinators.count, 3)
-    }
-    
     func test_didRegainFocus_fromLoginCoordinator() throws {
         let mockUserStore = UserStorage(secureStoreService: mockSecureStore,
                                         defaultsStore: mockDefaultStore)
-        // GIVEN the LoginCoordinator doesn't have an access token
         let loginCoordinator = LoginCoordinator(windowManager: mockWindowManager,
                                                 root: UINavigationController(),
                                                 analyticsCenter: mockAnalyticsCenter,
@@ -124,5 +108,7 @@ extension MainCoordinatorTests {
         sut.didRegainFocus(fromChild: loginCoordinator)
         // THEN no coordinator should be launched
         XCTAssertEqual(sut.childCoordinators.count, 0)
+        // THEN the network client should be initialised
+        XCTAssertNotNil(sut.networkClient)
     }
 }

--- a/Tests/UnitTests/Application/MainCoordinatorTests.swift
+++ b/Tests/UnitTests/Application/MainCoordinatorTests.swift
@@ -96,6 +96,8 @@ extension MainCoordinatorTests {
     }
     
     func test_didRegainFocus_fromLoginCoordinator() throws {
+        // GIVEN access token has been stored in the token holder
+        sut.tokenHolder.accessToken = "testAccessToken"
         let mockUserStore = UserStorage(secureStoreService: mockSecureStore,
                                         defaultsStore: mockDefaultStore)
         let loginCoordinator = LoginCoordinator(windowManager: mockWindowManager,
@@ -108,6 +110,8 @@ extension MainCoordinatorTests {
         sut.didRegainFocus(fromChild: loginCoordinator)
         // THEN no coordinator should be launched
         XCTAssertEqual(sut.childCoordinators.count, 0)
+        // THEN the token holders bearer token should have the access token
+        XCTAssertEqual(sut.tokenHolder.bearerToken, "testAccessToken")
         // THEN the network client should be initialised
         XCTAssertNotNil(sut.networkClient)
     }

--- a/Tests/UnitTests/Application/TokenHolderTests.swift
+++ b/Tests/UnitTests/Application/TokenHolderTests.swift
@@ -1,0 +1,32 @@
+@testable import OneLogin
+import XCTest
+
+final class TokenHolderTests: XCTestCase {
+    var sut = TokenHolder()
+}
+
+extension TokenHolderTests {
+    func test_bearerToken_returns() throws {
+        sut.accessToken = "testAccessToken"
+        XCTAssertEqual(try sut.bearerToken, "testAccessToken")
+    }
+    
+    func test_bearerToken_errors() throws {
+        do {
+            _ = try sut.bearerToken
+            XCTFail("Should throw TokenError error")
+        } catch {
+            XCTAssertTrue(error is TokenError)
+        }
+    }
+    
+    func test_tokenInDate() throws {
+        sut.tokenResponse = try MockTokenResponse().getJSONData()
+        XCTAssertTrue(sut.validAccessToken)
+    }
+    
+    func test_tokenOutdated() throws {
+        sut.tokenResponse = try MockTokenResponse().getOutdatedJSONData()
+        XCTAssertFalse(sut.validAccessToken)
+    }
+}

--- a/Tests/UnitTests/Login/AuthenticationCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/AuthenticationCoordinatorTests.swift
@@ -49,18 +49,11 @@ extension AuthenticationCoordinatorTests {
         // WHEN the AuthenticationCoordinator calls performLoginFlow on the session
         // and there is no error
         sut.start()
-
-        // swiftlint:disable line_length
-        let accessToken = "eEd2wTsYiaXEcZrXYoClvP9uZVvsSsJm4fw8haqSLcH8!B!i=U!/viQGDK3aQq/M2aUdwoxUqevzDX!A8NJFWrZ4VfLP/lgMGXdop=l2QtkLtBvP=iYAXCIBjtyP3i-bY5aP3lF4YLnldq02!jQWfxe1TvWesyMi9D1GIDq!X7JAJTMVHUIKH?-C18/-fcgkxHsQZhs/oFsW/56fTPsvdJPteu10nMF1gY0f8AChM6Yl5FAKX=UOdTHIoVJvf9Dt"
-        let refreshToken = "JPz2bPDtrU/NJAedvDC8Xk6eMFlf1qZn9MuYXvCDl?xTZlCUFR?oAwUzXlhlr29MiWf1!2NlFYJ5shibOLWPnwCD46LfzZ6fG3ThIgWYZUH/1n-1p/4?UxDuhP/4!Orx-AFFPezxppqSJK9xOsA0GY13sZwNG-61TSV-yzL=OijL3TxTJg7A5q5H7DwZz71CtYiFn1KIsENYQ-7xB8C63tS3epWRF-Tsb7BMWtIUIZC0gODblBz/eAQFCf6lvEjp"
-        let idToken = "KdJzZf0ecdXFsSjIYXbh-0A4Hj-X!?JR5dhTqDgkoy6JDP7R5B1mtzD0cgprmflfyi7ihSvRWg1n=RrRgTjj5hG-t1tuN2zmqacHmUpbfKGsZKk6EwfvFxMYh4YINYfqLdFKLgY224uaCRI8F9rDghBoHx5=vMY=L6l3EwG5R8!HND2j2W5JKNwCTp3zKMS4WRYz3Xk?CJEKqa2oFNtFNdoz0rUIH-i/sCgqWkpE2093s0PyMZQ1x49M88mjx=0E"
-        // swiftlint:enable line_length
-
         waitForTruth(self.mockLoginSession.didCallPerformLoginFlow, timeout: 20)
         // THEN the tokens are returned
-        XCTAssertEqual(tokenHolder.tokenResponse?.accessToken, accessToken)
-        XCTAssertEqual(tokenHolder.tokenResponse?.refreshToken, refreshToken)
-        XCTAssertEqual(tokenHolder.tokenResponse?.idToken, idToken)
+        XCTAssertEqual(tokenHolder.tokenResponse?.accessToken, "accessTokenResponse")
+        XCTAssertEqual(tokenHolder.tokenResponse?.refreshToken, "refreshTokenResponse")
+        XCTAssertEqual(tokenHolder.tokenResponse?.idToken, "idTokenResponse")
     }
 
     func test_start_loginError_network() throws {

--- a/Tests/UnitTests/Login/EnrolmentCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/EnrolmentCoordinatorTests.swift
@@ -14,10 +14,6 @@ final class EnrolmentCoordinatorTests: XCTestCase {
     var tokenHolder: TokenHolder!
     var sut: EnrolmentCoordinator!
     
-    // swiftlint:disable line_length
-    let accessTokenValue = "eEd2wTsYiaXEcZrXYoClvP9uZVvsSsJm4fw8haqSLcH8!B!i=U!/viQGDK3aQq/M2aUdwoxUqevzDX!A8NJFWrZ4VfLP/lgMGXdop=l2QtkLtBvP=iYAXCIBjtyP3i-bY5aP3lF4YLnldq02!jQWfxe1TvWesyMi9D1GIDq!X7JAJTMVHUIKH?-C18/-fcgkxHsQZhs/oFsW/56fTPsvdJPteu10nMF1gY0f8AChM6Yl5FAKX=UOdTHIoVJvf9Dt"
-    // swiftlint:enable line_length
-    
     override func setUp() {
         super.setUp()
 
@@ -87,7 +83,7 @@ extension EnrolmentCoordinatorTests {
         sut.start()
         // THEN the journey should be saved in user defaults
         XCTAssertEqual(mockDefaultsStore.savedData["accessTokenExpiry"] as? Date, Date.accessTokenExp)
-        XCTAssertEqual(mockSecureStore.savedItems["accessToken"], accessTokenValue)
+        XCTAssertEqual(mockSecureStore.savedItems["accessToken"], "accessTokenResponse")
     }
 
     func test_start_deviceLocalAuthSet_passcode_fails() throws {
@@ -156,7 +152,7 @@ extension EnrolmentCoordinatorTests {
         Task { await sut.enrolLocalAuth(reason: "") }
         // THEN the journey should be saved in user defaults
         waitForTruth(self.mockDefaultsStore.savedData["accessTokenExpiry"] as? Date == Date.accessTokenExp, timeout: 20)
-        XCTAssertEqual(mockSecureStore.savedItems["accessToken"], accessTokenValue)
+        XCTAssertEqual(mockSecureStore.savedItems["accessToken"], "accessTokenResponse")
         XCTAssertEqual(mockLAContext.localizedFallbackTitle, "Enter passcode")
         XCTAssertEqual(mockLAContext.localizedCancelTitle, "Cancel")
     }

--- a/Tests/UnitTests/Mocks/OutdatedTokenResponse.json
+++ b/Tests/UnitTests/Mocks/OutdatedTokenResponse.json
@@ -3,5 +3,6 @@
     "refresh_token": "refreshTokenResponse",
     "id_token": "idTokenResponse",
     "token_type": "token",
-    "expiry_date": 1729427067
+    "expiry_date": 0
 }
+

--- a/Tests/UnitTests/Mocks/ReturnTypes/MockTokenResponse.swift
+++ b/Tests/UnitTests/Mocks/ReturnTypes/MockTokenResponse.swift
@@ -7,8 +7,21 @@ class MockTokenResponse {
     }
     
     func getJSONData() throws -> TokenResponse {
-        let bundleDoingTest = Bundle(for: type(of: self ))
+        let bundleDoingTest = Bundle(for: type(of: self))
         guard let jsonPath = bundleDoingTest.path(forResource: "TokenResponse", ofType: "json"),
+              let jsonData = FileManager.default.contents(atPath: jsonPath) else {
+            throw DecodeError.invalid
+        }
+        
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let tokenResponse = try decoder.decode(TokenResponse.self, from: jsonData)
+        return tokenResponse
+    }
+    
+    func getOutdatedJSONData() throws -> TokenResponse {
+        let bundleDoingTest = Bundle(for: type(of: self))
+        guard let jsonPath = bundleDoingTest.path(forResource: "OutdatedTokenResponse", ofType: "json"),
               let jsonData = FileManager.default.contents(atPath: jsonPath) else {
             throw DecodeError.invalid
         }


### PR DESCRIPTION
# feat: initialise NetworkClient on login flow completion

Initialising the `NetworkClient` from the networking package with an `AuthenticationProvider`

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
