### PR TITLE
feat: login loading screen

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		C82B644A2BA1C300000C9524 /* LAContext+OneLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82B64492BA1C300000C9524 /* LAContext+OneLogin.swift */; };
 		C82B64522BA47D59000C9524 /* StringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82B64512BA47D59000C9524 /* StringTests.swift */; };
 		C82F950F2B9F0CCA00A90A6A /* UnlockScreenViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82F950E2B9F0CCA00A90A6A /* UnlockScreenViewControllerTests.swift */; };
+		C83E18122C05DDDB00B451D6 /* LoginLoadingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83E18112C05DDDB00B451D6 /* LoginLoadingViewModelTests.swift */; };
 		C8454A8F2B99D1BC000F9ED0 /* LoginCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8454A8E2B99D1BC000F9ED0 /* LoginCoordinatorTests.swift */; };
 		C851FFA22BADA4B200A7B73D /* SceneLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C851FFA12BADA4B200A7B73D /* SceneLifecycle.swift */; };
 		C851FFA42BADAAB600A7B73D /* SceneLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C851FFA32BADAAB600A7B73D /* SceneLifecycleTests.swift */; };
@@ -264,6 +265,7 @@
 		C82B64492BA1C300000C9524 /* LAContext+OneLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LAContext+OneLogin.swift"; sourceTree = "<group>"; };
 		C82B64512BA47D59000C9524 /* StringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringTests.swift; sourceTree = "<group>"; };
 		C82F950E2B9F0CCA00A90A6A /* UnlockScreenViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnlockScreenViewControllerTests.swift; sourceTree = "<group>"; };
+		C83E18112C05DDDB00B451D6 /* LoginLoadingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginLoadingViewModelTests.swift; sourceTree = "<group>"; };
 		C8454A8E2B99D1BC000F9ED0 /* LoginCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginCoordinatorTests.swift; sourceTree = "<group>"; };
 		C851FFA12BADA4B200A7B73D /* SceneLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneLifecycle.swift; sourceTree = "<group>"; };
 		C851FFA32BADAAB600A7B73D /* SceneLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneLifecycleTests.swift; sourceTree = "<group>"; };
@@ -751,6 +753,7 @@
 				41C8E42D2B7291F80063B8A3 /* FaceIDEnrollmentViewModelTests.swift */,
 				411D1FD22B73CA74002393D1 /* TouchIDEnrollmentViewModelTests.swift */,
 				41D469742B9758A5008705CD /* UnlockScreenViewModelTests.swift */,
+				C83E18112C05DDDB00B451D6 /* LoginLoadingViewModelTests.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -1536,6 +1539,7 @@
 				41A0BD112B2758E6009AE51F /* GenericErrorViewModelTests.swift in Sources */,
 				410464F62B29D078000E7CB2 /* UnableToLoginErrorViewModelTests.swift in Sources */,
 				C851FFA42BADAAB600A7B73D /* SceneLifecycleTests.swift in Sources */,
+				C83E18122C05DDDB00B451D6 /* LoginLoadingViewModelTests.swift in Sources */,
 				C8C6665A2BCFDBDE00CF249B /* TokenHolderTests.swift in Sources */,
 				41C8E42F2B72920F0063B8A3 /* FaceIDEnrollmentViewModelTests.swift in Sources */,
 				C8454A8F2B99D1BC000F9ED0 /* LoginCoordinatorTests.swift in Sources */,

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 		C8BADD292B87D89000385FE7 /* UserStorable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8BADD282B87D89000385FE7 /* UserStorable.swift */; };
 		C8BADD2B2B87D8FD00385FE7 /* DefaultsStorable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8BADD2A2B87D8FD00385FE7 /* DefaultsStorable.swift */; };
 		C8BADD2D2B87D9C800385FE7 /* UserStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8BADD2C2B87D9C800385FE7 /* UserStorage.swift */; };
+		C8BEC2942BFFA8C800C9775A /* LoginLoadingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8BEC2932BFFA8C800C9775A /* LoginLoadingViewModel.swift */; };
 		C8C343972B909A2F00E92FB9 /* String+OneLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C343962B909A2F00E92FB9 /* String+OneLogin.swift */; };
 		C8C3439B2B91F99600E92FB9 /* OnboardingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C3439A2B91F99600E92FB9 /* OnboardingCoordinator.swift */; };
 		C8C3439D2B921E3C00E92FB9 /* OnboardingCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C3439C2B921E3C00E92FB9 /* OnboardingCoordinatorTests.swift */; };
