### PR TITLE
fix: correcting build configuration test

### DIFF
--- a/Tests/ConfigTests/BuildConfig/BuildAppEnvironmentTests.swift
+++ b/Tests/ConfigTests/BuildConfig/BuildAppEnvironmentTests.swift
@@ -7,7 +7,7 @@ final class BuildAppEnvironmentTests: XCTestCase {
         XCTAssertEqual(sut.oneLoginAuthorize, URL(string: "https://auth-stub.mobile.build.account.gov.uk/authorize"))
         XCTAssertEqual(sut.stsLoginAuthorize, URL(string: "https://token.build.account.gov.uk/authorize"))
         XCTAssertEqual(sut.oneLoginToken, URL(string: "https://mobile.build.account.gov.uk/token"))
-        XCTAssertEqual(sut.stsLoginToken, URL(string: "https://token.staging.account.gov.uk/token"))
+        XCTAssertEqual(sut.stsLoginToken, URL(string: "https://token.build.account.gov.uk/token"))
         XCTAssertEqual(sut.privacyPolicyURL, URL(string: "https://signin.account.gov.uk/privacy-notice?lng=en"))
         XCTAssertEqual(sut.oneLoginClientID, "TEST_CLIENT_ID")
         XCTAssertEqual(sut.stsClientID, "bYrcuRVvnylvEgYSSbBjwXzHrwJ")


### PR DESCRIPTION
# DCMAW-8963: iOS | Mobile Platform | STS token endpoint

Correcting rebasing mistake to on build configuration tests.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
