### PR TITLE
refactor: improve tests involving assertions on Token expiry

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -387,7 +387,6 @@
 			children = (
 				C85DF8432AEBFDCC0064F68E /* Sessions+Services */,
 				C85DF8442AEBFDF00064F68E /* ReturnTypes */,
-				C8C6665D2BD007BD00CF249B /* OutdatedTokenResponse.json */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -642,6 +641,7 @@
 			children = (
 				C8520C2D2AE2C822006790C1 /* MockTokenResponse.swift */,
 				C8520C212AE2B642006790C1 /* TokenResponse.json */,
+				C8C6665D2BD007BD00CF249B /* OutdatedTokenResponse.json */,
 			);
 			path = ReturnTypes;
 			sourceTree = "<group>";

--- a/Tests/UnitTests/Application/TokenHolderTests.swift
+++ b/Tests/UnitTests/Application/TokenHolderTests.swift
@@ -26,7 +26,7 @@ extension TokenHolderTests {
     }
     
     func test_tokenOutdated() throws {
-        sut.tokenResponse = try MockTokenResponse().getOutdatedJSONData()
+        sut.tokenResponse = try MockTokenResponse().getJSONData(outdated: true)
         XCTAssertFalse(sut.validAccessToken)
     }
 }

--- a/Tests/UnitTests/Login/EnrolmentCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/EnrolmentCoordinatorTests.swift
@@ -54,12 +54,6 @@ final class EnrolmentCoordinatorTests: XCTestCase {
     }
 }
 
