### PR TITLE
feat:  dcmaw-8544 user can see email on home page

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -137,6 +137,7 @@
 		C8ECA1322BB73E2E00722218 /* WindowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8ECA1312BB73E2E00722218 /* WindowManager.swift */; };
 		D01A72772BE29B51004333F8 /* ProfileCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01A72762BE29B51004333F8 /* ProfileCoordinatorTests.swift */; };
 		D01A72792BE37B86004333F8 /* ViewIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01A72782BE37B86004333F8 /* ViewIdentifiable.swift */; };
+		D0275CBF2BFF876800AF9A50 /* TokenVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0275CBE2BFF876800AF9A50 /* TokenVerifier.swift */; };
 		D03B04CF2BECDB5C00418C0B /* KeyVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03B04CE2BECDB5C00418C0B /* KeyVerifier.swift */; };
 		D03B04D32BEE734900418C0B /* IdTokenPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03B04D22BEE734900418C0B /* IdTokenPayload.swift */; };
 		D03B04D52BF221BD00418C0B /* JWTVerifierError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03B04D42BF221BD00418C0B /* JWTVerifierError.swift */; };
@@ -333,6 +334,7 @@
 		C8ECA1312BB73E2E00722218 /* WindowManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowManager.swift; sourceTree = "<group>"; };
 		D01A72762BE29B51004333F8 /* ProfileCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileCoordinatorTests.swift; sourceTree = "<group>"; };
 		D01A72782BE37B86004333F8 /* ViewIdentifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewIdentifiable.swift; sourceTree = "<group>"; };
+		D0275CBE2BFF876800AF9A50 /* TokenVerifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenVerifier.swift; sourceTree = "<group>"; };
 		D03B04CE2BECDB5C00418C0B /* KeyVerifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyVerifier.swift; sourceTree = "<group>"; };
 		D03B04D22BEE734900418C0B /* IdTokenPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdTokenPayload.swift; sourceTree = "<group>"; };
 		D03B04D42BF221BD00418C0B /* JWTVerifierError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWTVerifierError.swift; sourceTree = "<group>"; };
@@ -1113,6 +1115,7 @@
 				D03B04CE2BECDB5C00418C0B /* KeyVerifier.swift */,
 				D03B04D22BEE734900418C0B /* IdTokenPayload.swift */,
 				D03B04D42BF221BD00418C0B /* JWTVerifierError.swift */,
+				D0275CBE2BFF876800AF9A50 /* TokenVerifier.swift */,
 			);
 			path = JWT;
 			sourceTree = "<group>";
@@ -1461,6 +1464,7 @@
 				D03B04CF2BECDB5C00418C0B /* KeyVerifier.swift in Sources */,
 				C8098B992AEFF287001517A0 /* AnalyticsService+GDS.swift in Sources */,
 				41E1A90E2BE125B10034B6C7 /* RequestAuthorizing.swift in Sources */,
+				D0275CBF2BFF876800AF9A50 /* TokenVerifier.swift in Sources */,
 				C8B320792B062F9100FECDF0 /* AuthenticationCoordinator.swift in Sources */,
 				D03B04D52BF221BD00418C0B /* JWTVerifierError.swift in Sources */,
 				D01A72792BE37B86004333F8 /* ViewIdentifiable.swift in Sources */,

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -138,7 +138,7 @@
 		D01A72772BE29B51004333F8 /* ProfileCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01A72762BE29B51004333F8 /* ProfileCoordinatorTests.swift */; };
 		D01A72792BE37B86004333F8 /* ViewIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01A72782BE37B86004333F8 /* ViewIdentifiable.swift */; };
 		D03B04CF2BECDB5C00418C0B /* KeyVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03B04CE2BECDB5C00418C0B /* KeyVerifier.swift */; };
-		D03B04D32BEE734900418C0B /* IdTokenInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03B04D22BEE734900418C0B /* IdTokenInfo.swift */; };
+		D03B04D32BEE734900418C0B /* IdTokenPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03B04D22BEE734900418C0B /* IdTokenPayload.swift */; };
 		D03B04D52BF221BD00418C0B /* JWTVerifierError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03B04D42BF221BD00418C0B /* JWTVerifierError.swift */; };
 		D08B0B552BD7F84300769CEA /* DeveloperMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B532BD7F84300769CEA /* DeveloperMenuViewController.swift */; };
 		D08B0B562BD7F84300769CEA /* DeveloperMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = D08B0B542BD7F84300769CEA /* DeveloperMenu.xib */; };
@@ -149,7 +149,6 @@
 		D08B0B732BDA8DD100769CEA /* TabbedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B712BDA8DD100769CEA /* TabbedViewController.swift */; };
 		D08B0B742BDA8DD100769CEA /* TabbedView.xib in Resources */ = {isa = PBXBuildFile; fileRef = D08B0B722BDA8DD100769CEA /* TabbedView.xib */; };
 		D08B0B762BDA95F600769CEA /* TabbedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B752BDA95F600769CEA /* TabbedViewModel.swift */; };
-		D08B0B782BDBD32900769CEA /* SignInViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B772BDBD32900769CEA /* SignInViewModel.swift */; };
 		D08B0B7D2BDBF86100769CEA /* TabbedViewSectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B7C2BDBF86100769CEA /* TabbedViewSectionHeader.swift */; };
 		D08B0B812BDC0D7100769CEA /* TabbedTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B802BDC0D7100769CEA /* TabbedTableViewCell.swift */; };
 		D08B0B832BDC0F4100769CEA /* TabbedViewCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B822BDC0F4100769CEA /* TabbedViewCellModel.swift */; };
