### PR TITLE
feat: dcmaw-8725 home and profile pages

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -144,6 +144,7 @@
 		D08B0B7F2BDBF87800769CEA /* TabbedViewSectionHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = D08B0B7E2BDBF87800769CEA /* TabbedViewSectionHeader.xib */; };
 		D08B0B812BDC0D7100769CEA /* TabbedTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B802BDC0D7100769CEA /* TabbedTableViewCell.swift */; };
 		D08B0B832BDC0F4100769CEA /* TabbedViewCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B822BDC0F4100769CEA /* TabbedViewCellModel.swift */; };
+		D08B0B852BDFA40A00769CEA /* TabbedViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B842BDFA40A00769CEA /* TabbedViewControllerTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -321,6 +322,7 @@
 		D08B0B7E2BDBF87800769CEA /* TabbedViewSectionHeader.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TabbedViewSectionHeader.xib; sourceTree = "<group>"; };
 		D08B0B802BDC0D7100769CEA /* TabbedTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbedTableViewCell.swift; sourceTree = "<group>"; };
 		D08B0B822BDC0F4100769CEA /* TabbedViewCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbedViewCellModel.swift; sourceTree = "<group>"; };
+		D08B0B842BDFA40A00769CEA /* TabbedViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbedViewControllerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -802,6 +804,7 @@
 			children = (
 				C82F950E2B9F0CCA00A90A6A /* UnlockScreenViewControllerTests.swift */,
 				C82F95102B9F0D4200A90A6A /* TokensViewControllerTests.swift */,
+				D08B0B842BDFA40A00769CEA /* TabbedViewControllerTests.swift */,
 			);
 			path = Screens;
 			sourceTree = "<group>";
@@ -1406,6 +1409,7 @@
 				C82B64522BA47D59000C9524 /* StringTests.swift in Sources */,
 				C8EBE8042AEFB7FF009B8A06 /* LoginSessionConfigurationTests.swift in Sources */,
 				C8E6A3EF2BBC1181005015AF /* WindowManagerTests.swift in Sources */,
+				D08B0B852BDFA40A00769CEA /* TabbedViewControllerTests.swift in Sources */,
 				1E891B7C2B63E1D500744E3D /* PasscodeInformationViewModelTests.swift in Sources */,
 				21FA1C4D2AE183D20052136E /* MockLoginSession.swift in Sources */,
 				41A0BD112B2758E6009AE51F /* GenericErrorViewModelTests.swift in Sources */,

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -134,6 +134,16 @@
 		D08B0B582BD7F97200769CEA /* DeveloperMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B572BD7F97200769CEA /* DeveloperMenuViewModel.swift */; };
 		D08B0B5A2BD7FAE600769CEA /* TokensViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B592BD7FAE600769CEA /* TokensViewModel.swift */; };
 		D08B0B5C2BD8046200769CEA /* HomeCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B5B2BD8046200769CEA /* HomeCoordinatorTests.swift */; };
