### PR TITLE
fix: dcmaw-8935-returning-user-boot-unlock-issue

### DIFF
--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -47,8 +47,7 @@ final class MainCoordinator: NSObject,
                     do {
                         tokenHolder.accessToken = try userStore.secureStoreService.readItem(itemName: .accessToken)
                         loginCoordinator?.root.dismiss(animated: false)
-                        loginCoordinator?.finish()
-                        homeCoordinator?.updateToken(accessToken: tokenHolder.accessToken)
+                        updateToken()
                         action()
                     } catch {
                         print("Error getting token: \(error)")
@@ -100,6 +99,13 @@ extension MainCoordinator {
         addTab(pc)
         profileCoordinator = pc
     }
+    
+    private func updateToken() {
+        homeCoordinator?.updateToken(accessToken: tokenHolder.accessToken)
+        profileCoordinator?.updateToken(accessToken: tokenHolder.accessToken)
+        networkClient = NetworkClient(authenticationProvider: tokenHolder)
+        homeCoordinator?.networkClient = networkClient
+    }
 }
 
 extension MainCoordinator: UITabBarControllerDelegate {
@@ -128,10 +134,7 @@ extension MainCoordinator: ParentCoordinator {
     func didRegainFocus(fromChild child: ChildCoordinator?) {
         switch child {
         case _ as LoginCoordinator:
-            homeCoordinator?.updateToken(accessToken: tokenHolder.accessToken)
-            profileCoordinator?.updateToken(accessToken: tokenHolder.accessToken)
-            networkClient = NetworkClient(authenticationProvider: tokenHolder)
-            homeCoordinator?.networkClient = networkClient
+            updateToken()
         default:
             break
         }

--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -46,6 +46,8 @@ final class MainCoordinator: NSObject,
                 if userStore.returningAuthenticatedUser {
                     do {
                         tokenHolder.accessToken = try userStore.secureStoreService.readItem(itemName: .accessToken)
+                        loginCoordinator?.root.dismiss(animated: false)
+                        loginCoordinator?.finish()
                         homeCoordinator?.updateToken(accessToken: tokenHolder.accessToken)
                         action()
                     } catch {

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -58,7 +58,7 @@ final class LoginCoordinator: NSObject,
                 do {
                     tokenHolder.accessToken = try userStore.secureStoreService.readItem(itemName: .accessToken)
                     windowManager.hideUnlockWindow()
-                    root.dismiss(animated: true)
+                    root.dismiss(animated: false)
                     finish()
                 } catch SecureStoreError.unableToRetrieveFromUserDefaults,
                         SecureStoreError.cantInitialiseData,


### PR DESCRIPTION
# DCMAW-8935: Returning user app boot Unlock issue

Fixes an issue where the login view was not dismissed if the app was sent to the background before the user re-authenticated with local auth - in this case by causing the local auth to fail.  This caused a mostly invisible nav controller to overaly the tabs, preventing user interaction.
Now when the app returns from the background and local auth is attempted, the login coordinator will dismiss it's root view controller if local auth is successful

Also changed this dismissal to be non-animated to remove a visual artifact

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~~- [ ] Met all accessibility requirements?~~
    ~~- [ ] Checked dynamic type sizes are applied~~
    ~~- [ ] Checked VoiceOver can navigate your new code~~
    ~~- [ ] Checked a user can navigate only using a keyboard around your new code~~ 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