@@ -335,7 +334,7 @@
 		D01A72762BE29B51004333F8 /* ProfileCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileCoordinatorTests.swift; sourceTree = "<group>"; };
 		D01A72782BE37B86004333F8 /* ViewIdentifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewIdentifiable.swift; sourceTree = "<group>"; };
 		D03B04CE2BECDB5C00418C0B /* KeyVerifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyVerifier.swift; sourceTree = "<group>"; };
-		D03B04D22BEE734900418C0B /* IdTokenInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdTokenInfo.swift; sourceTree = "<group>"; };
+		D03B04D22BEE734900418C0B /* IdTokenPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdTokenPayload.swift; sourceTree = "<group>"; };
 		D03B04D42BF221BD00418C0B /* JWTVerifierError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWTVerifierError.swift; sourceTree = "<group>"; };
 		D08B0B532BD7F84300769CEA /* DeveloperMenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperMenuViewController.swift; sourceTree = "<group>"; };
 		D08B0B542BD7F84300769CEA /* DeveloperMenu.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DeveloperMenu.xib; sourceTree = "<group>"; };
@@ -346,7 +345,6 @@
 		D08B0B712BDA8DD100769CEA /* TabbedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbedViewController.swift; sourceTree = "<group>"; };
 		D08B0B722BDA8DD100769CEA /* TabbedView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TabbedView.xib; sourceTree = "<group>"; };
 		D08B0B752BDA95F600769CEA /* TabbedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbedViewModel.swift; sourceTree = "<group>"; };
-		D08B0B772BDBD32900769CEA /* SignInViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInViewModel.swift; sourceTree = "<group>"; };
 		D08B0B7C2BDBF86100769CEA /* TabbedViewSectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbedViewSectionHeader.swift; sourceTree = "<group>"; };
 		D08B0B802BDC0D7100769CEA /* TabbedTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbedTableViewCell.swift; sourceTree = "<group>"; };
 		D08B0B822BDC0F4100769CEA /* TabbedViewCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbedViewCellModel.swift; sourceTree = "<group>"; };
@@ -1091,7 +1089,6 @@
 			children = (
 				D08B0B672BDA47AD00769CEA /* SignInView.xib */,
 				D08B0B642BDA478000769CEA /* SignInView.swift */,
-				D08B0B772BDBD32900769CEA /* SignInViewModel.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -1114,7 +1111,7 @@
 				D0BE24402BEBAEF100759529 /* JWTVerifier.swift */,
 				D0BE24422BEBB06700759529 /* JWKInfo.swift */,
 				D03B04CE2BECDB5C00418C0B /* KeyVerifier.swift */,
-				D03B04D22BEE734900418C0B /* IdTokenInfo.swift */,
+				D03B04D22BEE734900418C0B /* IdTokenPayload.swift */,
 				D03B04D42BF221BD00418C0B /* JWTVerifierError.swift */,
 			);
 			path = JWT;
@@ -1485,10 +1482,9 @@
 				C8C343A72B92340000E92FB9 /* AnalyticsCentral.swift in Sources */,
 				C8AA11D82B29C7FA00CE718B /* UnableToLoginErrorViewModel.swift in Sources */,
 				D0BE24432BEBB06700759529 /* JWKInfo.swift in Sources */,
-				D03B04D32BEE734900418C0B /* IdTokenInfo.swift in Sources */,
+				D03B04D32BEE734900418C0B /* IdTokenPayload.swift in Sources */,
 				D08B0B582BD7F97200769CEA /* DeveloperMenuViewModel.swift in Sources */,
 				D0BE24412BEBAEF100759529 /* JWTVerifier.swift in Sources */,
-				D08B0B782BDBD32900769CEA /* SignInViewModel.swift in Sources */,
 				C880DDE22AEAB6C100020796 /* AppEnvironment.swift in Sources */,
 				C8E109092BEE6C0C00B21038 /* HomeTabViewModel.swift in Sources */,
 				1EB667A32B59910D008D8199 /* NetworkMonitoring.swift in Sources */,

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -138,6 +138,7 @@
 		D01A72772BE29B51004333F8 /* ProfileCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01A72762BE29B51004333F8 /* ProfileCoordinatorTests.swift */; };
 		D01A72792BE37B86004333F8 /* ViewIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01A72782BE37B86004333F8 /* ViewIdentifiable.swift */; };
 		D0275CBF2BFF876800AF9A50 /* TokenVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0275CBE2BFF876800AF9A50 /* TokenVerifier.swift */; };
+		D0275CC12C00951600AF9A50 /* MockTokenVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0275CC02C00951600AF9A50 /* MockTokenVerifier.swift */; };
 		D03B04CF2BECDB5C00418C0B /* KeyVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03B04CE2BECDB5C00418C0B /* KeyVerifier.swift */; };
 		D03B04D32BEE734900418C0B /* IdTokenPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03B04D22BEE734900418C0B /* IdTokenPayload.swift */; };
 		D03B04D52BF221BD00418C0B /* JWTVerifierError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03B04D42BF221BD00418C0B /* JWTVerifierError.swift */; };