+		D08B0B652BDA478000769CEA /* SignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B642BDA478000769CEA /* SignInView.swift */; };
+		D08B0B682BDA47AD00769CEA /* SignInView.xib in Resources */ = {isa = PBXBuildFile; fileRef = D08B0B672BDA47AD00769CEA /* SignInView.xib */; };
+		D08B0B732BDA8DD100769CEA /* TabbedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B712BDA8DD100769CEA /* TabbedViewController.swift */; };
+		D08B0B742BDA8DD100769CEA /* TabbedView.xib in Resources */ = {isa = PBXBuildFile; fileRef = D08B0B722BDA8DD100769CEA /* TabbedView.xib */; };
+		D08B0B762BDA95F600769CEA /* TabbedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B752BDA95F600769CEA /* TabbedViewModel.swift */; };
+		D08B0B782BDBD32900769CEA /* SignInViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B772BDBD32900769CEA /* SignInViewModel.swift */; };
+		D08B0B7D2BDBF86100769CEA /* TabbedViewSectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B7C2BDBF86100769CEA /* TabbedViewSectionHeader.swift */; };
+		D08B0B7F2BDBF87800769CEA /* TabbedViewSectionHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = D08B0B7E2BDBF87800769CEA /* TabbedViewSectionHeader.xib */; };
+		D08B0B812BDC0D7100769CEA /* TabbedTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B802BDC0D7100769CEA /* TabbedTableViewCell.swift */; };
+		D08B0B832BDC0F4100769CEA /* TabbedViewCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B822BDC0F4100769CEA /* TabbedViewCellModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -301,6 +311,16 @@
 		D08B0B572BD7F97200769CEA /* DeveloperMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperMenuViewModel.swift; sourceTree = "<group>"; };
 		D08B0B592BD7FAE600769CEA /* TokensViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokensViewModel.swift; sourceTree = "<group>"; };
 		D08B0B5B2BD8046200769CEA /* HomeCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCoordinatorTests.swift; sourceTree = "<group>"; };
+		D08B0B642BDA478000769CEA /* SignInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInView.swift; sourceTree = "<group>"; };
+		D08B0B672BDA47AD00769CEA /* SignInView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SignInView.xib; sourceTree = "<group>"; };
+		D08B0B712BDA8DD100769CEA /* TabbedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbedViewController.swift; sourceTree = "<group>"; };
+		D08B0B722BDA8DD100769CEA /* TabbedView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TabbedView.xib; sourceTree = "<group>"; };
+		D08B0B752BDA95F600769CEA /* TabbedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbedViewModel.swift; sourceTree = "<group>"; };
+		D08B0B772BDBD32900769CEA /* SignInViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInViewModel.swift; sourceTree = "<group>"; };
+		D08B0B7C2BDBF86100769CEA /* TabbedViewSectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbedViewSectionHeader.swift; sourceTree = "<group>"; };
+		D08B0B7E2BDBF87800769CEA /* TabbedViewSectionHeader.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TabbedViewSectionHeader.xib; sourceTree = "<group>"; };
+		D08B0B802BDC0D7100769CEA /* TabbedTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbedTableViewCell.swift; sourceTree = "<group>"; };
+		D08B0B822BDC0F4100769CEA /* TabbedViewCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbedViewCellModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -454,6 +474,7 @@
 		4195E6C62B0CC6C50065E2BB /* Screens */ = {
 			isa = PBXGroup;
 			children = (
+				D08B0B5D2BD95C4900769CEA /* Home */,
 				D08B0B522BD7F7D600769CEA /* DeveloperMenu */,
 				414D97FF2B8DEBD000E267EF /* Unlock */,
 				4195E6C72B0CC6CD0065E2BB /* Tokens */,
@@ -713,6 +734,7 @@
 		C85E21152ACEECB000AF8B4E /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				D08B0B662BDA479000769CEA /* Components */,
 				C85E21162ACEECC600AF8B4E /* Buttons */,
 			);
 			path = Views;
@@ -951,6 +973,7 @@
 		C8ECA1282BB5955200722218 /* Tabs */ = {
 			isa = PBXGroup;
 			children = (
+				D08B0B7B2BDBF82600769CEA /* Views */,
 				C8ECA1232BB4805900722218 /* HomeCoordinator.swift */,
 				C8ECA1292BB5957500722218 /* WalletCoordinator.swift */,
 				C8ECA12B2BB5958000722218 /* ProfileCoordinator.swift */,
@@ -966,6 +989,37 @@
 				D08B0B572BD7F97200769CEA /* DeveloperMenuViewModel.swift */,
 			);
 			path = DeveloperMenu;
+			sourceTree = "<group>";
+		};
+		D08B0B5D2BD95C4900769CEA /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				D08B0B712BDA8DD100769CEA /* TabbedViewController.swift */,
+				D08B0B722BDA8DD100769CEA /* TabbedView.xib */,
+				D08B0B752BDA95F600769CEA /* TabbedViewModel.swift */,
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
+		D08B0B662BDA479000769CEA /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				D08B0B642BDA478000769CEA /* SignInView.swift */,
+				D08B0B672BDA47AD00769CEA /* SignInView.xib */,
+				D08B0B772BDBD32900769CEA /* SignInViewModel.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		D08B0B7B2BDBF82600769CEA /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				D08B0B7C2BDBF86100769CEA /* TabbedViewSectionHeader.swift */,
+				D08B0B7E2BDBF87800769CEA /* TabbedViewSectionHeader.xib */,
+				D08B0B802BDC0D7100769CEA /* TabbedTableViewCell.swift */,
+				D08B0B822BDC0F4100769CEA /* TabbedViewCellModel.swift */,
+			);
+			path = Views;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1143,13 +1197,16 @@
 			buildActionMask = 2147483647;
 			files = (
 				C8BACAF82B4DCCAC00530419 /* FeatureFlagsStaging.json in Resources */,
+				D08B0B682BDA47AD00769CEA /* SignInView.xib in Resources */,
 				3BBF28F02A9F7D3200491BB1 /* Assets.xcassets in Resources */,
 				C873B1D82AF82403002C39E8 /* OneLoginBuild.xctestplan in Resources */,
 				C873B1D92AF82403002C39E8 /* OneLoginStaging.xctestplan in Resources */,
 				C873B1DA2AF82403002C39E8 /* OneLoginUnit.xctestplan in Resources */,
+				D08B0B7F2BDBF87800769CEA /* TabbedViewSectionHeader.xib in Resources */,
 				1EB56D6D2B7CDE6D00BD548E /* Localizable.strings in Resources */,
 				C865444D2BD7D55000433897 /* PrivacyInfo.xcprivacy in Resources */,
 				3BBF28F12A9F7D3200491BB1 /* LaunchScreen.storyboard in Resources */,
+				D08B0B742BDA8DD100769CEA /* TabbedView.xib in Resources */,
 				414D98052B8DF0F100E267EF /* UnlockScreen.xib in Resources */,
 				C89632ED2B0D0886002A1473 /* TokensView.xib in Resources */,
 				C8BACAFA2B4DCCBD00530419 /* FeatureFlagsBuild.json in Resources */,
@@ -1281,6 +1338,7 @@
 				C8ECA1242BB4805900722218 /* HomeCoordinator.swift in Sources */,
 				1E717D772B72976D00CCAF3E /* LAContexting.swift in Sources */,
 				41C8E4332B73AA600063B8A3 /* TouchIDEnrollmentViewModel.swift in Sources */,
+				D08B0B732BDA8DD100769CEA /* TabbedViewController.swift in Sources */,
 				C8BADD222B8652F200385FE7 /* TokenHolder.swift in Sources */,
 				C8E6A3E82BBC0536005015AF /* WindowManagement.swift in Sources */,
 				C81ECB1B2B71709500AFC3A6 /* EnrolmentCoordinator.swift in Sources */,
@@ -1303,8 +1361,12 @@
 				C8098B992AEFF287001517A0 /* AnalyticsService+GDS.swift in Sources */,
 				C8B320792B062F9100FECDF0 /* AuthenticationCoordinator.swift in Sources */,
 				C8C343A92B923DB300E92FB9 /* StandardButtonViewModel.swift in Sources */,
+				D08B0B832BDC0F4100769CEA /* TabbedViewCellModel.swift in Sources */,
+				D08B0B762BDA95F600769CEA /* TabbedViewModel.swift in Sources */,
 				C8ECA1322BB73E2E00722218 /* WindowManager.swift in Sources */,
+				D08B0B652BDA478000769CEA /* SignInView.swift in Sources */,
 				41C5E32F2B45A36E00212A12 /* NetworkConnectionErrorViewModel.swift in Sources */,
+				D08B0B7D2BDBF86100769CEA /* TabbedViewSectionHeader.swift in Sources */,
 				C8B825C32B98C34A00336146 /* LoginCoordinator.swift in Sources */,
 				C85E21042ACEE34900AF8B4E /* MainCoordinator.swift in Sources */,
 				41C8E42C2B7252A70063B8A3 /* FaceIDEnrollmentViewModel.swift in Sources */,
@@ -1312,6 +1374,7 @@
 				C8C343A72B92340000E92FB9 /* AnalyticsCentral.swift in Sources */,
 				C8AA11D82B29C7FA00CE718B /* UnableToLoginErrorViewModel.swift in Sources */,
 				D08B0B582BD7F97200769CEA /* DeveloperMenuViewModel.swift in Sources */,
+				D08B0B782BDBD32900769CEA /* SignInViewModel.swift in Sources */,
 				C880DDE22AEAB6C100020796 /* AppEnvironment.swift in Sources */,
 				1EB667A32B59910D008D8199 /* NetworkMonitoring.swift in Sources */,
 				41C8E4312B73A0160063B8A3 /* BiometricEnrollmentAnalyticsScreen.swift in Sources */,
@@ -1324,6 +1387,7 @@
 				41D9DC452B55851A00FC7DDD /* NetworkMonitor.swift in Sources */,
 				C85E21182ACEECD800AF8B4E /* AnalyticsButtonViewModel.swift in Sources */,
 				C851FFA22BADA4B200A7B73D /* SceneLifecycle.swift in Sources */,
+				D08B0B812BDC0D7100769CEA /* TabbedTableViewCell.swift in Sources */,
 				C86B706B2B8E43DC00F4C9BF /* AnalyticsPreferenceViewModel.swift in Sources */,
 				C89632EF2B0D0895002A1473 /* TokensViewController.swift in Sources */,
 				C8ECA12A2BB5957500722218 /* WalletCoordinator.swift in Sources */,

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -30,7 +30,6 @@
 		414D98052B8DF0F100E267EF /* UnlockScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 414D98042B8DF0F100E267EF /* UnlockScreen.xib */; };
 		414D98072B8E078700E267EF /* UnlockScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 414D98062B8E078700E267EF /* UnlockScreenViewModel.swift */; };
 		41A0BD0A2B272118009AE51F /* ErrorScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A0BD092B272118009AE51F /* ErrorScreen.swift */; };
