### PR TITLE
fix: STS token error

### DIFF
--- a/OneLogin-Info.plist
+++ b/OneLogin-Info.plist
@@ -25,8 +25,8 @@
 	<string>$(ONE_LOGIN_CLIENT_ID)</string>
 	<key>Redirect URL</key>
 	<string>$(REDIRECT_URL)</string>
-	<key>STS Authorize URL</key>
-	<string>$(STS_AUTHORIZE_URL)</string>
+	<key>STS Base URL</key>
+	<string>$(STS_BASE_URL)</string>
 	<key>STS Client ID</key>
 	<string>$(STS_CLIENT_ID)</string>
 	<key>UIApplicationSceneManifest</key>

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -1615,7 +1615,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "uk.gov.one-login.staging";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REDIRECT_URL = "https://mobile.staging.account.gov.uk/redirect";
-				STS_AUTHORIZE_URL = token.staging.account.gov.uk;
+				STS_BASE_URL = token.staging.account.gov.uk;
 				STS_CLIENT_ID = ctQpngJQrFFCrppZtYQFFoklHaq;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -1654,7 +1654,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "uk.gov.one-login";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REDIRECT_URL = "";
-				STS_AUTHORIZE_URL = "";
+				STS_BASE_URL = "";
 				STS_CLIENT_ID = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -1928,7 +1928,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "uk.gov.one-login.staging";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REDIRECT_URL = "https://mobile.staging.account.gov.uk/redirect";
-				STS_AUTHORIZE_URL = token.staging.account.gov.uk;
+				STS_BASE_URL = token.staging.account.gov.uk;
 				STS_CLIENT_ID = ctQpngJQrFFCrppZtYQFFoklHaq;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -2117,7 +2117,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "uk.gov.one-login.build";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REDIRECT_URL = "https://mobile.build.account.gov.uk/redirect";
-				STS_AUTHORIZE_URL = token.build.account.gov.uk;
+				STS_BASE_URL = token.build.account.gov.uk;
 				STS_CLIENT_ID = bYrcuRVvnylvEgYSSbBjwXzHrwJ;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-authentication.git",
       "state" : {
-        "revision" : "99e8d600b6ad5875b0ad29243060ef9c4de02615",
-        "version" : "1.1.3"
+        "revision" : "81f1112f7fc54bdd6c227e58927afdf41e9ba915",
+        "version" : "1.1.4"
       }
     },
     {

--- a/Sources/Application/Environment/AppEnvironment.swift
+++ b/Sources/Application/Environment/AppEnvironment.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class AppEnvironment {
     enum Key: String {
         case oneLoginAuthorizeURL = "One Login Authorize URL"
-        case stsAuthorizeURL = "STS Authorize URL"
+        case stsBaseURL = "STS Base URL"
         case baseURL = "Base URL"
         case redirectURL = "Redirect URL"
         case oneLoginClientID = "One Login Client ID"
@@ -91,8 +91,16 @@ extension AppEnvironment {
     static var stsLoginAuthorize: URL {
         var components = URLComponents()
         components.scheme = "https"
-        components.host = string(for: .stsAuthorizeURL)
+        components.host = string(for: .stsBaseURL)
         components.path = "/authorize"
+        return components.url!
+    }
+    
+    static var stsLoginToken: URL {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = string(for: .stsBaseURL)
+        components.path = "/token"
         return components.url!
     }
     

--- a/Sources/Extensions/CustomTypes/LoginSessionConfiguration+OneLogin.swift
+++ b/Sources/Extensions/CustomTypes/LoginSessionConfiguration+OneLogin.swift
@@ -5,7 +5,7 @@ extension LoginSessionConfiguration {
     static var oneLogin: LoginSessionConfiguration {
         let env = AppEnvironment.self
         return .init(authorizationEndpoint: env.callingSTSEnabled ? env.stsLoginAuthorize : env.oneLoginAuthorize,
-                     tokenEndpoint: env.oneLoginToken,
+                     tokenEndpoint: env.callingSTSEnabled ? env.stsLoginToken : env.oneLoginToken,
                      scopes: env.callingSTSEnabled ? [.custom("sts")] : [.openid],
                      clientID: env.callingSTSEnabled ? env.stsClientID : env.oneLoginClientID,
                      redirectURI: env.oneLoginRedirect,

--- a/Tests/ConfigTests/BuildConfig/BuildAppEnvironmentTests.swift
+++ b/Tests/ConfigTests/BuildConfig/BuildAppEnvironmentTests.swift
@@ -7,6 +7,7 @@ final class BuildAppEnvironmentTests: XCTestCase {
         XCTAssertEqual(sut.oneLoginAuthorize, URL(string: "https://auth-stub.mobile.build.account.gov.uk/authorize"))
         XCTAssertEqual(sut.stsLoginAuthorize, URL(string: "https://token.build.account.gov.uk/authorize"))
         XCTAssertEqual(sut.oneLoginToken, URL(string: "https://mobile.build.account.gov.uk/token"))
+        XCTAssertEqual(sut.stsLoginToken, URL(string: "https://token.staging.account.gov.uk/token"))
         XCTAssertEqual(sut.privacyPolicyURL, URL(string: "https://signin.account.gov.uk/privacy-notice?lng=en"))
         XCTAssertEqual(sut.oneLoginClientID, "TEST_CLIENT_ID")
         XCTAssertEqual(sut.stsClientID, "bYrcuRVvnylvEgYSSbBjwXzHrwJ")

--- a/Tests/ConfigTests/StagingConfig/StagingAppEnvironmentTests.swift
+++ b/Tests/ConfigTests/StagingConfig/StagingAppEnvironmentTests.swift
@@ -7,6 +7,7 @@ final class StagingAppEnvironmentTests: XCTestCase {
         XCTAssertEqual(sut.oneLoginAuthorize, URL(string: "https://oidc.integration.account.gov.uk/authorize"))
         XCTAssertEqual(sut.stsLoginAuthorize, URL(string: "https://token.staging.account.gov.uk/authorize"))
         XCTAssertEqual(sut.oneLoginToken, URL(string: "https://mobile.staging.account.gov.uk/token"))
+        XCTAssertEqual(sut.stsLoginToken, URL(string: "https://token.staging.account.gov.uk/token"))
         XCTAssertEqual(sut.privacyPolicyURL, URL(string: "https://signin.account.gov.uk/privacy-notice?lng=en"))
         XCTAssertEqual(sut.oneLoginClientID, "sdJChz1oGajIz0O0tdPdh0CA2zW")
         XCTAssertEqual(sut.stsClientID, "ctQpngJQrFFCrppZtYQFFoklHaq")


### PR DESCRIPTION
# DCMAW-8963: iOS | Mobile Platform | STS token endpoint

In the previous work to set up a feature flag for using the STS authorization service the token endpoint was not included as needing specific configuration. This PR amends that with a change to use the latest version of the authentication package where the `idToken` is optional.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