@@ -311,6 +312,7 @@
 		C8BADD2C2B87D9C800385FE7 /* UserStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserStorage.swift; sourceTree = "<group>"; };
 		C8BADD2E2B889CB900385FE7 /* MockUserStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUserStore.swift; sourceTree = "<group>"; };
 		C8BADD302B889D4200385FE7 /* MockDefaultsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDefaultsStore.swift; sourceTree = "<group>"; };
+		C8BEC2932BFFA8C800C9775A /* LoginLoadingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginLoadingViewModel.swift; sourceTree = "<group>"; };
 		C8C343962B909A2F00E92FB9 /* String+OneLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+OneLogin.swift"; sourceTree = "<group>"; };
 		C8C3439A2B91F99600E92FB9 /* OnboardingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCoordinator.swift; sourceTree = "<group>"; };
 		C8C3439C2B921E3C00E92FB9 /* OnboardingCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -782,6 +784,7 @@
 				41C8E42B2B7252A70063B8A3 /* FaceIDEnrollmentViewModel.swift */,
 				41C8E4322B73AA600063B8A3 /* TouchIDEnrollmentViewModel.swift */,
 				C86B706A2B8E43DC00F4C9BF /* AnalyticsPreferenceViewModel.swift */,
+				C8BEC2932BFFA8C800C9775A /* LoginLoadingViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -1487,6 +1490,7 @@
 				41C8E42C2B7252A70063B8A3 /* FaceIDEnrollmentViewModel.swift in Sources */,
 				41FF35AC2B21F1AA00419DB3 /* GenericErrorViewModel.swift in Sources */,
 				C8C343A72B92340000E92FB9 /* AnalyticsCentral.swift in Sources */,
+				C8BEC2942BFFA8C800C9775A /* LoginLoadingViewModel.swift in Sources */,
 				C8AA11D82B29C7FA00CE718B /* UnableToLoginErrorViewModel.swift in Sources */,
 				D0BE24432BEBB06700759529 /* JWKInfo.swift in Sources */,
 				D03B04D32BEE734900418C0B /* IdTokenPayload.swift in Sources */,

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-common.git",
       "state" : {
-        "revision" : "8252c23731c621c05366e6861e21e35f2837926f",
-        "version" : "1.9.4"
+        "revision" : "3284b253a08691ea094684078bc88efd075c2482",
+        "version" : "1.11.1"
       }
     },
     {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-common.git",
       "state" : {
-        "revision" : "3284b253a08691ea094684078bc88efd075c2482",
-        "version" : "1.11.1"
+        "revision" : "3eff18aac8c5bce218558bd7b3d0208cd60cb1dc",
+        "version" : "1.11.2"
       }
     },
     {

--- a/Sources/Analytics/Onboarding/IntroAnalytics.swift
+++ b/Sources/Analytics/Onboarding/IntroAnalytics.swift
@@ -4,9 +4,11 @@ import Logging
 enum IntroAnalyticsScreen: String, ScreenType {
     case welcomeScreen = "introWelcomeScreen"
     case splashScreen = "splashScreen"
+    case loginLoadingScreen = "loginloadingScreen"
 }
 
 enum IntroAnalyticsScreenID: String {
     case welcomeScreen = "30a6b339-75a8-44a2-a79a-e108546419bf"
     case splashScreen = "3e95fe16-7ba7-4f46-a22e-4ae17112debf"
+    case loginLoadingScreen = "0672f0fa-8126-479b-b191-8e750fa3d909"
 }

--- a/Sources/Extensions/CustomTypes/AnalyticsService+GDS.swift
+++ b/Sources/Extensions/CustomTypes/AnalyticsService+GDS.swift
@@ -39,7 +39,7 @@ where Screen: Logging.ScreenType {
     }
     
     public var type: Logging.ScreenType {
-        self.screen
+        screen
     }
 }
 
@@ -50,6 +50,6 @@ where Screen: Logging.ScreenType {
     }
 
     public var type: Logging.ScreenType {
-        self.screen
+        screen
     }
 }

--- a/Sources/Login/AuthenticationCoordinator.swift
+++ b/Sources/Login/AuthenticationCoordinator.swift
@@ -41,21 +41,19 @@ final class AuthenticationCoordinator: NSObject,
             } catch let error as LoginError where error == .network {
                 let networkErrorScreen = errorPresenter
                     .createNetworkConnectionError(analyticsService: analyticsService) { [unowned self] in
-                        root.popViewController(animated: true)
-                        finish()
+                        returnFromErrorScreen()
                     }
                 root.pushViewController(networkErrorScreen, animated: true)
-                removeLoginLoadingScreen()
                 loginError = error
             } catch let error as LoginError where error == .non200,
                     let error as LoginError where error == .invalidRequest,
                     let error as LoginError where error == .clientError {
-                showLoginErrorScreen(error)
+                showUnableToLoginErrorScreen(error)
             } catch let error as LoginError where error == .userCancelled {
                 loginError = error
                 finish()
             } catch let error as JWTVerifierError {
-                showLoginErrorScreen(error)
+                showUnableToLoginErrorScreen(error)
             } catch {
                 showGenericErrorScreen(error)
             }