-		41A0BD0C2B2725C8009AE51F /* TokensScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A0BD0B2B2725C8009AE51F /* TokensScreen.swift */; };
 		41A0BD112B2758E6009AE51F /* GenericErrorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A0BD0F2B275168009AE51F /* GenericErrorViewModelTests.swift */; };
 		41C5E32F2B45A36E00212A12 /* NetworkConnectionErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41C5E32E2B45A36E00212A12 /* NetworkConnectionErrorViewModel.swift */; };
 		41C5E3322B45B07D00212A12 /* NetworkConnectionErrorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41C5E3302B45AFAA00212A12 /* NetworkConnectionErrorViewModelTests.swift */; };
@@ -145,6 +144,7 @@
 		D08B0B812BDC0D7100769CEA /* TabbedTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B802BDC0D7100769CEA /* TabbedTableViewCell.swift */; };
 		D08B0B832BDC0F4100769CEA /* TabbedViewCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B822BDC0F4100769CEA /* TabbedViewCellModel.swift */; };
 		D08B0B852BDFA40A00769CEA /* TabbedViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B842BDFA40A00769CEA /* TabbedViewControllerTests.swift */; };
+		D08B0B8D2BE0FDB100769CEA /* HomeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B8C2BE0FDB100769CEA /* HomeScreen.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -210,7 +210,6 @@
 		414D98042B8DF0F100E267EF /* UnlockScreen.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = UnlockScreen.xib; sourceTree = "<group>"; };
 		414D98062B8E078700E267EF /* UnlockScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnlockScreenViewModel.swift; sourceTree = "<group>"; };
 		41A0BD092B272118009AE51F /* ErrorScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorScreen.swift; sourceTree = "<group>"; };
-		41A0BD0B2B2725C8009AE51F /* TokensScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokensScreen.swift; sourceTree = "<group>"; };
 		41A0BD0F2B275168009AE51F /* GenericErrorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericErrorViewModelTests.swift; sourceTree = "<group>"; };
 		41C5E32E2B45A36E00212A12 /* NetworkConnectionErrorViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkConnectionErrorViewModel.swift; sourceTree = "<group>"; };
 		41C5E3302B45AFAA00212A12 /* NetworkConnectionErrorViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkConnectionErrorViewModelTests.swift; sourceTree = "<group>"; };
@@ -323,6 +322,7 @@
 		D08B0B802BDC0D7100769CEA /* TabbedTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbedTableViewCell.swift; sourceTree = "<group>"; };
 		D08B0B822BDC0F4100769CEA /* TabbedViewCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbedViewCellModel.swift; sourceTree = "<group>"; };
 		D08B0B842BDFA40A00769CEA /* TabbedViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbedViewControllerTests.swift; sourceTree = "<group>"; };
+		D08B0B8C2BE0FDB100769CEA /* HomeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreen.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -557,8 +557,8 @@
 				C80B87202B029EBB0087C6D5 /* WelcomeScreen.swift */,
 				41A0BD092B272118009AE51F /* ErrorScreen.swift */,
 				C80B871E2B029EAB0087C6D5 /* LoginModal.swift */,
-				41A0BD0B2B2725C8009AE51F /* TokensScreen.swift */,
 				1EDA358B2B29FAAD0062FA46 /* LoginModalSecondScreen.swift */,
+				D08B0B8C2BE0FDB100769CEA /* HomeScreen.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -1452,10 +1452,10 @@
 			files = (
 				C80B87212B029EBB0087C6D5 /* WelcomeScreen.swift in Sources */,
 				C80B87232B029EE90087C6D5 /* TimeInterval.swift in Sources */,
-				41A0BD0C2B2725C8009AE51F /* TokensScreen.swift in Sources */,
 				41A0BD0A2B272118009AE51F /* ErrorScreen.swift in Sources */,
 				C80B87262B029F1A0087C6D5 /* XCUIElement.swift in Sources */,
 				C80B871A2B029E230087C6D5 /* LoginUITests.swift in Sources */,
+				D08B0B8D2BE0FDB100769CEA /* HomeScreen.swift in Sources */,
 				C80B87282B029F440087C6D5 /* ScreenObject.swift in Sources */,
 				C80B871F2B029EAB0087C6D5 /* LoginModal.swift in Sources */,
 				1EDA358C2B29FAAD0062FA46 /* LoginModalSecondScreen.swift in Sources */,

--- a/Sources/Resources/cy-GB.lproj/Localizable.strings
+++ b/Sources/Resources/cy-GB.lproj/Localizable.strings
@@ -86,3 +86,7 @@
 
 // MARK: Unlock screen
 "app_unlockButton" = "Datgloi";
+
+// MARK: Home screen
+"app_homeTitle" = "Hafan";
+"app_displayEmail" = "Rydych wedi mewngofnodi fel\n%@";

--- a/Sources/Resources/en.lproj/Localizable.strings
+++ b/Sources/Resources/en.lproj/Localizable.strings
@@ -86,3 +86,7 @@
 
 // MARK: Unlock screen
 "app_unlockButton" = "Unlock";
+
+// MARK: Home screen
+"app_homeTitle" = "Home";
+"app_displayEmail" = "You’re signed in as\n%@";

--- a/Sources/Screens/Home/TabbedView.xib
+++ b/Sources/Screens/Home/TabbedView.xib
@@ -20,13 +20,12 @@
             <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="YNW-9V-3R7">
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="YNW-9V-3R7">
                     <rect key="frame" x="0.0" y="59" width="393" height="793"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </tableView>
             </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