@@ -335,6 +336,7 @@
 		D01A72762BE29B51004333F8 /* ProfileCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileCoordinatorTests.swift; sourceTree = "<group>"; };
 		D01A72782BE37B86004333F8 /* ViewIdentifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewIdentifiable.swift; sourceTree = "<group>"; };
 		D0275CBE2BFF876800AF9A50 /* TokenVerifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenVerifier.swift; sourceTree = "<group>"; };
+		D0275CC02C00951600AF9A50 /* MockTokenVerifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTokenVerifier.swift; sourceTree = "<group>"; };
 		D03B04CE2BECDB5C00418C0B /* KeyVerifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyVerifier.swift; sourceTree = "<group>"; };
 		D03B04D22BEE734900418C0B /* IdTokenPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdTokenPayload.swift; sourceTree = "<group>"; };
 		D03B04D42BF221BD00418C0B /* JWTVerifierError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWTVerifierError.swift; sourceTree = "<group>"; };
@@ -720,6 +722,7 @@
 			children = (
 				21FA1C4B2AE183A50052136E /* MockLoginSession.swift */,
 				1E717D722B72937500CCAF3E /* MockLAContext.swift */,
+				D0275CC02C00951600AF9A50 /* MockTokenVerifier.swift */,
 				41E1A90F2BE126910034B6C7 /* Networking */,
 				C8E6A3E92BBC05DB005015AF /* Application */,
 				C8C3439E2B92226900E92FB9 /* Analytics */,
@@ -1549,6 +1552,7 @@
 				C8520C2E2AE2C822006790C1 /* MockTokenResponse.swift in Sources */,
 				41E1A9152BE128610034B6C7 /* MockURLOpener.swift in Sources */,
 				C8C3439D2B921E3C00E92FB9 /* OnboardingCoordinatorTests.swift in Sources */,
+				D0275CC12C00951600AF9A50 /* MockTokenVerifier.swift in Sources */,
 				41C5E3322B45B07D00212A12 /* NetworkConnectionErrorViewModelTests.swift in Sources */,
 				411D1FD32B73CA74002393D1 /* TouchIDEnrollmentViewModelTests.swift in Sources */,
 				C8B5EFC52B0E53EE004EA4D4 /* XCTestCase+TestExtensions.swift in Sources */,

--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -76,8 +76,8 @@ final class MainCoordinator: NSObject,
                                   analyticsCenter: analyticsCenter,
                                   networkMonitor: NetworkMonitor.shared,
                                   userStore: userStore,
-                                  tokenHolder: tokenHolder,
-                                  startupError: error)
+                                  tokenHolder: tokenHolder)
+        lc.startupError = error
         openChildModally(lc, animated: false)
         loginCoordinator = lc
     }

--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -14,9 +14,9 @@ final class MainCoordinator: NSObject,
     let userStore: UserStorable
     let tokenHolder = TokenHolder()
     var networkClient: NetworkClient?
-    private var loginCoordinator: LoginCoordinator?
-    private var homeCoordinator: HomeCoordinator?
-    private var profileCoordinator: ProfileCoordinator?
+    private weak var loginCoordinator: LoginCoordinator?
+    private weak var homeCoordinator: HomeCoordinator?
+    private weak var profileCoordinator: ProfileCoordinator?
     
     init(windowManager: WindowManagement,
          root: UITabBarController,

--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -55,7 +55,7 @@ final class MainCoordinator: NSObject,
                     } catch {
                         loginCoordinator?.root.dismiss(animated: false)
                         tokenHolder.accessToken = nil
-                        userStore.defaultsStore.set(nil, forKey: .accessTokenExpiry)
+                        try? userStore.clearTokenInfo()
                         showLogin(error)
                         action()
                     }
@@ -77,7 +77,7 @@ final class MainCoordinator: NSObject,
                                   networkMonitor: NetworkMonitor.shared,
                                   userStore: userStore,
                                   tokenHolder: tokenHolder)
-        lc.startupError = error
+        lc.tokenReadError = error
         openChildModally(lc, animated: false)
         loginCoordinator = lc
     }

--- a/Sources/Application/TokenHolder.swift
+++ b/Sources/Application/TokenHolder.swift
@@ -12,7 +12,7 @@ class TokenHolder: AuthenticationProvider {
         }
     }
     var accessToken: String?