@@ -77,15 +75,13 @@ final class AuthenticationCoordinator: NSObject,
 }
 
 extension AuthenticationCoordinator {
-    private func showLoginErrorScreen(_ error: Error) {
+    private func showUnableToLoginErrorScreen(_ error: Error) {
         let unableToLoginErrorScreen = errorPresenter
             .createUnableToLoginError(errorDescription: error.localizedDescription,
                                       analyticsService: analyticsService) { [unowned self] in
-                root.popViewController(animated: true)
-                finish()
+                returnFromErrorScreen()
             }
         root.pushViewController(unableToLoginErrorScreen, animated: true)
-        removeLoginLoadingScreen()
         loginError = error
     }
     
@@ -93,15 +89,15 @@ extension AuthenticationCoordinator {
         let genericErrorScreen = errorPresenter
             .createGenericError(errorDescription: error.localizedDescription,
                                 analyticsService: analyticsService) { [unowned self] in
-                root.popViewController(animated: true)
-                finish()
+                returnFromErrorScreen()
             }
         root.pushViewController(genericErrorScreen, animated: true)
-        removeLoginLoadingScreen()
         loginError = error
     }
     
-    private func removeLoginLoadingScreen() {
+    private func returnFromErrorScreen() {
         root.viewControllers.remove(at: root.viewControllers.count - 1)
+        root.popViewController(animated: true)
+        finish()
     }
 }

--- a/Sources/Login/AuthenticationCoordinator.swift
+++ b/Sources/Login/AuthenticationCoordinator.swift
@@ -57,15 +57,7 @@ final class AuthenticationCoordinator: NSObject,
             } catch let error as JWTVerifierError {
                 showLoginErrorScreen(error)
             } catch {
-                let genericErrorScreen = errorPresenter
-                    .createGenericError(errorDescription: error.localizedDescription,
-                                        analyticsService: analyticsService) { [unowned self] in
-                        root.popViewController(animated: true)
-                        finish()
-                    }
-                root.pushViewController(genericErrorScreen, animated: true)
-                removeLoginLoadingScreen()
-                loginError = error
+                showGenericErrorScreen(error)
             }
         }
     }
@@ -75,18 +67,11 @@ final class AuthenticationCoordinator: NSObject,
             if let loginCoordinator = parentCoordinator as? LoginCoordinator {
                 loginCoordinator.introViewController?.enableIntroButton()
             }
-            try session.finalise(redirectURL: url)
             let loginLoadingScreen = GDSLoadingViewController(viewModel: LoginLoadingViewModel())
             root.pushViewController(loginLoadingScreen, animated: false)
+            try session.finalise(redirectURL: url)
         } catch {
-            let genericErrorScreen = errorPresenter
-                .createGenericError(errorDescription: error.localizedDescription,
-                                    analyticsService: analyticsService) { [unowned self] in
-                    root.popViewController(animated: true)
-                    finish()
-                }
-            root.pushViewController(genericErrorScreen, animated: true)
-            loginError = error
+            showGenericErrorScreen(error)
         }
     }
 }
@@ -100,6 +85,18 @@ extension AuthenticationCoordinator {
                 finish()
             }
         root.pushViewController(unableToLoginErrorScreen, animated: true)
+        removeLoginLoadingScreen()
+        loginError = error
+    }
+    
+    private func showGenericErrorScreen(_ error: Error) {
+        let genericErrorScreen = errorPresenter
+            .createGenericError(errorDescription: error.localizedDescription,
+                                analyticsService: analyticsService) { [unowned self] in
+                root.popViewController(animated: true)
+                finish()
+            }
+        root.pushViewController(genericErrorScreen, animated: true)
         removeLoginLoadingScreen()
         loginError = error
     }

--- a/Sources/Login/AuthenticationCoordinator.swift
+++ b/Sources/Login/AuthenticationCoordinator.swift
@@ -34,7 +34,7 @@ final class AuthenticationCoordinator: NSObject,
                 tokenHolder.tokenResponse = try await session.performLoginFlow(configuration: LoginSessionConfiguration.oneLogin)
                 // TODO: DCMAW-8570 This should be considered non-optional once tokenID work is completed on BE
                 if AppEnvironment.callingSTSEnabled,