-            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <color key="backgroundColor" systemColor="systemGroupedBackgroundColor"/>
             <constraints>
                 <constraint firstItem="YNW-9V-3R7" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="HtN-7I-1hw"/>
                 <constraint firstItem="YNW-9V-3R7" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="PMS-Mp-oma"/>
@@ -37,8 +36,8 @@
         </view>
     </objects>
     <resources>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        <systemColor name="systemGroupedBackgroundColor">
+            <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Sources/Screens/Home/TabbedView.xib
+++ b/Sources/Screens/Home/TabbedView.xib
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="TabbedViewController" customModule="OneLogin" customModuleProvider="target">
+            <connections>
+                <outlet property="tableView" destination="YNW-9V-3R7" id="o9F-6G-1fa"/>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="YNW-9V-3R7">
+                    <rect key="frame" x="0.0" y="59" width="393" height="793"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                </tableView>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="YNW-9V-3R7" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="HtN-7I-1hw"/>
+                <constraint firstItem="YNW-9V-3R7" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="PMS-Mp-oma"/>
+                <constraint firstItem="YNW-9V-3R7" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="QQC-M4-dx1"/>
+                <constraint firstAttribute="bottom" secondItem="YNW-9V-3R7" secondAttribute="bottom" id="sSU-qe-beT"/>
+            </constraints>
+            <point key="canvasLocation" x="90.839694656488547" y="19.718309859154932"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Sources/Screens/Home/TabbedViewController.swift
+++ b/Sources/Screens/Home/TabbedViewController.swift
@@ -1,0 +1,78 @@
+import GDSCommon
+import UIKit
+
+final class TabbedViewController: BaseViewController {
+
+    override var nibName: String? { "TabbedView" }
+    @IBOutlet private var tableView: UITableView!
+    let headerView = SignInView()
+    let viewModel: TabbedViewModel
+    
+    init(viewModel: TabbedViewModel) {
+        self.viewModel = viewModel
+        super.init(viewModel: viewModel,
+                   nibName: "TabbedView",
+                   bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        tableView.delegate = viewModel
+        tableView.dataSource = viewModel.dataSource
+        title = "Home"
+        navigationController?.navigationBar.prefersLargeTitles = true
+    }
+
+
+    
+    override func viewDidLayoutSubviews() {
+         super.viewDidLayoutSubviews()
+
+         guard let headerView = tableView.tableHeaderView else {
+             return
+         }
+
+         // The table view header is created with the frame size set in
+         // the Storyboard. Calculate the new size and reset the header
+         // view to trigger the layout.
+
+         // Calculate the minimum height of the header view that allows
+         // the text label to fit its preferred width.
+
+         let size = headerView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
+
+         if headerView.frame.size.height != size.height {
+             headerView.frame.size.height = size.height
+
+             // Need to set the header view property of the table view
+             // to trigger the new layout. Be careful to only do this
+             // once when the height changes or we get stuck in a layout loop.
+
+             tableView.tableHeaderView = headerView
+
+             // Now that the table view header is sized correctly have
+             // the table view redo its layout so that the cells are
+             // correcly positioned for the new header size.
+
+             // This only seems to be necessary on iOS 9.
+
+             tableView.layoutIfNeeded()
+         }
+     }
+ 
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/Sources/Screens/Home/TabbedViewController.swift
+++ b/Sources/Screens/Home/TabbedViewController.swift
@@ -5,7 +5,11 @@ import UIKit
 final class TabbedViewController: BaseViewController {
 
     override var nibName: String? { "TabbedView" }
-    @IBOutlet private var tableView: UITableView!
+    @IBOutlet private var tableView: UITableView! {
+        didSet {
+            tableView.accessibilityIdentifier = "tabbed-view-table-view"
+        }
+    }
     
     private let headerView: UIView?
     private let viewModel: TabbedViewModel

--- a/Sources/Screens/Home/TabbedViewModel.swift
+++ b/Sources/Screens/Home/TabbedViewModel.swift
@@ -1,0 +1,28 @@
+import GDSCommon
+import UIKit
+
+final class TabbedViewModel: NSObject, BaseViewModel {
+    var rightBarButtonTitle: GDSCommon.GDSLocalisedString?
+    var backButtonIsHidden: Bool
+    var title: String?
+    var dataSource: UITableViewDataSource?
+    
+    init(rightBarButtonTitle: GDSCommon.GDSLocalisedString? = nil, backButtonIsHidden: Bool = true, title: String? = nil, dataSource: UITableViewDataSource? = nil) {
+        self.rightBarButtonTitle = rightBarButtonTitle
+        self.backButtonIsHidden = backButtonIsHidden
+        self.title = title
+        self.dataSource = dataSource
+    }
+    
+    func didAppear() {
+        
+    }
+    
+    func didDismiss() {
+        
+    }
+}
+
+extension TabbedViewModel: UITableViewDelegate {
+    
+}

--- a/Sources/Screens/Home/TabbedViewModel.swift
+++ b/Sources/Screens/Home/TabbedViewModel.swift
@@ -22,7 +22,7 @@ final class TabbedViewModel: NSObject, BaseViewModel {
     }
     
     var numberOfSections: Int {
-        sectionHeaderTitles.count > 0 ? sectionHeaderTitles.count : 1
+        sectionHeaderTitles.count
     }
     
     func numberOfRowsInSection(_ section: Int) -> Int {

--- a/Sources/Screens/Home/TabbedViewModel.swift
+++ b/Sources/Screens/Home/TabbedViewModel.swift
@@ -29,11 +29,7 @@ final class TabbedViewModel: NSObject, BaseViewModel {
         cellModels[section].count
     }
     
-    func didAppear() {
-        
-    }
+    func didAppear() { /* protocol conformance */ }
     
-    func didDismiss() {
-        
-    }
+    func didDismiss() { /* protocol conformance */ }
 }

--- a/Sources/Screens/Home/TabbedViewModel.swift
+++ b/Sources/Screens/Home/TabbedViewModel.swift
@@ -2,16 +2,31 @@ import GDSCommon
 import UIKit
 
 final class TabbedViewModel: NSObject, BaseViewModel {
-    var rightBarButtonTitle: GDSCommon.GDSLocalisedString?
+    var rightBarButtonTitle: GDSLocalisedString?
     var backButtonIsHidden: Bool
-    var title: String?
-    var dataSource: UITableViewDataSource?
     
-    init(rightBarButtonTitle: GDSCommon.GDSLocalisedString? = nil, backButtonIsHidden: Bool = true, title: String? = nil, dataSource: UITableViewDataSource? = nil) {
+    let navigationTitle: GDSLocalisedString?
+    let sectionHeaderTitles: [GDSLocalisedString]
+    let cellModels: [[TabbedViewCellModel]]
+    
+    init(rightBarButtonTitle: GDSLocalisedString? = nil,
+         backButtonIsHidden: Bool = true,
+         title: GDSLocalisedString? = nil,
+         sectionHeaderTitles: [GDSLocalisedString] = [GDSLocalisedString](),
+         cellModels: [[TabbedViewCellModel]] = [[TabbedViewCellModel]]()) {
         self.rightBarButtonTitle = rightBarButtonTitle
         self.backButtonIsHidden = backButtonIsHidden
-        self.title = title
-        self.dataSource = dataSource
+        self.navigationTitle = title
+        self.sectionHeaderTitles = sectionHeaderTitles
+        self.cellModels = cellModels
+    }
+    
+    var numberOfSections: Int {
+        sectionHeaderTitles.count > 0 ? sectionHeaderTitles.count : 1
+    }
+    
+    func numberOfRowsInSection(_ section: Int) -> Int {
+        cellModels[section].count
     }
     
     func didAppear() {
@@ -21,8 +36,4 @@ final class TabbedViewModel: NSObject, BaseViewModel {
     func didDismiss() {
         
     }
-}
-
-extension TabbedViewModel: UITableViewDelegate {
-    
 }

--- a/Sources/Screens/Home/TabbedViewModel.swift
+++ b/Sources/Screens/Home/TabbedViewModel.swift
@@ -1,9 +1,9 @@
 import GDSCommon
 import UIKit
 
-final class TabbedViewModel: NSObject, BaseViewModel {
-    var rightBarButtonTitle: GDSLocalisedString?
-    var backButtonIsHidden: Bool
+struct TabbedViewModel: BaseViewModel {
+    let rightBarButtonTitle: GDSLocalisedString?
+    let backButtonIsHidden: Bool
     
     let navigationTitle: GDSLocalisedString?
     let sectionHeaderTitles: [GDSLocalisedString]

--- a/Sources/Tabs/HomeCoordinator.swift
+++ b/Sources/Tabs/HomeCoordinator.swift
@@ -1,4 +1,5 @@
 import Coordination
+import GDSCommon
 import UIKit
 
 final class HomeCoordinator: NSObject,
@@ -8,15 +9,20 @@ final class HomeCoordinator: NSObject,
     var parentCoordinator: ParentCoordinator?
     var root = UINavigationController()
     private var accessToken: String?
-    private (set)var baseVc: TokensViewController?
+    private (set)var baseVc: TabbedViewController?
 
     func start() {
         let tokensViewModel = TokensViewModel {
             self.showDeveloperMenu()
         }
-        let tokensViewController = TokensViewController(viewModel: tokensViewModel)
-        baseVc = tokensViewController
-        root.setViewControllers([tokensViewController], animated: true)
+
+        let viewModel = TabbedViewModel(title: "app_homeTitle",
+                                        sectionHeaderTitles: [GDSLocalisedString(stringLiteral: "Developer Menu")],
+        cellModels: createCellModels())
+        let hc = TabbedViewController(viewModel: viewModel,
+                                      headerView: SignInView(viewModel: SignInViewModel()))
+        baseVc = hc
+        root.setViewControllers([hc], animated: true)
     }
     
     func updateToken(accessToken: String?) {
@@ -28,5 +34,12 @@ final class HomeCoordinator: NSObject,
         let developerMenuVC = DeveloperMenuViewController()
         navController.setViewControllers([developerMenuVC], animated: true)
         root.present(navController, animated: true)
+    }
+    
+    private func createCellModels() -> [[TabbedViewCellModel]] {
+        let developerModel = TabbedViewCellModel(cellTitle: GDSLocalisedString(stringLiteral: "Developer Menu")) {
+            self.showDeveloperMenu()
+        }
+        return [[developerModel]]
     }
 }

--- a/Sources/Tabs/HomeCoordinator.swift
+++ b/Sources/Tabs/HomeCoordinator.swift
@@ -16,9 +16,11 @@ final class HomeCoordinator: NSObject,
             self.showDeveloperMenu()
         }
 
+        
         let viewModel = TabbedViewModel(title: "app_homeTitle",
-                                        sectionHeaderTitles: [GDSLocalisedString(stringLiteral: "Developer Menu")],
-        cellModels: createCellModels())
+                                        sectionHeaderTitles: createSectionHeaders(),
+                                        cellModels: createCellModels())
+
         let hc = TabbedViewController(viewModel: viewModel,
                                       headerView: SignInView(viewModel: SignInViewModel()))
         baseVc = hc
@@ -37,9 +39,22 @@ final class HomeCoordinator: NSObject,
     }
     
     private func createCellModels() -> [[TabbedViewCellModel]] {
+        #if DEBUG
         let developerModel = TabbedViewCellModel(cellTitle: GDSLocalisedString(stringLiteral: "Developer Menu")) {
             self.showDeveloperMenu()
         }
+        #else
+        let developerModel = TabbedViewCellModel()
+        #endif
+        
         return [[developerModel]]
+    }
+    
+    private func createSectionHeaders() -> [GDSLocalisedString] {
+        #if DEBUG
+        [GDSLocalisedString(stringLiteral: "Developer Menu")]
+        #else
+        [GDSLocalisedString]()
+        #endif
     }
 }

--- a/Sources/Tabs/HomeCoordinator.swift
+++ b/Sources/Tabs/HomeCoordinator.swift
@@ -12,10 +12,6 @@ final class HomeCoordinator: NSObject,
     private (set)var baseVc: TabbedViewController?
 
     func start() {
-        let tokensViewModel = TokensViewModel {
-            self.showDeveloperMenu()
-        }
-
         
         let viewModel = TabbedViewModel(title: "app_homeTitle",
                                         sectionHeaderTitles: createSectionHeaders(),

--- a/Sources/Tabs/HomeCoordinator.swift
+++ b/Sources/Tabs/HomeCoordinator.swift
@@ -36,7 +36,7 @@ final class HomeCoordinator: NSObject,
     
     private func createCellModels() -> [[TabbedViewCellModel]] {
         #if DEBUG
-        let developerModel = TabbedViewCellModel(cellTitle: GDSLocalisedString(stringLiteral: "Developer Menu")) {
+        let developerModel = TabbedViewCellModel(cellTitle: "Developer Menu") {
             self.showDeveloperMenu()
         }
         #else
@@ -48,7 +48,7 @@ final class HomeCoordinator: NSObject,
     
     private func createSectionHeaders() -> [GDSLocalisedString] {
         #if DEBUG
-        [GDSLocalisedString(stringLiteral: "Developer Menu")]
+        ["Developer Menu"]
         #else
         [GDSLocalisedString]()
         #endif

--- a/Sources/Tabs/Views/TabbedTableViewCell.swift
+++ b/Sources/Tabs/Views/TabbedTableViewCell.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class TabbedTableViewCell: UITableViewCell {
+final class TabbedTableViewCell: UITableViewCell {
     var viewModel: TabbedViewCellModel? {
         didSet {
             textLabel?.text = viewModel?.cellTitle?.value

--- a/Sources/Tabs/Views/TabbedTableViewCell.swift
+++ b/Sources/Tabs/Views/TabbedTableViewCell.swift
@@ -8,16 +8,9 @@
 import UIKit
 
 class TabbedTableViewCell: UITableViewCell {
-
-    override func awakeFromNib() {
-        super.awakeFromNib()
-        // Initialization code
+    var viewModel: TabbedViewCellModel? {
+        didSet {
+            textLabel?.text = viewModel?.cellTitle?.value
+        }
     }
-
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
-    }
-
 }

--- a/Sources/Tabs/Views/TabbedTableViewCell.swift
+++ b/Sources/Tabs/Views/TabbedTableViewCell.swift
@@ -1,10 +1,3 @@
-//
-//  TabbedTableViewCell.swift
-//  OneLogin
-//
-//  Created by Dubey, Josh on 26/04/2024.
-//
-
 import UIKit
 
 class TabbedTableViewCell: UITableViewCell {

--- a/Sources/Tabs/Views/TabbedTableViewCell.swift
+++ b/Sources/Tabs/Views/TabbedTableViewCell.swift
@@ -1,0 +1,23 @@
+//
+//  TabbedTableViewCell.swift
+//  OneLogin
+//
+//  Created by Dubey, Josh on 26/04/2024.
+//
+
+import UIKit
+
+class TabbedTableViewCell: UITableViewCell {
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+
+}

--- a/Sources/Tabs/Views/TabbedViewCellModel.swift
+++ b/Sources/Tabs/Views/TabbedViewCellModel.swift
@@ -1,0 +1,8 @@
+//
+//  TabbedViewCellModel.swift
+//  OneLogin
+//
+//  Created by Dubey, Josh on 26/04/2024.
+//
+
+import Foundation

--- a/Sources/Tabs/Views/TabbedViewCellModel.swift
+++ b/Sources/Tabs/Views/TabbedViewCellModel.swift
@@ -2,8 +2,8 @@ import Foundation
 import GDSCommon
 
 struct TabbedViewCellModel {
-    var cellTitle: GDSLocalisedString?
-    var action: (() -> Void)?
+    let cellTitle: GDSLocalisedString?
+    let action: (() -> Void)?
     
     init(cellTitle: GDSLocalisedString? = nil, action: (() -> Void)? = nil) {
         self.cellTitle = cellTitle

--- a/Sources/Tabs/Views/TabbedViewCellModel.swift
+++ b/Sources/Tabs/Views/TabbedViewCellModel.swift
@@ -1,8 +1,12 @@
-//
-//  TabbedViewCellModel.swift
-//  OneLogin
-//
-//  Created by Dubey, Josh on 26/04/2024.
-//
-
 import Foundation
+import GDSCommon
+
+struct TabbedViewCellModel {
+    var cellTitle: GDSLocalisedString?
+    var action: (() -> Void)?
+    
+    init(cellTitle: GDSLocalisedString? = nil, action: (() -> Void)? = nil) {
+        self.cellTitle = cellTitle
+        self.action = action
+    }
+}

--- a/Sources/Tabs/Views/TabbedViewSectionHeader.swift
+++ b/Sources/Tabs/Views/TabbedViewSectionHeader.swift
@@ -1,20 +1,21 @@
-//
-//  TabbedViewSectionHeader.swift
-//  OneLogin
-//
-//  Created by Dubey, Josh on 26/04/2024.
-//
-
+import GDSCommon
 import UIKit
 
-class TabbedViewSectionHeader: UIView {
-
-    /*
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        // Drawing code
+class TabbedViewSectionHeader: NibView {
+    private let title: GDSLocalisedString?
+    init(title: GDSLocalisedString? = nil) {
+        self.title = title
+        super.init()
     }
-    */
-
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    @IBOutlet private var sectionTitleLabel: UILabel! {
+        didSet {
+            sectionTitleLabel.font = .bodyBold
+            sectionTitleLabel.text = title?.value
+        }
+    }
 }

--- a/Sources/Tabs/Views/TabbedViewSectionHeader.swift
+++ b/Sources/Tabs/Views/TabbedViewSectionHeader.swift
@@ -1,7 +1,7 @@
 import GDSCommon
 import UIKit
 
-class TabbedViewSectionHeader: NibView {
+final class TabbedViewSectionHeader: NibView {
     private let title: GDSLocalisedString?
     init(title: GDSLocalisedString? = nil) {
         self.title = title

--- a/Sources/Tabs/Views/TabbedViewSectionHeader.swift
+++ b/Sources/Tabs/Views/TabbedViewSectionHeader.swift
@@ -1,0 +1,20 @@
+//
+//  TabbedViewSectionHeader.swift
+//  OneLogin
+//
+//  Created by Dubey, Josh on 26/04/2024.
+//
+
+import UIKit
+
+class TabbedViewSectionHeader: UIView {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/Sources/Tabs/Views/TabbedViewSectionHeader.xib
+++ b/Sources/Tabs/Views/TabbedViewSectionHeader.xib
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+        </view>
+    </objects>
+</document>

--- a/Sources/Tabs/Views/TabbedViewSectionHeader.xib
+++ b/Sources/Tabs/Views/TabbedViewSectionHeader.xib
@@ -1,18 +1,60 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="TabbedViewSectionHeader" customModule="OneLogin" customModuleProvider="target">
+            <connections>
+                <outlet property="sectionTitleLabel" destination="YYi-tZ-DVs" id="FAM-9F-pIL"/>
+            </connections>
+        </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <subviews>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="H9o-6P-jJu">
+                    <rect key="frame" x="20" y="59" width="373" height="759"/>
+                    <subviews>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eKt-TD-WD8">
+                            <rect key="frame" x="0.0" y="0.0" width="373" height="16"/>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="16" id="aNp-7i-hPf"/>
+                            </constraints>
+                        </view>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YYi-tZ-DVs">
+                            <rect key="frame" x="0.0" y="16" width="373" height="735"/>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qQt-u1-mhn">
+                            <rect key="frame" x="0.0" y="751" width="373" height="8"/>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="8" id="pCd-cv-4Ih"/>
+                            </constraints>
+                        </view>
+                    </subviews>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                </stackView>
+            </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <constraints>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="H9o-6P-jJu" secondAttribute="trailing" id="3a6-W4-PrA"/>
+                <constraint firstItem="H9o-6P-jJu" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="20" id="7Wn-fe-g6G"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="H9o-6P-jJu" secondAttribute="bottom" id="8ZJ-hl-Ssr"/>
+                <constraint firstItem="H9o-6P-jJu" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="cfj-EX-MvC"/>
+            </constraints>
+            <point key="canvasLocation" x="-170" y="-11"/>
         </view>
     </objects>
 </document>

--- a/Sources/Views/Components/SignInView.swift
+++ b/Sources/Views/Components/SignInView.swift
@@ -15,8 +15,8 @@ class SignInView: NibView {
     
     @IBOutlet private var emailLabel: UILabel! {
         didSet {
-            guard let emailLabel else { return }
             emailLabel.attributedText = attributedEmailString
+            emailLabel.accessibilityIdentifier = "signin-view-email-label"
         }
     }
     

--- a/Sources/Views/Components/SignInView.swift
+++ b/Sources/Views/Components/SignInView.swift
@@ -1,7 +1,7 @@
 import GDSCommon
 import UIKit
 
-class SignInView: NibView {
+final class SignInView: NibView {
 
     var viewModel: SignInViewModel
     init(viewModel: SignInViewModel) {

--- a/Sources/Views/Components/SignInView.swift
+++ b/Sources/Views/Components/SignInView.swift
@@ -1,0 +1,13 @@
+import GDSCommon
+import UIKit
+
+class SignInView: NibView {
+
+    init() {
+        super.init(forcedNibName: "SignInView", bundle: nil)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Sources/Views/Components/SignInView.swift
+++ b/Sources/Views/Components/SignInView.swift
@@ -3,11 +3,32 @@ import UIKit
 
 class SignInView: NibView {
 
-    init() {
+    var viewModel: SignInViewModel
+    init(viewModel: SignInViewModel) {
+        self.viewModel = viewModel
         super.init(forcedNibName: "SignInView", bundle: nil)
     }
     
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    @IBOutlet private var emailLabel: UILabel! {
+        didSet {
+            guard let emailLabel else { return }
+            emailLabel.attributedText = attributedEmailString
+        }
+    }
+    
+    func updateEmail(_ email: String) {
+        viewModel.userEmail = email
+        emailLabel.attributedText = attributedEmailString
+    }
+    
+    private var attributedEmailString: NSAttributedString? {
+        guard let email = viewModel.userEmail else { return nil }
+        return GDSLocalisedString(stringKey: "app_displayEmail",
+                                  email,
+                                  attributes: [(email, [.font: UIFont.bodyBold])]).attributedValue
     }
 }

--- a/Sources/Views/Components/SignInView.xib
+++ b/Sources/Views/Components/SignInView.xib
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="8in-tw-f79">
+                    <rect key="frame" x="0.0" y="59" width="393" height="759"/>
+                    <subviews>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XUr-uo-Fnn">
+                            <rect key="frame" x="0.0" y="8" width="393" height="1"/>
+                            <color key="backgroundColor" systemColor="systemGray5Color"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="1" id="Afu-hP-iNK"/>
+                            </constraints>
+                        </view>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="7b3-3r-wlx">
+                            <rect key="frame" x="0.0" y="17" width="393" height="725"/>
+                            <subviews>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QLj-Oo-23b">
+                                    <rect key="frame" x="16" y="8" width="361" height="709"/>
+                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                            </subviews>
+                            <edgeInsets key="layoutMargins" top="8" left="16" bottom="8" right="16"/>
+                        </stackView>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dus-Ap-mP8">
+                            <rect key="frame" x="0.0" y="750" width="393" height="1"/>
+                            <color key="backgroundColor" systemColor="systemGray5Color"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="1" id="8we-Kv-7vT"/>
+                            </constraints>
+                        </view>
+                    </subviews>
+                    <viewLayoutGuide key="safeArea" id="v3x-ux-dhh"/>
+                    <edgeInsets key="layoutMargins" top="8" left="0.0" bottom="8" right="0.0"/>
+                </stackView>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="8in-tw-f79" secondAttribute="trailing" id="Ded-WI-ygk"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="8in-tw-f79" secondAttribute="bottom" id="Gs5-Jf-vgK"/>
+                <constraint firstItem="8in-tw-f79" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="nXO-Er-dHC"/>
+                <constraint firstItem="8in-tw-f79" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="o7J-Jj-ZGd"/>
+            </constraints>
+            <point key="canvasLocation" x="-94" y="20"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGray5Color">
+            <color red="0.8980392157" green="0.8980392157" blue="0.91764705879999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Sources/Views/Components/SignInView.xib
+++ b/Sources/Views/Components/SignInView.xib
@@ -9,7 +9,11 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SignInView" customModule="OneLogin" customModuleProvider="target">
+            <connections>
+                <outlet property="emailLabel" destination="QLj-Oo-23b" id="EyE-60-ID8"/>
+            </connections>
+        </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
             <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
@@ -28,14 +32,14 @@
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="7b3-3r-wlx">
                             <rect key="frame" x="0.0" y="17" width="393" height="725"/>
                             <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QLj-Oo-23b">
-                                    <rect key="frame" x="16" y="8" width="361" height="709"/>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QLj-Oo-23b">
+                                    <rect key="frame" x="20" y="8" width="357" height="709"/>
                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                             </subviews>
-                            <edgeInsets key="layoutMargins" top="8" left="16" bottom="8" right="16"/>
+                            <edgeInsets key="layoutMargins" top="8" left="20" bottom="8" right="16"/>
                         </stackView>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dus-Ap-mP8">
                             <rect key="frame" x="0.0" y="750" width="393" height="1"/>
@@ -50,7 +54,7 @@
                 </stackView>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
-            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <color key="backgroundColor" systemColor="systemGroupedBackgroundColor"/>
             <constraints>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="8in-tw-f79" secondAttribute="trailing" id="Ded-WI-ygk"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="8in-tw-f79" secondAttribute="bottom" id="Gs5-Jf-vgK"/>
@@ -61,11 +65,11 @@
         </view>
     </objects>
     <resources>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
         <systemColor name="systemGray5Color">
             <color red="0.8980392157" green="0.8980392157" blue="0.91764705879999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemGroupedBackgroundColor">
+            <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Sources/Views/Components/SignInViewModel.swift
+++ b/Sources/Views/Components/SignInViewModel.swift
@@ -1,0 +1,8 @@
+//
+//  SignInViewModel.swift
+//  OneLogin
+//
+//  Created by Dubey, Josh on 26/04/2024.
+//
+
+import Foundation

--- a/Sources/Views/Components/SignInViewModel.swift
+++ b/Sources/Views/Components/SignInViewModel.swift
@@ -1,8 +1,5 @@
-//
-//  SignInViewModel.swift
-//  OneLogin
-//
-//  Created by Dubey, Josh on 26/04/2024.
-//
+import GDSCommon
 
-import Foundation
+struct SignInViewModel {
+    var userEmail: String?
+}

--- a/Tests/UITests/LoginUITests.swift
+++ b/Tests/UITests/LoginUITests.swift
@@ -39,8 +39,8 @@ extension LoginUITests {
         XCTAssertEqual(loginModal.title.label, "Welcome to the Auth Stub")
         XCTAssertEqual(loginModal.loginButton.label, "Login")
         // Select 'Login' Button
-        let tokensScreen = loginModal.tapBrowserLoginButton()
-        XCTAssertEqual(tokensScreen.title.label, "Logged in ")
+        let homeScreen = loginModal.tapBrowserLoginButton()
+        XCTAssertEqual(homeScreen.title.label, "Home")
     }
     
     func test_loginCancelPath() throws {

--- a/Tests/UITests/ScreenObjects/App/HomeScreen.swift
+++ b/Tests/UITests/ScreenObjects/App/HomeScreen.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-struct TokensScreen: ScreenObject {
+struct HomeScreen: ScreenObject {
     let app: XCUIApplication
     
     var view: XCUIElement {
@@ -8,6 +8,6 @@ struct TokensScreen: ScreenObject {
     }
     
     var title: XCUIElement {
-        app.staticTexts["logged-in-title"]
+        return app.navigationBars.staticTexts.firstMatch
     }
 }

--- a/Tests/UITests/ScreenObjects/App/LoginModal.swift
+++ b/Tests/UITests/ScreenObjects/App/LoginModal.swift
@@ -39,10 +39,10 @@ struct LoginModal: ScreenObject {
         cancelButton.tap()
     }
     
-    func tapBrowserLoginButton() -> TokensScreen {
+    func tapBrowserLoginButton() -> HomeScreen {
         loginButton.tap()
         
-        return TokensScreen(app: app).waitForAppearance()
+        return HomeScreen(app: app).waitForAppearance()
     }
     
     func tapBrowserRedirectWithOAuthErrorButton() -> ErrorScreen {

--- a/Tests/UnitTests/Login/HomeCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/HomeCoordinatorTests.swift
@@ -30,8 +30,8 @@ final class HomeCoordinatorTests: XCTestCase {
     func test_updateToken() throws {
         sut.start()
         let vc = try XCTUnwrap(sut.baseVc)
-        XCTAssertEqual(try vc.accessTokenLabel.text, "Access Token: ")
+        XCTAssertEqual(try vc.emailLabel.text, nil)
         sut.updateToken(accessToken: "testAccessToken")
-        XCTAssertEqual(try vc.accessTokenLabel.text, "Access Token: testAccessToken")
+        XCTAssertEqual(try vc.emailLabel.text, "You’re signed in as\nsarahelizabeth_1991@gmail.com")
     }
 }

--- a/Tests/UnitTests/Screens/TabbedViewControllerTests.swift
+++ b/Tests/UnitTests/Screens/TabbedViewControllerTests.swift
@@ -1,29 +1,54 @@
+import GDSCommon
 @testable import OneLogin
 import XCTest
 
 final class TabbedViewControllerTests: XCTestCase {
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+    var sut: TabbedViewController!
+    var viewModel: TabbedViewModel!
+    
+    private var didTapRow = false
+    
+    override func setUp() {
+        viewModel = TabbedViewModel(sectionHeaderTitles: createSectionHeaders(),
+        cellModels: createCellModels())
+        sut = TabbedViewController(viewModel: viewModel, headerView: UIView())
+        sut.loadViewIfNeeded()
+
     }
 
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    override func tearDown() {
+        sut = nil
+        viewModel = nil
+        didTapRow = false
     }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    
+    func test_numberOfSections() {
+        XCTAssertEqual(sut.numberOfSections(in: try sut.tabbedTableView), 1)
     }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
+    
+    func test_numberOfRows() {
+        XCTAssertEqual(sut.tableView(try sut.tabbedTableView, numberOfRowsInSection: 0), 1)
+    }
+    
+    func test_rowSelected() throws {
+        XCTAssertFalse(didTapRow)
+        let indexPath = IndexPath(row: 0, section: 0)
+        try sut.tabbedTableView.reloadData()
+        sut.tableView(try XCTUnwrap(sut.tabbedTableView), didSelectRowAt: indexPath)
+        XCTAssertTrue(didTapRow)
+    }
+    
+    private func createCellModels() -> [[TabbedViewCellModel]] {
+        let testModel = TabbedViewCellModel(cellTitle: GDSLocalisedString(stringLiteral: "Test Cell")) {
+            self.didTapRow = true
         }
+        
+        return [[testModel]]
+    }
+    
+    private func createSectionHeaders() -> [GDSLocalisedString] {
+        [GDSLocalisedString(stringLiteral: "Test Header")]
     }
 
 }
@@ -32,6 +57,12 @@ extension TabbedViewController {
     var emailLabel: UILabel {
         get throws {
             try XCTUnwrap(view[child: "signin-view-email-label"])
+        }
+    }
+    
+    var tabbedTableView: UITableView {
+        get throws {
+            try XCTUnwrap(view[child: "tabbed-view-table-view"])
         }
     }
 }

--- a/Tests/UnitTests/Screens/TabbedViewControllerTests.swift
+++ b/Tests/UnitTests/Screens/TabbedViewControllerTests.swift
@@ -1,0 +1,37 @@
+@testable import OneLogin
+import XCTest
+
+final class TabbedViewControllerTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}
+
+extension TabbedViewController {
+    var emailLabel: UILabel {
+        get throws {
+            try XCTUnwrap(view[child: "signin-view-email-label"])
+        }
+    }
+}


### PR DESCRIPTION
# DCMAW-8725:  iOS | Create UI framework for the home & profile pages, and add to home tab

Create a new TabbedViewController, that holds a tableview of grouped inset style.
Create a header view to hold the user's email address.
Create supporting view models, etc., in anticipation of populating Home and Profile tabs.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
