### PR TITLE
fix: dcmaw-8998 app crash when timing out face id prompt 

### DIFF
--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-common.git",
       "state" : {
-        "revision" : "b1fb09e5b1a30c48a53bc421f1c3619ae3edab46",
-        "version" : "1.8.1"
+        "revision" : "8e3c771b08d657b9947f1f67cc3f02bd12dfe8c2",
+        "version" : "1.8.2"
       }
     },
     {

--- a/Sources/Application/SceneLifecycle.swift
+++ b/Sources/Application/SceneLifecycle.swift
@@ -18,7 +18,7 @@ extension SceneLifecycle {
     }
     
     func promptToUnlock() {
-        coordinator?.evaluateRevisit {
+        coordinator?.evaluateRevisit { [unowned self] in
             windowManager?.hideUnlockWindow()
         }
     }

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -53,19 +53,23 @@ final class LoginCoordinator: NSObject,
     }
     
     func getAccessToken() {
-        do {
-            tokenHolder.accessToken = try userStore.secureStoreService.readItem(itemName: .accessToken)
-            windowManager.hideUnlockWindow()
-            root.dismiss(animated: true)
-            finish()
-        } catch SecureStoreError.unableToRetrieveFromUserDefaults,
-                SecureStoreError.cantInitialiseData,
-                SecureStoreError.cantRetrieveKey {
-            userStore.refreshStorage(accessControlLevel: LAContext().isPasscodeOnly ? .anyBiometricsOrPasscode : .currentBiometricsOrPasscode)
-            windowManager.hideUnlockWindow()
-            start()
-        } catch {
-            print("Local Authentication error: \(error)")
+        Task {
+            await MainActor.run {
+                do {
+                    tokenHolder.accessToken = try userStore.secureStoreService.readItem(itemName: .accessToken)
+                    windowManager.hideUnlockWindow()
+                    root.dismiss(animated: true)
+                    finish()
+                } catch SecureStoreError.unableToRetrieveFromUserDefaults,
+                        SecureStoreError.cantInitialiseData,
+                        SecureStoreError.cantRetrieveKey {
+                    userStore.refreshStorage(accessControlLevel: LAContext().isPasscodeOnly ? .anyBiometricsOrPasscode : .currentBiometricsOrPasscode)
+                    windowManager.hideUnlockWindow()
+                    start()
+                } catch {
+                    print("Local Authentication error: \(error)")
+                }
+            }
         }
     }
     

--- a/Tests/UnitTests/Application/MainCoordinatorTests.swift
+++ b/Tests/UnitTests/Application/MainCoordinatorTests.swift
@@ -71,27 +71,27 @@ extension MainCoordinatorTests {
         try mockSecureStore.saveItem(item: "testAccessToken", itemName: .accessToken)
         mockDefaultStore.set(Date() + 60, forKey: .accessTokenExpiry)
         // WHEN the MainCoordinator's evaluateRevisit method is called with an action
-        sut.evaluateRevisit { evaluateRevisitActionCalled = true }
+        sut.evaluateRevisit { self.evaluateRevisitActionCalled = true }
         // THEN the access token is read from the token holder and the action is called
-        XCTAssertEqual(sut.tokenHolder.accessToken, "testAccessToken")
+        waitForTruth(self.sut.tokenHolder.accessToken == "testAccessToken", timeout: 20)
         XCTAssertTrue(evaluateRevisitActionCalled)
     }
     
     func test_evaluateRevisit_accessTokenNil() throws {
         // GIVEN access token has not been stored anywhere
         // WHEN the MainCoordinator's evaluateRevisit method is called with an action
-        sut.evaluateRevisit { evaluateRevisitActionCalled = true }
+        sut.evaluateRevisit { self.evaluateRevisitActionCalled = true }
         // THEN the action is called
-        XCTAssertTrue(evaluateRevisitActionCalled)
+        waitForTruth(self.evaluateRevisitActionCalled == true, timeout: 20)
     }
     
     func test_evaluateRevisit_accessTokenNotNil() throws {
         // GIVEN access token has been stored in the token holder
         sut.tokenHolder.accessToken = "testAccessToken"
         // WHEN the MainCoordinator's evaluateRevisit method is called with an action
-        sut.evaluateRevisit { evaluateRevisitActionCalled = true }
+        sut.evaluateRevisit { self.evaluateRevisitActionCalled = true }
         // THEN the access token is removed from the token holder and the action is called
-        XCTAssertNil(sut.tokenHolder.accessToken)
+        waitForTruth(self.sut.tokenHolder.accessToken == nil, timeout: 20)
         XCTAssertTrue(evaluateRevisitActionCalled)
     }
     

--- a/Tests/UnitTests/Application/SceneLifecycleTests.swift
+++ b/Tests/UnitTests/Application/SceneLifecycleTests.swift
@@ -58,7 +58,7 @@ extension SceneLifecycleTests {
     
     func test_promptToUnlock() throws {
         sut.promptToUnlock()
-        XCTAssertTrue(mockWindowManager.hideUnlockWindowCalled)
+        waitForTruth(self.mockWindowManager.hideUnlockWindowCalled == true, timeout: 20)
     }
     
     func test_splashscreen_analytics() throws {

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -123,7 +123,7 @@ extension LoginCoordinatorTests {
         // WHEN the LoginCoordinator's returningUserFlow method is called
         sut.returningUserFlow()
         // THEN the token holder's access token property should get the access token from secure store
-        XCTAssertTrue(mockWindowManager.hideUnlockWindowCalled)
+        waitForTruth(self.mockWindowManager.hideUnlockWindowCalled == true, timeout: 20)
         XCTAssertEqual(sut.tokenHolder.accessToken, "123456789")
     }
     
@@ -134,7 +134,7 @@ extension LoginCoordinatorTests {
         // WHEN the LoginCoordinator is started
         sut.start()
         // THEN the token holder's access token property should get the access token from secure store
-        XCTAssertTrue(mockWindowManager.hideUnlockWindowCalled)
+        waitForTruth(self.mockWindowManager.hideUnlockWindowCalled == true, timeout: 20)
         XCTAssertEqual(sut.tokenHolder.accessToken, "123456789")
     }
     
@@ -152,7 +152,7 @@ extension LoginCoordinatorTests {
         // WHEN the LoginCoordinator's getAccessToken method is called
         sut.getAccessToken()
         // THEN the token holder's access token property should get the access token from secure store
-        XCTAssertTrue(mockWindowManager.hideUnlockWindowCalled)
+        waitForTruth(self.mockWindowManager.hideUnlockWindowCalled == true, timeout: 20)
         XCTAssertEqual(sut.tokenHolder.accessToken, "123456789")
     }
     
@@ -162,7 +162,7 @@ extension LoginCoordinatorTests {
         // WHEN the LoginCoordinator's getAccessToken method is called
         sut.getAccessToken()
         // THEN the token holder's access token property should not get the access token from secure store
-        XCTAssertEqual(sut.tokenHolder.accessToken, nil)
+        waitForTruth(self.sut.tokenHolder.accessToken == nil, timeout: 20)
         // THEN user store should be refreshed
         XCTAssertTrue(mockSecureStore.didCallDeleteStore)
         XCTAssertNil(mockDefaultStore.savedData[.accessTokenExpiry])
@@ -177,7 +177,7 @@ extension LoginCoordinatorTests {
         // WHEN the LoginCoordinator's getAccessToken method is called
         sut.getAccessToken()
         // THEN the token holder's access token property should not get the access token from secure store
-        XCTAssertEqual(sut.tokenHolder.accessToken, nil)
+        waitForTruth(self.sut.tokenHolder.accessToken == nil, timeout: 20)
         // THEN user store should be refreshed
         XCTAssertTrue(mockSecureStore.didCallDeleteStore)
         XCTAssertNil(mockDefaultStore.savedData[.accessTokenExpiry])
@@ -192,7 +192,7 @@ extension LoginCoordinatorTests {
         // WHEN the LoginCoordinator's getAccessToken method is called
         sut.getAccessToken()
         // THEN the token holder's access token property should not get the access token from secure store
-        XCTAssertEqual(sut.tokenHolder.accessToken, nil)
+        waitForTruth(self.sut.tokenHolder.accessToken == nil, timeout: 20)
         // THEN user store should be refreshed
         XCTAssertTrue(mockSecureStore.didCallDeleteStore)
         XCTAssertNil(mockDefaultStore.savedData[.accessTokenExpiry])


### PR DESCRIPTION
# DCMAW-8998: iOS | App Crash when timing out FaceID Prompt

Wait for biometric verification asynchronously.  This prevents it from blocking the main thread, which was causing the OS to kill the app due to unresponsiveness.

Also snuck in fix for repeated tabs appearing when the user returned the app to the foreground after the access token had expired

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review  

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~~- [ ] Met all accessibility requirements?~~
    ~~- [ ] Checked dynamic type sizes are applied~~
    ~~- [ ] Checked VoiceOver can navigate your new code~~
    ~~- [ ] Checked a user can navigate only using a keyboard around your new code~~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