-                    let idToken = tokenHolder.tokenResponse?.idToken {
+                   let idToken = tokenHolder.tokenResponse?.idToken {
                     tokenHolder.idTokenPayload = try await tokenVerifier.verifyToken(idToken)
                 }
                 finish()
@@ -96,7 +96,7 @@ extension AuthenticationCoordinator {
     }
     
     private func returnFromErrorScreen() {
-        root.viewControllers.remove(at: root.viewControllers.count - 1)
+        root.viewControllers.removeLast()
         root.popViewController(animated: true)
         finish()
     }

--- a/Sources/Login/AuthenticationCoordinator.swift
+++ b/Sources/Login/AuthenticationCoordinator.swift
@@ -45,13 +45,13 @@ final class AuthenticationCoordinator: NSObject,
                     }
                 root.pushViewController(networkErrorScreen, animated: true)
                 loginError = error
+            } catch let error as LoginError where error == .userCancelled {
+                loginError = error
+                finish()
             } catch let error as LoginError where error == .non200,
                     let error as LoginError where error == .invalidRequest,
                     let error as LoginError where error == .clientError {
                 showUnableToLoginErrorScreen(error)
-            } catch let error as LoginError where error == .userCancelled {
-                loginError = error
-                finish()
             } catch let error as JWTVerifierError {
                 showUnableToLoginErrorScreen(error)
             } catch {

--- a/Sources/Login/AuthenticationCoordinator.swift
+++ b/Sources/Login/AuthenticationCoordinator.swift
@@ -37,7 +37,6 @@ final class AuthenticationCoordinator: NSObject,
                     let idToken = tokenHolder.tokenResponse?.idToken {
                     tokenHolder.idTokenPayload = try await tokenVerifier.verifyToken(idToken)
                 }
-                root.dismiss(animated: false)
                 finish()
             } catch let error as LoginError where error == .network {
                 let networkErrorScreen = errorPresenter
@@ -46,6 +45,7 @@ final class AuthenticationCoordinator: NSObject,
                         finish()
                     }
                 root.pushViewController(networkErrorScreen, animated: true)
+                removeLoginLoadingScreen()
                 loginError = error
             } catch let error as LoginError where error == .non200,
                     let error as LoginError where error == .invalidRequest,
@@ -64,6 +64,7 @@ final class AuthenticationCoordinator: NSObject,
                         finish()
                     }
                 root.pushViewController(genericErrorScreen, animated: true)
+                removeLoginLoadingScreen()
                 loginError = error
             }
         }
@@ -75,9 +76,8 @@ final class AuthenticationCoordinator: NSObject,
                 loginCoordinator.introViewController?.enableIntroButton()
             }
             try session.finalise(redirectURL: url)
-            let loadingScreen = GDSLoadingViewController(viewModel: LoginLoadingViewModel())
-            loadingScreen.modalPresentationStyle = .fullScreen
-            root.present(loadingScreen, animated: false)
+            let loginLoadingScreen = GDSLoadingViewController(viewModel: LoginLoadingViewModel())
+            root.pushViewController(loginLoadingScreen, animated: false)
         } catch {
             let genericErrorScreen = errorPresenter
                 .createGenericError(errorDescription: error.localizedDescription,
@@ -100,6 +100,11 @@ extension AuthenticationCoordinator {
                 finish()
             }
         root.pushViewController(unableToLoginErrorScreen, animated: true)
+        removeLoginLoadingScreen()
         loginError = error
+    }
+    
+    private func removeLoginLoadingScreen() {
+        root.viewControllers.remove(at: root.viewControllers.count - 1)
     }
 }

--- a/Sources/Login/AuthenticationCoordinator.swift
+++ b/Sources/Login/AuthenticationCoordinator.swift
@@ -65,7 +65,7 @@ final class AuthenticationCoordinator: NSObject,
             if let loginCoordinator = parentCoordinator as? LoginCoordinator {
                 loginCoordinator.introViewController?.enableIntroButton()
             }