-fileprivate extension Date {
-    static var accessTokenExp: Self {
-        .init(timeIntervalSinceReferenceDate: 1729427067)
-    }
-}
-
 extension EnrolmentCoordinatorTests {
     func test_start_noDeviceLocalAuthSet() throws {
         // GIVEN the local authentication context returned true for canEvaluatePolicy for authentication
@@ -78,12 +72,13 @@ extension EnrolmentCoordinatorTests {
         // GIVEN the local authentication context returned true for canEvaluatePolicy for authentication
         mockLAContext.returnedFromCanEvaluatePolicyForAuthentication = true
         // GIVEN the token holder's token response has tokens
-        sut.tokenHolder.tokenResponse = try MockTokenResponse().getJSONData()
+        let tokenResponse = try MockTokenResponse().getJSONData()
+        sut.tokenHolder.tokenResponse = tokenResponse
         // WHEN the EnrolmentCoordinator is started
         sut.start()
         // THEN the journey should be saved in user defaults
-        XCTAssertEqual(mockDefaultsStore.savedData["accessTokenExpiry"] as? Date, Date.accessTokenExp)
-        XCTAssertEqual(mockSecureStore.savedItems["accessToken"], "accessTokenResponse")
+        XCTAssertEqual(mockDefaultsStore.savedData["accessTokenExpiry"] as? Date, tokenResponse.expiryDate)
+        XCTAssertEqual(mockSecureStore.savedItems["accessToken"], tokenResponse.accessToken)
     }
 
     func test_start_deviceLocalAuthSet_passcode_fails() throws {
@@ -147,12 +142,13 @@ extension EnrolmentCoordinatorTests {
         // GIVEN the local authentication context returned true for evaluatePolicy
         mockLAContext.returnedFromEvaluatePolicy = true
         // GIVEN the token holder's token response has tokens
-        sut.tokenHolder.tokenResponse = try MockTokenResponse().getJSONData()
+        let tokenResponse = try MockTokenResponse().getJSONData()
+        sut.tokenHolder.tokenResponse = tokenResponse
         // WHEN the EnrolmentCoordinator's enrolLocalAuth method is called
         Task { await sut.enrolLocalAuth(reason: "") }
         // THEN the journey should be saved in user defaults
-        waitForTruth(self.mockDefaultsStore.savedData["accessTokenExpiry"] as? Date == Date.accessTokenExp, timeout: 20)
-        XCTAssertEqual(mockSecureStore.savedItems["accessToken"], "accessTokenResponse")
+        waitForTruth(self.mockDefaultsStore.savedData["accessTokenExpiry"] as? Date == tokenResponse.expiryDate, timeout: 20)
+        XCTAssertEqual(mockSecureStore.savedItems["accessToken"], tokenResponse.accessToken)
         XCTAssertEqual(mockLAContext.localizedFallbackTitle, "Enter passcode")
         XCTAssertEqual(mockLAContext.localizedCancelTitle, "Cancel")
     }

--- a/Tests/UnitTests/Mocks/ReturnTypes/MockTokenResponse.swift
+++ b/Tests/UnitTests/Mocks/ReturnTypes/MockTokenResponse.swift
@@ -6,28 +6,20 @@ class MockTokenResponse {
         case invalid
     }
     
-    func getJSONData() throws -> TokenResponse {
+    func getJSONData(outdated: Bool = false) throws -> TokenResponse {
         let bundleDoingTest = Bundle(for: type(of: self))
-        guard let jsonPath = bundleDoingTest.path(forResource: "TokenResponse", ofType: "json"),
+        guard let jsonPath = bundleDoingTest.path(forResource: "\(outdated ? "Outdated" : "")TokenResponse", ofType: "json"),
               let jsonData = FileManager.default.contents(atPath: jsonPath) else {
             throw DecodeError.invalid
         }
         
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
-        let tokenResponse = try decoder.decode(TokenResponse.self, from: jsonData)
-        return tokenResponse
-    }
-    
-    func getOutdatedJSONData() throws -> TokenResponse {
-        let bundleDoingTest = Bundle(for: type(of: self))
-        guard let jsonPath = bundleDoingTest.path(forResource: "OutdatedTokenResponse", ofType: "json"),
-              let jsonData = FileManager.default.contents(atPath: jsonPath) else {
-            throw DecodeError.invalid
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let dateInt = try container.decode(Double.self)
+            return Date(timeIntervalSinceNow: dateInt)
         }
-        
-        let decoder = JSONDecoder()
-        decoder.keyDecodingStrategy = .convertFromSnakeCase
         let tokenResponse = try decoder.decode(TokenResponse.self, from: jsonData)
         return tokenResponse
     }

--- a/Tests/UnitTests/Mocks/ReturnTypes/MockTokenResponse.swift
+++ b/Tests/UnitTests/Mocks/ReturnTypes/MockTokenResponse.swift
@@ -7,20 +7,19 @@ class MockTokenResponse {
     }
     
     func getJSONData(outdated: Bool = false) throws -> TokenResponse {
-        let bundleDoingTest = Bundle(for: type(of: self))
-        guard let jsonPath = bundleDoingTest.path(forResource: "\(outdated ? "Outdated" : "")TokenResponse", ofType: "json"),
+        let bundleForTest = Bundle(for: type(of: self))
+        guard let jsonPath = bundleForTest.path(forResource: (outdated ? "OutdatedTokenResponse" : "TokenResponse"), ofType: "json"),
               let jsonData = FileManager.default.contents(atPath: jsonPath) else {
             throw DecodeError.invalid
         }
         
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
-        decoder.dateDecodingStrategy = .custom { decoder in
-            let container = try decoder.singleValueContainer()
-            let dateInt = try container.decode(Double.self)
-            return Date(timeIntervalSinceNow: dateInt)
+        decoder.dateDecodingStrategy = .custom {
+            let container = try $0.singleValueContainer()
+            let dateDouble = try container.decode(Double.self)
+            return Date(timeIntervalSinceNow: dateDouble)
         }
-        let tokenResponse = try decoder.decode(TokenResponse.self, from: jsonData)
-        return tokenResponse
+        return try decoder.decode(TokenResponse.self, from: jsonData)
     }
 }

--- a/Tests/UnitTests/Mocks/ReturnTypes/OutdatedTokenResponse.json
+++ b/Tests/UnitTests/Mocks/ReturnTypes/OutdatedTokenResponse.json
@@ -3,6 +3,6 @@
     "refresh_token": "refreshTokenResponse",
     "id_token": "idTokenResponse",
     "token_type": "token",
-    "expiry_date": 0
+    "expiry_date": -180
 }
 

--- a/Tests/UnitTests/Mocks/ReturnTypes/TokenResponse.json
+++ b/Tests/UnitTests/Mocks/ReturnTypes/TokenResponse.json
@@ -3,5 +3,5 @@
     "refresh_token": "refreshTokenResponse",
     "id_token": "idTokenResponse",
     "token_type": "token",
-    "expiry_date": 1729427067
+    "expiry_date": 180
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,7 +16,7 @@ require 'securerandom'
 ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "600"
 
 default_platform(:ios)
-xcode_select("/Applications/Xcode_15.1.app")
+xcode_select("/Applications/Xcode_15.2.app")
 
 platform :ios do
   desc "Run Tests without Sonar Coverage"


### PR DESCRIPTION
# refactor: improve tests involving assertions on Token expiry

The AppAuth library creates a Date object from a JSON `expiry_date` property. This Date object is initialised using the current time and date and sets a time based on the number value in the JSON property. This option is not available in swift when using JSONDecoder.
This PR uses a custom decoding strategy to achieve this to mirror the behaviour of the AppAuth library.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