-    var idToken: IdTokenInfo?
+    var idTokenPayload: IdTokenPayload?
     
     var bearerToken: String {
         get throws {

--- a/Sources/Login/AuthenticationCoordinator.swift
+++ b/Sources/Login/AuthenticationCoordinator.swift
@@ -31,7 +31,7 @@ final class AuthenticationCoordinator: NSObject,
                 // TODO: DCMAW-8570 This should be considiered non-optional once tokenID work is completed on BE
                 if AppEnvironment.callingSTSEnabled,
                     let idToken = tokenHolder.tokenResponse?.idToken {
-                    tokenHolder.idToken = try await verifyIDToken(idToken)
+                    tokenHolder.idTokenPayload = try await verifyIDToken(idToken)
                 }
                 finish()
             } catch let error as LoginError where error == .network {
@@ -85,7 +85,7 @@ final class AuthenticationCoordinator: NSObject,
 }
 
 extension AuthenticationCoordinator {
-    private func verifyIDToken(_ token: String) async throws -> IdTokenInfo? {
+    private func verifyIDToken(_ token: String) async throws -> IdTokenPayload? {
         let verifier = JWTVerifier(token: token)
         return try await verifier.verifyCredential()
     }

--- a/Sources/Login/AuthenticationCoordinator.swift
+++ b/Sources/Login/AuthenticationCoordinator.swift
@@ -13,15 +13,18 @@ final class AuthenticationCoordinator: NSObject,
     let errorPresenter = ErrorPresenter.self
     var tokenHolder: TokenHolder
     var loginError: Error?
+    private var tokenVerifier: TokenVerifier
     
     init(root: UINavigationController,
          session: LoginSession,
          analyticsService: AnalyticsService,
-         tokenHolder: TokenHolder) {
+         tokenHolder: TokenHolder,
+         tokenVerifier: TokenVerifier = JWTVerifier()) {
         self.root = root
         self.session = session
         self.analyticsService = analyticsService
         self.tokenHolder = tokenHolder
+        self.tokenVerifier = tokenVerifier
     }
     
     func start() {
@@ -31,7 +34,7 @@ final class AuthenticationCoordinator: NSObject,
                 // TODO: DCMAW-8570 This should be considiered non-optional once tokenID work is completed on BE
                 if AppEnvironment.callingSTSEnabled,
                     let idToken = tokenHolder.tokenResponse?.idToken {
-                    tokenHolder.idTokenPayload = try await verifyIDToken(idToken)
+                    tokenHolder.idTokenPayload = try await tokenVerifier.verifyToken(idToken)
                 }
                 finish()
             } catch let error as LoginError where error == .network {
@@ -85,11 +88,6 @@ final class AuthenticationCoordinator: NSObject,
 }
 
 extension AuthenticationCoordinator {
-    private func verifyIDToken(_ token: String) async throws -> IdTokenPayload? {
-        let verifier = JWTVerifier(token: token)
-        return try await verifier.verifyCredential()
-    }
-    
     private func showLoginErrorScreen(_ error: Error) {
         let unableToLoginErrorScreen = errorPresenter
             .createUnableToLoginError(errorDescription: error.localizedDescription,

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -20,8 +20,8 @@ final class LoginCoordinator: NSObject,
     let tokenHolder: TokenHolder
     private let viewControllerFactory = OnboardingViewControllerFactory.self
     private let errorPresenter = ErrorPresenter.self
-    private var authCoordinator: AuthenticationCoordinator?
-    var introViewController: IntroViewController?
+    private weak var authCoordinator: AuthenticationCoordinator?
+    weak var introViewController: IntroViewController?
     
     init(windowManager: WindowManagement,
          root: UINavigationController,

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -23,7 +23,7 @@ final class LoginCoordinator: NSObject,
     private weak var authCoordinator: AuthenticationCoordinator?
     weak var introViewController: IntroViewController?
     private var tokenVerifier: TokenVerifier
-    var startupError: Error?
+    var tokenReadError: Error?
     
     init(windowManager: WindowManagement,
          root: UINavigationController,
@@ -72,6 +72,7 @@ final class LoginCoordinator: NSObject,
                 } catch {
                     userStore.refreshStorage(accessControlLevel: LAContext().isPasscodeOnly ? .anyBiometricsOrPasscode : .currentBiometricsOrPasscode)
                     windowManager.hideUnlockWindow()
+                    tokenReadError = error
                     start()
                 }
             }
@@ -97,9 +98,9 @@ final class LoginCoordinator: NSObject,
             }
 
         root.setViewControllers([rootViewController], animated: true)
-        if let startupError {
+        if let tokenReadError {
             let unableToLoginErrorScreen = ErrorPresenter
-                .createUnableToLoginError(errorDescription: startupError.localizedDescription,
+                .createUnableToLoginError(errorDescription: tokenReadError.localizedDescription,
                                           analyticsService: analyticsCenter.analyticsService) { [unowned self] in
                     root.popViewController(animated: true)
                 }

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -23,7 +23,7 @@ final class LoginCoordinator: NSObject,
     private weak var authCoordinator: AuthenticationCoordinator?
     weak var introViewController: IntroViewController?
     private var tokenVerifier: TokenVerifier
-    private var startupError: Error?
+    var startupError: Error?
     
     init(windowManager: WindowManagement,
          root: UINavigationController,
@@ -31,8 +31,7 @@ final class LoginCoordinator: NSObject,
          networkMonitor: NetworkMonitoring,
          userStore: UserStorable,
          tokenHolder: TokenHolder,
-         tokenVerifier: TokenVerifier = JWTVerifier(),
-         startupError: Error? = nil) {
+         tokenVerifier: TokenVerifier = JWTVerifier()) {
         self.windowManager = windowManager
         self.root = root
         self.analyticsCenter = analyticsCenter
@@ -40,7 +39,6 @@ final class LoginCoordinator: NSObject,
         self.userStore = userStore
         self.tokenHolder = tokenHolder
         self.tokenVerifier = tokenVerifier
-        self.startupError = startupError
         root.modalPresentationStyle = .overFullScreen
     }
     

--- a/Sources/Screens/DeveloperMenu/DeveloperMenuViewController.swift
+++ b/Sources/Screens/DeveloperMenu/DeveloperMenuViewController.swift
@@ -45,7 +45,7 @@ final class DeveloperMenuViewController: BaseViewController {
                 let data = try await networkClient?.makeAuthorizedRequest(exchangeRequest: URLRequest(url: AppEnvironment.stsToken),
                                                                           scope: "sts-test.hello-world.read",
                                                                           request: URLRequest(url: AppEnvironment.stsHelloWorld))
-                happyPathResultLabel.showSuccessMessage("Success: \(String(data: data!, encoding: .utf8) ?? "no body")")
+                happyPathResultLabel.showSuccessMessage("Success: \(String(decoding: data!, as: UTF8.self))")
             } catch let error as ServerError {
                 happyPathResultLabel.showErrorMessage(error)
             } catch {

--- a/Sources/Screens/Tabs/TabbedViewController.swift
+++ b/Sources/Screens/Tabs/TabbedViewController.swift
@@ -7,7 +7,6 @@ final class TabbedViewController: BaseViewController {
     
     private var viewModel: TabbedViewModel
     private let headerView: UIView?
-    private var accessToken: String?
     
     init(viewModel: TabbedViewModel,
          headerView: UIView? = nil) {
@@ -44,11 +43,9 @@ final class TabbedViewController: BaseViewController {
         }
     }
     
-    func updateToken(accessToken: String?) {
-        // TODO: DCMAW-8544 To be replaced by secure token JWT with capability to extract e-mail for display
-        self.accessToken = accessToken
+    func updateToken(_ tokenHolder: TokenHolder) {
         guard let headerView = headerView as? SignInView else { return }
-        headerView.updateEmail("example@email.com")
+        headerView.userEmail = tokenHolder.idTokenPayload?.email
         resizeHeaderView()
         viewModel.isLoggedIn = true
     }

--- a/Sources/Tabs/HomeCoordinator.swift
+++ b/Sources/Tabs/HomeCoordinator.swift
@@ -43,11 +43,11 @@ final class HomeCoordinator: NSObject,
     func showDeveloperMenu() {
         let navController = UINavigationController()
         let devMenuViewModel = DeveloperMenuViewModel()
-        if let accessToken = try? userStore.secureStoreService.readItem(itemName: .accessToken),
-            let tokenHolder {
-            tokenHolder.accessToken = accessToken
-            networkClient = NetworkClient(authenticationProvider: tokenHolder)
+        if tokenHolder?.accessToken == nil,
+            let accessToken = try? userStore.secureStoreService.readItem(itemName: .accessToken) {
+            tokenHolder?.accessToken = accessToken
         }
+        networkClient = NetworkClient(authenticationProvider: tokenHolder)
         let developerMenuVC = DeveloperMenuViewController(viewModel: devMenuViewModel,
                                                           networkClient: networkClient)
         navController.setViewControllers([developerMenuVC], animated: true)

--- a/Sources/Tabs/ProfileCoordinator.swift
+++ b/Sources/Tabs/ProfileCoordinator.swift
@@ -28,12 +28,12 @@ final class ProfileCoordinator: NSObject,
         let viewModel = ProfileTabViewModel(analyticsService: analyticsService,
                                             sectionModels: TabbedViewSectionFactory.profileSections(urlOpener: urlOpener))
         let profileViewController = TabbedViewController(viewModel: viewModel,
-                                                         headerView: SignInView(viewModel: SignInViewModel()))
+                                                         headerView: SignInView())
         baseVc = profileViewController
         root.setViewControllers([profileViewController], animated: true)
     }
     
-    func updateToken(accessToken: String?) {
-        baseVc?.updateToken(accessToken: accessToken)
+    func updateToken(_ tokenHolder: TokenHolder) {
+        baseVc?.updateToken(tokenHolder)
     }
 }

--- a/Sources/Utilities/JWT/IdTokenPayload.swift
+++ b/Sources/Utilities/JWT/IdTokenPayload.swift
@@ -1,7 +1,7 @@
 import Foundation
 import JWTKit
 
-struct IdTokenInfo: JWTPayload {
+struct IdTokenPayload: JWTPayload {
 
     var sub: SubjectClaim
     var aud: AudienceClaim

--- a/Sources/Utilities/JWT/JWKInfo.swift
+++ b/Sources/Utilities/JWT/JWKInfo.swift
@@ -13,7 +13,7 @@ struct JWKSInfo: Codable {
     
     func jwkForKID(_ kid: String) throws -> JWK? {
         guard let jwkInfo = self.keys.first(where: { $0.kid  == kid }) else { return nil }
-        guard let json = try jwkInfo.jsonString else { return nil }
+        let json = try jwkInfo.jsonString
         return try JWK(json: json)
     }
 }
@@ -41,10 +41,10 @@ struct JWKInfo: Codable {
         case y
     }
     
-    var jsonString: String? {
+    var jsonString: String {
         get throws {
             let jsonData = try JSONEncoder().encode(self)
-            return String(data: jsonData, encoding: .utf8)
+            return String(decoding: jsonData, as: UTF8.self)
         }
     }
 }

--- a/Sources/Utilities/JWT/JWTVerifier.swift
+++ b/Sources/Utilities/JWT/JWTVerifier.swift
@@ -13,7 +13,7 @@ final class JWTVerifier {
 }
 
 extension JWTVerifier {
-    func verifyCredential() async throws -> IdTokenInfo? {
+    func verifyCredential() async throws -> IdTokenPayload? {
         let jwksInfo = try await fetchJWKs()
         
         guard let kid = try extractKIDFromHeader(),

--- a/Sources/Utilities/JWT/KeyVerifier.swift
+++ b/Sources/Utilities/JWT/KeyVerifier.swift
@@ -8,13 +8,19 @@ protocol KeyVerifier {
 struct ES256KeyVerifier: KeyVerifier {
     let signers = JWTSigners(defaultJSONEncoder: .oneLoginJWTEncoder,
                              defaultJSONDecoder: .oneLoginJWTDecoder)
-    
-    init(jsonWebKey: JWK) throws {
-        try signers.use(jwk: jsonWebKey)
+        
+    init(jsonWebKey: JWK? = nil) throws {
+        if let jsonWebKey {
+            try signers.use(jwk: jsonWebKey)
+        }
     }
     
     func verify(jwt: String) throws -> IdTokenPayload {
         try signers.verify(jwt)
+    }
+    
+    func extract(jwt: String) throws -> IdTokenPayload {
+        return try signers.unverified(jwt)
     }
 }
 

--- a/Sources/Utilities/JWT/KeyVerifier.swift
+++ b/Sources/Utilities/JWT/KeyVerifier.swift
@@ -2,7 +2,7 @@ import Foundation
 import JWTKit
 
 protocol KeyVerifier {
-    func verify(jwt: String) throws -> IdTokenInfo
+    func verify(jwt: String) throws -> IdTokenPayload
 }
 
 struct ES256KeyVerifier: KeyVerifier {
@@ -13,7 +13,7 @@ struct ES256KeyVerifier: KeyVerifier {
         try signers.use(jwk: jsonWebKey)
     }
     
-    func verify(jwt: String) throws -> IdTokenInfo {
+    func verify(jwt: String) throws -> IdTokenPayload {
         try signers.verify(jwt)
     }
 }

--- a/Sources/Utilities/JWT/TokenVerifier.swift
+++ b/Sources/Utilities/JWT/TokenVerifier.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+protocol TokenVerifier {
+    func verifyToken(_ token: String) async throws -> IdTokenPayload?
+    func extractPayload(_ token: String) throws -> IdTokenPayload?
+}

--- a/Sources/Utilities/Storage/UserStorable.swift
+++ b/Sources/Utilities/Storage/UserStorable.swift
@@ -34,6 +34,7 @@ extension UserStorable {
     
     func clearTokenInfo() throws {
         try secureStoreService.deleteItem(itemName: .accessToken)
+        try secureStoreService.deleteItem(itemName: .idToken)
         defaultsStore.removeObject(forKey: .accessTokenExpiry)
     }
 }

--- a/Sources/Views/Components/SignInView.swift
+++ b/Sources/Views/Components/SignInView.swift
@@ -2,10 +2,13 @@ import GDSCommon
 import UIKit
 
 final class SignInView: NibView {
-    var viewModel: SignInViewModel
+    var userEmail: String? {
+        didSet {
+            emailLabel.attributedText = attributedEmailString
+        }
+    }
     
-    init(viewModel: SignInViewModel) {
-        self.viewModel = viewModel
+    init() {
         super.init(forcedNibName: "SignInView", bundle: nil)
     }
     
@@ -15,20 +18,14 @@ final class SignInView: NibView {
     
     @IBOutlet private var emailLabel: UILabel! {
         didSet {
-            emailLabel.attributedText = attributedEmailString
             emailLabel.accessibilityIdentifier = "signin-view-email-label"
         }
     }
     
-    func updateEmail(_ email: String) {
-        viewModel.userEmail = email
-        emailLabel.attributedText = attributedEmailString
-    }
-    
     private var attributedEmailString: NSAttributedString? {
-        guard let email = viewModel.userEmail else { return nil }
+        guard let userEmail else { return nil }
         return GDSLocalisedString(stringKey: "app_displayEmail",
-                                  email,
-                                  attributes: [(email, [.font: UIFont.bodyBold])]).attributedValue
+                                  userEmail,
+                                  attributes: [(userEmail, [.font: UIFont.bodyBold])]).attributedValue
     }
 }

--- a/Sources/Views/Components/SignInView.swift
+++ b/Sources/Views/Components/SignInView.swift
@@ -12,6 +12,7 @@ final class SignInView: NibView {
         super.init(forcedNibName: "SignInView", bundle: nil)
     }
     
+    @available(*, unavailable, renamed: "init()")
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Sources/Views/Components/SignInView.xib
+++ b/Sources/Views/Components/SignInView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -32,7 +32,7 @@
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="7b3-3r-wlx">
                             <rect key="frame" x="0.0" y="17" width="393" height="725"/>
                             <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QLj-Oo-23b">
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QLj-Oo-23b">
                                     <rect key="frame" x="20" y="8" width="357" height="709"/>
                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                     <nil key="textColor"/>

--- a/Sources/Views/Components/SignInViewModel.swift
+++ b/Sources/Views/Components/SignInViewModel.swift
@@ -1,5 +1,0 @@
-import GDSCommon
-
-struct SignInViewModel {
-    var userEmail: String?
-}

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -121,24 +121,24 @@ extension LoginCoordinatorTests {
     }
     
     func test_returningUserFlow() throws {
-        // GIVEN the access token is saved in secure store
-        try mockSecureStore.saveItem(item: "123456789", itemName: .accessToken)
+        // GIVEN the id token is saved in secure store
+        try mockSecureStore.saveItem(item: MockJWKSResponse.idToken, itemName: .idToken)
         // WHEN the LoginCoordinator's returningUserFlow method is called
         sut.returningUserFlow()
-        // THEN the token holder's access token property should get the access token from secure store
+        // THEN the token holder's access idTokenPayload should be populated
         waitForTruth(self.mockWindowManager.hideUnlockWindowCalled == true, timeout: 20)
-        XCTAssertEqual(sut.tokenHolder.accessToken, "123456789")
+        XCTAssertNotNil(sut.tokenHolder.idTokenPayload)
     }
     
     func test_start_getAccessToken_succeeds() throws {
         // GIVEN the access token is saved in secure store and the token expiry is in date
-        try mockSecureStore.saveItem(item: "123456789", itemName: .accessToken)
+        try mockSecureStore.saveItem(item: MockJWKSResponse.idToken, itemName: .idToken)
         mockDefaultStore.set(Date() + 60, forKey: .accessTokenExpiry)
         // WHEN the LoginCoordinator is started
         sut.start()
-        // THEN the token holder's access token property should get the access token from secure store
+        // THEN the token holder's idTokenPayload should be populated
         waitForTruth(self.mockWindowManager.hideUnlockWindowCalled == true, timeout: 20)
-        XCTAssertEqual(sut.tokenHolder.accessToken, "123456789")
+        XCTAssertNotNil(sut.tokenHolder.idTokenPayload)
     }
     
     func test_start_launchOnboardingCoordinator() throws {
@@ -150,20 +150,20 @@ extension LoginCoordinatorTests {
     }
     
     func test_getAccessToken_succeeds() throws {
-        try mockSecureStore.saveItem(item: "123456789", itemName: .accessToken)
+        try mockSecureStore.saveItem(item: MockJWKSResponse.idToken, itemName: .idToken)
         mockDefaultStore.set(Date() + 60, forKey: .accessTokenExpiry)
         // WHEN the LoginCoordinator's getAccessToken method is called
-        sut.getAccessToken()
+        sut.getIdToken()
         // THEN the token holder's access token property should get the access token from secure store
         waitForTruth(self.mockWindowManager.hideUnlockWindowCalled == true, timeout: 20)
-        XCTAssertEqual(sut.tokenHolder.accessToken, "123456789")
+        XCTAssertNotNil(sut.tokenHolder.idTokenPayload)
     }
     
     func test_getAccessToken_error_unableToRetrieveFromUserDefaults() throws {
         // GIVEN the secure store returns a unableToRetrieveFromUserDefaults error from trying to read the access token
         mockSecureStore.errorFromReadItem = SecureStoreError.unableToRetrieveFromUserDefaults
         // WHEN the LoginCoordinator's getAccessToken method is called
-        sut.getAccessToken()
+        sut.getIdToken()
         // THEN the token holder's access token property should not get the access token from secure store
         waitForTruth(self.sut.tokenHolder.accessToken == nil, timeout: 20)
         // THEN user store should be refreshed
@@ -178,7 +178,7 @@ extension LoginCoordinatorTests {
         // GIVEN the secure store returns a cantInitialiseData error from trying to read the access token
         mockSecureStore.errorFromReadItem = SecureStoreError.cantInitialiseData
         // WHEN the LoginCoordinator's getAccessToken method is called
-        sut.getAccessToken()
+        sut.getIdToken()
         // THEN the token holder's access token property should not get the access token from secure store
         waitForTruth(self.sut.tokenHolder.accessToken == nil, timeout: 20)
         // THEN user store should be refreshed
@@ -193,7 +193,7 @@ extension LoginCoordinatorTests {
         // GIVEN the secure store returns a cantRetrieveKey error from trying to read the access token
         mockSecureStore.errorFromReadItem = SecureStoreError.cantRetrieveKey
         // WHEN the LoginCoordinator's getAccessToken method is called
-        sut.getAccessToken()
+        sut.getIdToken()
         // THEN the token holder's access token property should not get the access token from secure store
         waitForTruth(self.sut.tokenHolder.accessToken == nil, timeout: 20)
         // THEN user store should be refreshed

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -170,8 +170,8 @@ extension LoginCoordinatorTests {
         XCTAssertTrue(mockSecureStore.didCallDeleteStore)
         XCTAssertNil(mockDefaultStore.savedData[.accessTokenExpiry])
         XCTAssertTrue(mockWindowManager.hideUnlockWindowCalled)
-        XCTAssertTrue(sut.root.viewControllers.count == 1)
-        XCTAssertTrue(sut.root.topViewController is IntroViewController)
+        XCTAssertTrue(sut.root.viewControllers.count == 2)
+        XCTAssertTrue(sut.root.topViewController is GDSErrorViewController)
     }
     
     func test_getAccessToken_error_cantInitialiseData() throws {
@@ -185,8 +185,8 @@ extension LoginCoordinatorTests {
         XCTAssertTrue(mockSecureStore.didCallDeleteStore)
         XCTAssertNil(mockDefaultStore.savedData[.accessTokenExpiry])
         XCTAssertTrue(mockWindowManager.hideUnlockWindowCalled)
-        XCTAssertTrue(sut.root.viewControllers.count == 1)
-        XCTAssertTrue(sut.root.topViewController is IntroViewController)
+        XCTAssertTrue(sut.root.viewControllers.count == 2)
+        XCTAssertTrue(sut.root.topViewController is GDSErrorViewController)
     }
     
     func test_getAccessToken_error_cantRetrieveKey() throws {
@@ -200,8 +200,8 @@ extension LoginCoordinatorTests {
         XCTAssertTrue(mockSecureStore.didCallDeleteStore)
         XCTAssertNil(mockDefaultStore.savedData[.accessTokenExpiry])
         XCTAssertTrue(mockWindowManager.hideUnlockWindowCalled)
-        XCTAssertTrue(sut.root.viewControllers.count == 1)
-        XCTAssertTrue(sut.root.topViewController is IntroViewController)
+        XCTAssertTrue(sut.root.viewControllers.count == 2)
+        XCTAssertTrue(sut.root.topViewController is GDSErrorViewController)
     }
     
     func test_launchOnboardingCoordinator_succeeds() throws {

--- a/Tests/UnitTests/Mocks/Sessions+Services/MockTokenVerifier.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/MockTokenVerifier.swift
@@ -1,0 +1,32 @@
+import Foundation
+import JWTKit
+@testable import OneLogin
+
+final class MockTokenVerifier: TokenVerifier {
+    var verificationFailed = false
+    var extractionFailed = false
+    
+    func verifyToken(_ token: String) async throws -> IdTokenPayload? {
+        if verificationFailed {
+            throw JWTVerifierError.invalidJWTFormat
+        }
+        return Self.mockPayload
+    }
+    
+    func extractPayload(_ token: String) throws -> IdTokenPayload? {
+        if extractionFailed {
+            throw JWTVerifierError.invalidJWTFormat
+        }
+        return Self.mockPayload
+    }
+}
+
+extension MockTokenVerifier {
+    static let mockPayload = IdTokenPayload(sub: "subject",
+                                            aud: "audience",
+                                            iss: "issuer",
+                                            exp: .init(value: Date()),
+                                            iat: .init(value: Date()),
+                                            email: "mock@email.com",
+                                            emailVerified: true)
+}

--- a/Tests/UnitTests/Mocks/Sessions+Services/Networking/MockJWKSResponse.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Networking/MockJWKSResponse.swift
@@ -1,8 +1,8 @@
 import Foundation
 // swiftlint:disable line_length
 struct MockJWKSResponse {
-    static var jwksJson: Data = {
-        """
+    static var jwksJson: Data =
+        Data("""
         {
             "keys": [
               {
@@ -24,11 +24,10 @@ struct MockJWKSResponse {
               }
             ]
         }
-        """.data(using: .utf8)!
-    }()
+        """.utf8)
     
-    static var jwksJsonNonMatchingKIDs: Data = {
-        """
+    static var jwksJsonNonMatchingKIDs: Data =
+        Data("""
         {
             "keys": [
               {
@@ -50,8 +49,7 @@ struct MockJWKSResponse {
               }
             ]
         }
-        """.data(using: .utf8)!
-    }()
+        """.utf8)
 
     static let idToken =  "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjE2ZGI2NTg3LTU0NDUtNDVkNi1hN2Q5LTk4NzgxZWJkZjkzZCJ9.eyJhdWQiOiJNT0JJTEVfQ0xJRU5UX0lEIiwiaXNzIjoiaHR0cHM6Ly90b2tlbi5idWlsZC5hY2NvdW50Lmdvdi51ayIsInN1YiI6IjljNWFhYzU2LTE0YzAtNDJkNi05MzFkLWI0NmNkM2QzNWFlMSIsImlhdCI6MTcxNTI2NTkwMywiZXhwIjoxNzE2NDc1NTAzLCJlbWFpbCI6ImFiY0BleGFtcGxlLmNvbSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlfQ.mlXHI1nb8d4pWRS9Zrt1cDLN2WdzC8t4BuVdvY8uh9VsNMXTA8ORyZW4gIsymKAaggY8oxA1yqaW7C5OQmETAw"
     

--- a/Tests/UnitTests/Screens/DeveloperMenuViewControllerTests.swift
+++ b/Tests/UnitTests/Screens/DeveloperMenuViewControllerTests.swift
@@ -39,7 +39,7 @@ final class DeveloperMenuViewControllerTests: XCTestCase {
     
     func test_happyPathButton() throws {
         UserDefaults.standard.set(true, forKey: "EnableCallingSTS")
-        mockNetworkClient.authorizedData = "testData".data(using: .utf8)
+        mockNetworkClient.authorizedData = Data("testData".utf8)
         try sut.happyPathButton.sendActions(for: .touchUpInside)
         waitForTruth(self.mockNetworkClient.requestFinished == true, timeout: 3)
         XCTAssertEqual(try sut.happyPathResultLabel.text, "Success: testData")

--- a/Tests/UnitTests/Tabs/ProfileCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/ProfileCoordinatorTests.swift
@@ -38,8 +38,10 @@ final class ProfileCoordinatorTests: XCTestCase {
     func test_updateToken() throws {
         sut.start()
         let vc = try XCTUnwrap(sut.baseVc)
-        XCTAssertEqual(try vc.emailLabel.text, nil)
-        sut.updateToken(accessToken: "testAccessToken")
-        XCTAssertEqual(try vc.emailLabel.text, "You’re signed in as\nexample@email.com")
+        XCTAssertEqual(try vc.emailLabel.text, "")
+        let tokenHolder = TokenHolder()
+        tokenHolder.idTokenPayload = MockTokenVerifier.mockPayload
+        sut.updateToken(tokenHolder)
+        XCTAssertEqual(try vc.emailLabel.text, "You’re signed in as\nmock@email.com")
     }
 }


### PR DESCRIPTION
# DCMAW-8544 | User can see their email on the home page

After successful login, decode the idToken to extract the e-mail, and display on the home page

Added additional functionality to JWTVerifier to decode the idToken without performing verification, since at the point of decoding, the idToken will already have been verified, whether it has been freshly update from BE or retrieved from secure store (as we wouldn't store an unverified token).  This is to prevent the need from having to make another JWKS call every time we decode.

Also refactored so that the initial biometrics/passcode request is for the idToken, not the access token.   The access token is retrieved from the secure store when the Developer Menu is visited, as that is when it is actually required.  This will invoke another biometric auth request, as that is the nature of how secure store works, i.e., every access to the store requires retrieval of the private key from the secure enclave, and every secure enclave access requires biometric authentication.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
~~- [ ] Created a `draft` pull request if it is not yet ready for review~~

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~~- [ ] Met all accessibility requirements?~~
    ~~- [ ] Checked dynamic type sizes are applied~~
    ~~- [ ] Checked VoiceOver can navigate your new code~~
    ~~- [ ] Checked a user can navigate only using a keyboard around your new code~~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