-            let loginLoadingScreen = GDSLoadingViewController(viewModel: LoginLoadingViewModel())
+            let loginLoadingScreen = GDSLoadingViewController(viewModel: LoginLoadingViewModel(analyticsService: analyticsService))
             root.pushViewController(loginLoadingScreen, animated: false)
             try session.finalise(redirectURL: url)
         } catch {

--- a/Sources/Login/ViewModels/FaceIDEnrollmentViewModel.swift
+++ b/Sources/Login/ViewModels/FaceIDEnrollmentViewModel.swift
@@ -13,9 +13,10 @@ struct FaceIDEnrollmentViewModel: GDSInformationViewModel, BaseViewModel {
     let footnote: GDSLocalisedString? = "app_enableFaceIDFootnote"
     let primaryButtonViewModel: ButtonViewModel
     let secondaryButtonViewModel: ButtonViewModel?
+    let analyticsService: AnalyticsService
+    
     let rightBarButtonTitle: GDSLocalisedString? = nil
     let backButtonIsHidden: Bool = true
-    let analyticsService: AnalyticsService
     
     init(analyticsService: AnalyticsService,
          primaryButtonAction: @escaping () -> Void,
@@ -32,7 +33,6 @@ struct FaceIDEnrollmentViewModel: GDSInformationViewModel, BaseViewModel {
         }
     }
     
-    
     func didAppear() {
         let screen = ScreenView(id: BiometricEnrollmentAnalyticsScreenID.faceIDEnrollment.rawValue,
                                 screen: BiometricEnrollmentAnalyticsScreen.faceIDEnrollment,
@@ -40,7 +40,5 @@ struct FaceIDEnrollmentViewModel: GDSInformationViewModel, BaseViewModel {
         analyticsService.trackScreen(screen)
     }
     
-    func didDismiss() {
-        // Conforming to BaseViewModel
-    }
+    func didDismiss() { /* Conforming to BaseViewModel */ }
 }

--- a/Sources/Login/ViewModels/LoginLoadingViewModel.swift
+++ b/Sources/Login/ViewModels/LoginLoadingViewModel.swift
@@ -1,0 +1,5 @@
+import GDSCommon
+
+struct LoginLoadingViewModel: GDSLoadingViewModel {
+    var loadingLabelKey: GDSLocalisedString = GDSLocalisedString(stringLiteral: "Loading")
+}

--- a/Sources/Login/ViewModels/LoginLoadingViewModel.swift
+++ b/Sources/Login/ViewModels/LoginLoadingViewModel.swift
@@ -1,5 +1,11 @@
 import GDSCommon
 
-struct LoginLoadingViewModel: GDSLoadingViewModel {
+struct LoginLoadingViewModel: GDSLoadingViewModel, BaseViewModel {
+    var rightBarButtonTitle: GDSLocalisedString?
+    var backButtonIsHidden: Bool = true
     var loadingLabelKey: GDSLocalisedString = GDSLocalisedString(stringLiteral: "Loading")
+    
+    func didAppear() { }
+    
+    func didDismiss() { }
 }

--- a/Sources/Login/ViewModels/LoginLoadingViewModel.swift
+++ b/Sources/Login/ViewModels/LoginLoadingViewModel.swift
@@ -1,12 +1,24 @@
+import GDSAnalytics
 import GDSCommon
+import Logging
 
 struct LoginLoadingViewModel: GDSLoadingViewModel, BaseViewModel {
     let loadingLabelKey: GDSLocalisedString = "app_loadingBody"
+    let analyticsService: AnalyticsService
     
     let rightBarButtonTitle: GDSLocalisedString? = nil
     let backButtonIsHidden: Bool = true
     
-    func didAppear() { }
+    init(analyticsService: AnalyticsService) {
+        self.analyticsService = analyticsService
+    }
+    
+    func didAppear() {
+        let screen = ScreenView(id: IntroAnalyticsScreenID.loginLoadingScreen.rawValue,
+                                screen: IntroAnalyticsScreen.loginLoadingScreen,
+                                titleKey: loadingLabelKey.stringKey)
+        analyticsService.trackScreen(screen)
+    }
     
     func didDismiss() { /* Conforming to BaseViewModel */ }
 }

--- a/Sources/Login/ViewModels/LoginLoadingViewModel.swift
+++ b/Sources/Login/ViewModels/LoginLoadingViewModel.swift
@@ -3,7 +3,7 @@ import GDSCommon
 struct LoginLoadingViewModel: GDSLoadingViewModel, BaseViewModel {
     var rightBarButtonTitle: GDSLocalisedString?
     var backButtonIsHidden: Bool = true
-    var loadingLabelKey: GDSLocalisedString = GDSLocalisedString(stringLiteral: "Loading")
+    var loadingLabelKey: GDSLocalisedString = GDSLocalisedString(stringLiteral: "app_loadingBody")
     
     func didAppear() { }
     

--- a/Sources/Login/ViewModels/LoginLoadingViewModel.swift
+++ b/Sources/Login/ViewModels/LoginLoadingViewModel.swift
@@ -1,11 +1,12 @@
 import GDSCommon
 
 struct LoginLoadingViewModel: GDSLoadingViewModel, BaseViewModel {
-    var rightBarButtonTitle: GDSLocalisedString?
-    var backButtonIsHidden: Bool = true
-    var loadingLabelKey: GDSLocalisedString = GDSLocalisedString(stringLiteral: "app_loadingBody")
+    let loadingLabelKey: GDSLocalisedString = "app_loadingBody"
+    
+    let rightBarButtonTitle: GDSLocalisedString? = nil
+    let backButtonIsHidden: Bool = true
     
     func didAppear() { }
     
-    func didDismiss() { }
+    func didDismiss() { /* Conforming to BaseViewModel */ }
 }

--- a/Sources/Login/ViewModels/OneLoginIntroViewModel.swift
+++ b/Sources/Login/ViewModels/OneLoginIntroViewModel.swift
@@ -33,7 +33,5 @@ struct OneLoginIntroViewModel: IntroViewModel, BaseViewModel {
         analyticsService.trackScreen(screen)
     }
     
-    func didDismiss() {
-        // Here for BaseViewModel compliance
-    }
+    func didDismiss() { /* Conforming to BaseViewModel */ }
 }

--- a/Sources/Login/ViewModels/PasscodeInformationViewModel.swift
+++ b/Sources/Login/ViewModels/PasscodeInformationViewModel.swift
@@ -37,7 +37,5 @@ struct PasscodeInformationViewModel: GDSInformationViewModel, BaseViewModel {
         analyticsService.trackScreen(screen)
     }
     
-    func didDismiss() {
-        // Here for BaseViewModel compliance
-    }
+    func didDismiss() { /* Conforming to BaseViewModel */ }
 }

--- a/Sources/Login/ViewModels/TouchIDEnrollmentViewModel.swift
+++ b/Sources/Login/ViewModels/TouchIDEnrollmentViewModel.swift
@@ -13,9 +13,10 @@ struct TouchIDEnrollmentViewModel: GDSInformationViewModel, BaseViewModel {
     let footnote: GDSLocalisedString? = "app_enableTouchIDFootnote"
     let primaryButtonViewModel: ButtonViewModel
     let secondaryButtonViewModel: ButtonViewModel?
+    let analyticsService: AnalyticsService
+    
     let rightBarButtonTitle: GDSLocalisedString? = nil
     let backButtonIsHidden: Bool = true
-    let analyticsService: AnalyticsService
     
     init(analyticsService: AnalyticsService,
          primaryButtonAction: @escaping () -> Void,
@@ -32,7 +33,6 @@ struct TouchIDEnrollmentViewModel: GDSInformationViewModel, BaseViewModel {
         }
     }
     
-    
     func didAppear() {
         let screen = ScreenView(id: BiometricEnrollmentAnalyticsScreenID.touchIDEnrollment.rawValue,
                                 screen: BiometricEnrollmentAnalyticsScreen.touchIDEnrollment,
@@ -40,7 +40,5 @@ struct TouchIDEnrollmentViewModel: GDSInformationViewModel, BaseViewModel {
         analyticsService.trackScreen(screen)
     }
     
-    func didDismiss() {
-        // Conforming to BaseViewModel
-    }
+    func didDismiss() { /* Conforming to BaseViewModel */ }
 }

--- a/Sources/Resources/cy-GB.lproj/Localizable.strings
+++ b/Sources/Resources/cy-GB.lproj/Localizable.strings
@@ -11,6 +11,8 @@
 
 "app_disagreeButton" = "Anghytuno";
 
+"app_loadingBody" = "Llwytho";
+
 "app_maybeLaterButton" = "Efallai nes ymlaen";
 
 "app_enterPasscodeButton" = "Rhowch god mynediad";

--- a/Sources/Resources/en.lproj/Localizable.strings
+++ b/Sources/Resources/en.lproj/Localizable.strings
@@ -11,6 +11,8 @@
 
 "app_disagreeButton" = "Disagree";
 
+"app_loadingBody" = "Loading";
+
 "app_maybeLaterButton" = "Maybe later";
 
 "app_enterPasscodeButton" = "Enter passcode";

--- a/Sources/Screens/Unlock/UnlockScreenViewModel.swift
+++ b/Sources/Screens/Unlock/UnlockScreenViewModel.swift
@@ -20,7 +20,8 @@ struct UnlockScreenViewModel: BaseViewModel {
     }
     
     func didAppear() {
-        let screen = ScreenView(screen: BiometricEnrollmentAnalyticsScreen.unlockScreen, titleKey: "unlock screen")
+        let screen = ScreenView(screen: BiometricEnrollmentAnalyticsScreen.unlockScreen,
+                                titleKey: "unlock screen")
         analyticsService.trackScreen(screen)
     }
     

--- a/Tests/UnitTests/Login/AuthenticationCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/AuthenticationCoordinatorTests.swift
@@ -178,10 +178,27 @@ extension AuthenticationCoordinatorTests {
         // and there is an unknown error
         let callbackURL = URL(string: "https://www.test.com")!
         sut.handleUniversalLink(callbackURL)
-        // THEN the 'generic' error screen is shown
+        waitForTruth(self.navigationController.viewControllers.count == 2, timeout: 20)
+        // THEN the loading screen is on the navigation stack
+        XCTAssertTrue(navigationController.viewControllers.first is GDSLoadingViewController)
+        // THEN the 'generic' error screen is top of the navigation stack
         let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorViewController)
         XCTAssertTrue(vc.viewModel is GenericErrorViewModel)
         // THEN the loginError should be an unknown generic error
         sut.loginError = AuthenticationError.generic
+    }
+    
+    func test_returnFromErrorScreen() throws {
+        mockLoginSession.errorFromPerformLoginFlow = AuthenticationError.generic
+        sut.start()
+        // GIVEN the AuthenticationCoordinator has logged in via start()
+        // WHEN the AuthenticationCoordinator calls performLoginFlow on the session
+        // and there is a non200 error
+        waitForTruth(self.navigationController.viewControllers.count == 1, timeout: 20)
+        // THEN the 'unable to login' error screen is shown
+        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorViewController)
+        let errorButton: UIButton = try XCTUnwrap(vc.view[child: "error-primary-button"])
+        errorButton.sendActions(for: .touchUpInside)
+        XCTAssertEqual(navigationController.viewControllers.count, 0)
     }
 }

--- a/Tests/UnitTests/Login/AuthenticationCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/AuthenticationCoordinatorTests.swift
@@ -121,9 +121,9 @@ extension AuthenticationCoordinatorTests {
         sut.start()
         // GIVEN the AuthenticationCoordinator has logged in via start()
         // WHEN the AuthenticationCoordinator calls performLoginFlow on the session
-        // and there is a non200 error
+        // and there is a generic error
         waitForTruth(self.navigationController.viewControllers.count == 1, timeout: 20)
-        // THEN the 'unable to login' error screen is shown
+        // THEN the 'generic' error screen is shown
         XCTAssertTrue(sut.root.topViewController is GDSErrorViewController)
         let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorViewController)
         XCTAssertTrue(vc.viewModel is GenericErrorViewModel)
@@ -136,9 +136,9 @@ extension AuthenticationCoordinatorTests {
         sut.start()
         // GIVEN the AuthenticationCoordinator has logged in via start()
         // WHEN the AuthenticationCoordinator calls performLoginFlow on the session
-        // and there is a non200 error
+        // and there is an unknown error
         waitForTruth(self.navigationController.viewControllers.count == 1, timeout: 20)
-        // THEN the 'unable to login' error screen is shown
+        // THEN the 'generic' error screen is shown
         XCTAssertTrue(sut.root.topViewController is GDSErrorViewController)
         let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorViewController)
         XCTAssertTrue(vc.viewModel is GenericErrorViewModel)
@@ -193,12 +193,13 @@ extension AuthenticationCoordinatorTests {
         sut.start()
         // GIVEN the AuthenticationCoordinator has logged in via start()
         // WHEN the AuthenticationCoordinator calls performLoginFlow on the session
-        // and there is a non200 error
         waitForTruth(self.navigationController.viewControllers.count == 1, timeout: 20)
-        // THEN the 'unable to login' error screen is shown
+        // THEN an error screen is shown
         let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorViewController)
+        // WHEN the primary button of the error screen is selected
         let errorButton: UIButton = try XCTUnwrap(vc.view[child: "error-primary-button"])
         errorButton.sendActions(for: .touchUpInside)
+        // THEN the added view controller should be removed
         XCTAssertEqual(navigationController.viewControllers.count, 0)
     }
 }

