### PR TITLE
feat: disable/enable sign in buttton

### DIFF
--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-common.git",
       "state" : {
-        "revision" : "8e3c771b08d657b9947f1f67cc3f02bd12dfe8c2",
-        "version" : "1.8.2"
+        "revision" : "8252c23731c621c05366e6861e21e35f2837926f",
+        "version" : "1.9.4"
       }
     },
     {

--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -15,8 +15,8 @@ final class MainCoordinator: NSObject,
     let tokenHolder = TokenHolder()
     var networkClient: NetworkClient?
     private weak var loginCoordinator: LoginCoordinator?
-    private weak var homeCoordinator: HomeCoordinator?
-    private weak var profileCoordinator: ProfileCoordinator?
+    private unowned var homeCoordinator: HomeCoordinator?
+    private unowned var profileCoordinator: ProfileCoordinator?
     
     init(windowManager: WindowManagement,
          root: UITabBarController,

--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -14,9 +14,9 @@ final class MainCoordinator: NSObject,
     let userStore: UserStorable
     let tokenHolder = TokenHolder()
     var networkClient: NetworkClient?
-    private weak var loginCoordinator: LoginCoordinator?
-    private unowned var homeCoordinator: HomeCoordinator?
-    private unowned var profileCoordinator: ProfileCoordinator?
+    private var loginCoordinator: LoginCoordinator?
+    private var homeCoordinator: HomeCoordinator?
+    private var profileCoordinator: ProfileCoordinator?
     
     init(windowManager: WindowManagement,
          root: UITabBarController,

--- a/Sources/Login/AuthenticationCoordinator.swift
+++ b/Sources/Login/AuthenticationCoordinator.swift
@@ -7,7 +7,7 @@ final class AuthenticationCoordinator: NSObject,
                                        ChildCoordinator,
                                        NavigationCoordinator {
     let root: UINavigationController
-    var parentCoordinator: ParentCoordinator?
+    weak var parentCoordinator: ParentCoordinator?
     let session: LoginSession
     let analyticsService: AnalyticsService
     let errorPresenter = ErrorPresenter.self

--- a/Sources/Login/AuthenticationCoordinator.swift
+++ b/Sources/Login/AuthenticationCoordinator.swift
@@ -67,6 +67,9 @@ final class AuthenticationCoordinator: NSObject,
     
     func handleUniversalLink(_ url: URL) {
         do {
+            if let loginCoordinator = parentCoordinator as? LoginCoordinator {
+                loginCoordinator.introViewController?.enableIntroButton()
+            }
             try session.finalise(redirectURL: url)
         } catch {
             let genericErrorScreen = errorPresenter

--- a/Sources/Login/EnrolmentCoordinator.swift
+++ b/Sources/Login/EnrolmentCoordinator.swift
@@ -8,7 +8,7 @@ final class EnrolmentCoordinator: NSObject,
                                   ChildCoordinator,
                                   NavigationCoordinator {
     let root: UINavigationController
-    var parentCoordinator: ParentCoordinator?
+    weak var parentCoordinator: ParentCoordinator?
     let analyticsService: AnalyticsService
     let userStore: UserStorable
     var localAuth: LAContexting

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -21,7 +21,7 @@ final class LoginCoordinator: NSObject,
     private let viewControllerFactory = OnboardingViewControllerFactory.self
     private let errorPresenter = ErrorPresenter.self
     private unowned var authCoordinator: AuthenticationCoordinator?
-    private unowned var introViewController: IntroViewController?
+    unowned var introViewController: IntroViewController?
     
     init(windowManager: WindowManagement,
          root: UINavigationController,
@@ -83,6 +83,7 @@ final class LoginCoordinator: NSObject,
                 } else {
                     let networkErrorScreen = errorPresenter
                         .createNetworkConnectionError(analyticsService: analyticsCenter.analyticsService) { [unowned self] in
+                            introViewController?.enableIntroButton()
                             root.popViewController(animated: true)
                             if networkMonitor.isConnected {
                                 launchAuthenticationCoordinator()

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -1,5 +1,6 @@
 import Authentication
 import Coordination
+import GDSCommon
 import LocalAuthentication
 import Logging
 import SecureStore
@@ -19,7 +20,8 @@ final class LoginCoordinator: NSObject,
     let tokenHolder: TokenHolder
     private let viewControllerFactory = OnboardingViewControllerFactory.self
     private let errorPresenter = ErrorPresenter.self
-    private weak var authCoordinator: AuthenticationCoordinator?
+    private unowned var authCoordinator: AuthenticationCoordinator?
+    private unowned var introViewController: IntroViewController?
     
     init(windowManager: WindowManagement,
          root: UINavigationController,
@@ -90,6 +92,7 @@ final class LoginCoordinator: NSObject,
                 }
             }
         root.setViewControllers([rootViewController], animated: true)
+        introViewController = rootViewController
         launchOnboardingCoordinator()
     }
     
@@ -106,7 +109,7 @@ final class LoginCoordinator: NSObject,
                                            analyticsService: analyticsCenter.analyticsService,
                                            tokenHolder: tokenHolder)
         openChildInline(ac)
-        self.authCoordinator = ac
+        authCoordinator = ac
     }
     
     func handleUniversalLink(_ url: URL) {
@@ -128,6 +131,7 @@ extension LoginCoordinator: ParentCoordinator {
         case _ as OnboardingCoordinator:
             return
         case let child as AuthenticationCoordinator where child.loginError != nil:
+            introViewController?.enableIntroButton()
             return
         case let child as AuthenticationCoordinator where child.loginError == nil:
             launchEnrolmentCoordinator(localAuth: LAContext())

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -12,7 +12,7 @@ final class LoginCoordinator: NSObject,
                               ChildCoordinator {
     let windowManager: WindowManagement
     let root: UINavigationController
-    var parentCoordinator: ParentCoordinator?
+    weak var parentCoordinator: ParentCoordinator?
     var childCoordinators = [ChildCoordinator]()
     let analyticsCenter: AnalyticsCentral
     let networkMonitor: NetworkMonitoring
@@ -20,8 +20,8 @@ final class LoginCoordinator: NSObject,
     let tokenHolder: TokenHolder
     private let viewControllerFactory = OnboardingViewControllerFactory.self
     private let errorPresenter = ErrorPresenter.self
-    private unowned var authCoordinator: AuthenticationCoordinator?
-    unowned var introViewController: IntroViewController?
+    private var authCoordinator: AuthenticationCoordinator?
+    var introViewController: IntroViewController?
     
     init(windowManager: WindowManagement,
          root: UINavigationController,

--- a/Sources/Login/OnboardingCoordinator.swift
+++ b/Sources/Login/OnboardingCoordinator.swift
@@ -7,7 +7,7 @@ final class OnboardingCoordinator: NSObject,
                                    AnyCoordinator,
                                    ChildCoordinator {
     let root = UINavigationController()
-    var parentCoordinator: ParentCoordinator?
+    weak var parentCoordinator: ParentCoordinator?
     private var analyticsPreferenceStore: AnalyticsPreferenceStore
     private let urlOpener: URLOpener
     private let viewControllerFactory = OnboardingViewControllerFactory.self

--- a/Sources/Tabs/HomeCoordinator.swift
+++ b/Sources/Tabs/HomeCoordinator.swift
@@ -7,7 +7,7 @@ final class HomeCoordinator: NSObject,
                              AnyCoordinator,
                              ChildCoordinator,
                              NavigationCoordinator {
-    var parentCoordinator: ParentCoordinator?
+    weak var parentCoordinator: ParentCoordinator?
     let root = UINavigationController()
     let analyticsService: AnalyticsService
     var networkClient: RequestAuthorizing?

--- a/Sources/Tabs/ProfileCoordinator.swift
+++ b/Sources/Tabs/ProfileCoordinator.swift
@@ -7,11 +7,11 @@ final class ProfileCoordinator: NSObject,
                                 AnyCoordinator,
                                 ChildCoordinator,
                                 NavigationCoordinator {
-    var parentCoordinator: ParentCoordinator?
+    weak var parentCoordinator: ParentCoordinator?
     let root = UINavigationController()
     let analyticsService: AnalyticsService
     private let urlOpener: URLOpener
-    private (set)var baseVc: TabbedViewController?
+    private(set) var baseVc: TabbedViewController?
     
     init(analyticsService: AnalyticsService,
          urlOpener: URLOpener,

--- a/Sources/Tabs/WalletCoordinator.swift
+++ b/Sources/Tabs/WalletCoordinator.swift
@@ -6,7 +6,7 @@ final class WalletCoordinator: NSObject,
                                AnyCoordinator,
                                ChildCoordinator,
                                NavigationCoordinator {
-    var parentCoordinator: ParentCoordinator?
+    weak var parentCoordinator: ParentCoordinator?
     let root = UINavigationController()
     
     func start() {

--- a/Tests/UnitTests/Login/AuthenticationCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/AuthenticationCoordinatorTests.swift
@@ -157,19 +157,6 @@ extension AuthenticationCoordinatorTests {
         // THEN the loginError should be a userCancelled error
         sut.loginError = LoginError.userCancelled
     }
-
-    func test_handleUniversalLink_catchAllError() throws {
-        mockLoginSession.errorFromFinalise = AuthenticationError.generic
-        // WHEN the AuthenticationCoordinator calls finalise on the session
-        // and there is an unknown error
-        let callbackURL = URL(string: "https://www.test.com")!
-        sut.handleUniversalLink(callbackURL)
-        // THEN the 'generic' error screen is shown
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorViewController)
-        XCTAssertTrue(vc.viewModel is GenericErrorViewModel)
-        // THEN the loginError should be an unknown generic error
-        sut.loginError = AuthenticationError.generic
-    }
     
     func test_loginError_jwterror() throws {
         mockLoginSession.errorFromPerformLoginFlow = JWTVerifierError.unableToFetchJWKs
@@ -183,5 +170,18 @@ extension AuthenticationCoordinatorTests {
         XCTAssertTrue(vc.viewModel is UnableToLoginErrorViewModel)
         // THEN the loginError should be an unableToFetchJWKs error
         sut.loginError = JWTVerifierError.unableToFetchJWKs
+    }
+    
+    func test_handleUniversalLink_catchAllError() throws {
+        mockLoginSession.errorFromFinalise = AuthenticationError.generic
+        // WHEN the AuthenticationCoordinator calls finalise on the session
+        // and there is an unknown error
+        let callbackURL = URL(string: "https://www.test.com")!
+        sut.handleUniversalLink(callbackURL)
+        // THEN the 'generic' error screen is shown
+        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorViewController)
+        XCTAssertTrue(vc.viewModel is GenericErrorViewModel)
+        // THEN the loginError should be an unknown generic error
+        sut.loginError = AuthenticationError.generic
     }
 }

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -98,13 +98,13 @@ extension LoginCoordinatorTests {
         XCTAssertTrue(sut.root.viewControllers.count == 1)
         XCTAssertTrue(sut.root.topViewController is IntroViewController)
         // WHEN the button to login is tapped
-        let introScreen = try XCTUnwrap(navigationController.topViewController as? IntroViewController)
+        let introScreen = try XCTUnwrap(sut.root.topViewController as? IntroViewController)
         let introButton: UIButton = try XCTUnwrap(introScreen.view[child: "intro-button"])
         introButton.sendActions(for: .touchUpInside)
         // THEN the displayed screen should be the Network Connection error screen
-        waitForTruth(self.navigationController.viewControllers.count == 2, timeout: 20)
+        waitForTruth(self.sut.root.viewControllers.count == 2, timeout: 20)
         XCTAssertTrue(sut.root.topViewController is GDSErrorViewController)
-        let errorScreen = try XCTUnwrap(navigationController.topViewController as? GDSErrorViewController)
+        let errorScreen = try XCTUnwrap(sut.root.topViewController as? GDSErrorViewController)
         XCTAssertTrue(errorScreen.viewModel is NetworkConnectionErrorViewModel)
     }
     
@@ -260,8 +260,8 @@ extension LoginCoordinatorTests {
         sut.didRegainFocus(fromChild: authCoordinator)
         // THEN the LoginCoordinator should still have IntroViewController as it's top view controller
         XCTAssertTrue(sut.root.topViewController is IntroViewController)
-        let vc = try XCTUnwrap(sut.root.topViewController as? IntroViewController)
-        let introButton: UIButton = try XCTUnwrap(vc.view[child: "intro-button"])
+        let introScreen = try XCTUnwrap(sut.root.topViewController as? IntroViewController)
+        let introButton: UIButton = try XCTUnwrap(introScreen.view[child: "intro-button"])
         XCTAssertTrue(introButton.isEnabled)
     }
 }

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -260,5 +260,8 @@ extension LoginCoordinatorTests {
         sut.didRegainFocus(fromChild: authCoordinator)
         // THEN the LoginCoordinator should still have IntroViewController as it's top view controller
         XCTAssertTrue(sut.root.topViewController is IntroViewController)
+        let vc = try XCTUnwrap(sut.root.topViewController as? IntroViewController)
+        let introButton: UIButton = try XCTUnwrap(vc.view[child: "intro-button"])
+        XCTAssertTrue(introButton.isEnabled)
     }
 }

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -256,12 +256,13 @@ extension LoginCoordinatorTests {
         authCoordinator.loginError = AuthenticationError.generic
         // GIVEN the LoginCoordinator has started and set it's view controllers
         sut.start()
+        let vc = try XCTUnwrap(sut.root.topViewController as? IntroViewController)
+        vc.loadView()
         // GIVEN the LoginCoordinator regained focus from the AuthenticationCoordinator
         sut.didRegainFocus(fromChild: authCoordinator)
         // THEN the LoginCoordinator should still have IntroViewController as it's top view controller
         XCTAssertTrue(sut.root.topViewController is IntroViewController)
-        let introScreen = try XCTUnwrap(sut.root.topViewController as? IntroViewController)
-        let introButton: UIButton = try XCTUnwrap(introScreen.view[child: "intro-button"])
+        let introButton: UIButton = try XCTUnwrap(vc.view[child: "intro-button"])
         XCTAssertTrue(introButton.isEnabled)
     }
 }

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -106,6 +106,9 @@ extension LoginCoordinatorTests {
         XCTAssertTrue(sut.root.topViewController is GDSErrorViewController)
         let errorScreen = try XCTUnwrap(sut.root.topViewController as? GDSErrorViewController)
         XCTAssertTrue(errorScreen.viewModel is NetworkConnectionErrorViewModel)
+        let errorButton: UIButton = try XCTUnwrap(errorScreen.view[child: "error-primary-button"])
+        errorButton.sendActions(for: .touchUpInside)
+        XCTAssertTrue(introButton.isEnabled)
     }
     
     func test_firstTimeUserFlow() throws {


### PR DESCRIPTION
# DCMAW-8928: iOS | Disable and add loading icon to Sign In button

Previously the "Sign in" button on the intro screen was not disabled when interacted with and could produce incorrect behaviour if the user interacted with the button again while the authentication modal was launching.
This PR implements disabling the button and reenabling it when the authentication modal is dismissed.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