--- a/Tests/UnitTests/Login/ViewModels/LoginLoadingViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/LoginLoadingViewModelTests.swift
@@ -33,5 +33,6 @@ extension LoginLoadingViewModelTests {
                                 titleKey: "app_loadingBody")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"], screen.parameters["screen_id"])
     }
 }

--- a/Tests/UnitTests/Login/ViewModels/LoginLoadingViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/LoginLoadingViewModelTests.swift
@@ -1,0 +1,37 @@
+import GDSAnalytics
+@testable import OneLogin
+import XCTest
+
+final class LoginLoadingViewModelTests: XCTestCase {
+    var mockAnalyticsService: MockAnalyticsService!
+    var sut: LoginLoadingViewModel!
+
+    override func setUp() {
+        super.setUp()
+
+        mockAnalyticsService = MockAnalyticsService()
+        sut = LoginLoadingViewModel(analyticsService: mockAnalyticsService)
+    }
+
+    override func tearDown() {
+        mockAnalyticsService = nil
+        sut =  nil
+    }
+}
+
+extension LoginLoadingViewModelTests {
+    func test_label_contents() throws {
+        XCTAssertEqual(sut.loadingLabelKey.stringKey, "app_loadingBody")
+    }
+    
+    func test_didAppear() throws {
+        XCTAssertEqual(mockAnalyticsService.screensVisited.count, 0)
+        sut.didAppear()
+        XCTAssertEqual(mockAnalyticsService.screensVisited.count, 1)
+        let screen = ScreenView(id: IntroAnalyticsScreenID.loginLoadingScreen.rawValue,
+                                screen: IntroAnalyticsScreen.loginLoadingScreen,
+                                titleKey: "app_loadingBody")
+        XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
+    }
+}

--- a/Tests/UnitTests/Login/ViewModels/PasscodeInformationViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/PasscodeInformationViewModelTests.swift
@@ -42,14 +42,10 @@ extension PasscodeInformationViewModelTests {
                               linkDomain: AppEnvironment.oneLoginBaseURL,
                               external: .false)
         XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
-        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["text"],
-                       event.parameters["text"])
-        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["type"],
-                       event.parameters["type"])
-        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["link_domain"],
-                       event.parameters["link_domain"])
-        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["external"],
-                       event.parameters["external"])
+        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["text"], event.parameters["text"])
+        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["type"], event.parameters["type"])
+        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["link_domain"], event.parameters["link_domain"])
+        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["external"], event.parameters["external"])
     }
     
     func test_didAppear() throws {
@@ -60,9 +56,7 @@ extension PasscodeInformationViewModelTests {
                                 screen: InformationAnalyticsScreen.passcode,
                                 titleKey: "app_noPasscodeSetupTitle")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"],
-                       screen.parameters["title"])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"],
-                       screen.parameters["screen_id"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"], screen.parameters["screen_id"])
     }
 }

--- a/Tests/UnitTests/Login/ViewModels/TouchIDEnrollmentViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/TouchIDEnrollmentViewModelTests.swift
@@ -70,7 +70,6 @@ extension TouchIDEnrollmentViewModelTests {
                                 titleKey: "app_enableTouchIDTitle")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"],
-                       screen.parameters["screen_id"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"], screen.parameters["screen_id"])
     }
 }

--- a/Tests/UnitTests/Login/ViewModels/UnlockScreenViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/UnlockScreenViewModelTests.swift
@@ -48,5 +48,6 @@ extension UnlockScreenViewModelTests {
                                 titleKey: "unlock screen")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"], screen.parameters["screen_id"])
     }
 }

--- a/Tests/UnitTests/Mocks/Sessions+Services/Analytics/MockAnalyticsService.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Analytics/MockAnalyticsService.swift
@@ -26,7 +26,7 @@ final class MockAnalyticsService: AnalyticsService {
         screenParamsLogged = parameters
     }
     
-    func trackScreen(_ screen: Logging.LoggableScreenV2, parameters: [String: Any]) {
+    func trackScreen(_ screen: LoggableScreenV2, parameters: [String: Any]) {
         screensVisited.append(screen.name)
         
         guard var parameters = parameters as? [String: String] else {

--- a/Tests/UnitTests/Resources/LocalizedEnglishStringTests.swift
+++ b/Tests/UnitTests/Resources/LocalizedEnglishStringTests.swift
@@ -17,6 +17,8 @@ final class LocalizedEnglishStringTests: XCTestCase {
                        "Agree")
         XCTAssertEqual("app_disagreeButton".getEnglishString(),
                        "Disagree")
+        XCTAssertEqual("app_loadingBody".getEnglishString(),
+                       "Loading")
         XCTAssertEqual("app_maybeLaterButton".getEnglishString(),
                        "Maybe later")
         XCTAssertEqual("app_enterPasscodeButton".getEnglishString(),

--- a/Tests/UnitTests/Resources/LocalizedWelshStringTests.swift
+++ b/Tests/UnitTests/Resources/LocalizedWelshStringTests.swift
@@ -17,6 +17,8 @@ final class LocalizedWelshStringTests: XCTestCase {
                        "Cytuno")
         XCTAssertEqual("app_disagreeButton".getWelshString(),
                        "Anghytuno")
+        XCTAssertEqual("app_loadingBody".getWelshString(),
+                       "Llwytho")
         XCTAssertEqual("app_maybeLaterButton".getWelshString(),
                        "Efallai nes ymlaen")
         XCTAssertEqual("app_enterPasscodeButton".getWelshString(),


### PR DESCRIPTION
# DCMAW-8013: iOS | User sees Loading page after completing authentication WebView
# DCMAW-8993: iOS | Implement GA4 schema on the 'Loading' page

Previously, we had not implemented a loading screen for the first time user login journeys into the app which interacts with the web auth server. Ideally we would give the user sufficient feedback about network requests completing and disable the UI. This PR implements the loading screen for the first time user login journeys.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
