### PR TITLE
feat:  Add GA4 analytics to cancel button on login modal

### DIFF
--- a/Sources/Login/AuthenticationCoordinator.swift
+++ b/Sources/Login/AuthenticationCoordinator.swift
@@ -1,5 +1,6 @@
 import Authentication
 import Coordination
+import GDSAnalytics
 import GDSCommon
 import Logging
 import UIKit
@@ -47,6 +48,7 @@ final class AuthenticationCoordinator: NSObject,
                 loginError = error
             } catch let error as LoginError where error == .userCancelled {
                 loginError = error
+                logUserCancelEvent()
                 finish()
             } catch let error as LoginError where error == .non200,
                     let error as LoginError where error == .invalidRequest,
@@ -99,5 +101,10 @@ extension AuthenticationCoordinator {
         root.viewControllers.removeLast()
         root.popViewController(animated: true)
         finish()
+    }
+    
+    private func logUserCancelEvent() {
+        let userCancelEvent = ButtonEvent(textKey: "back")
+        analyticsService.logEvent(userCancelEvent)
     }
 }

--- a/Tests/UnitTests/Login/AuthenticationCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/AuthenticationCoordinatorTests.swift
@@ -1,4 +1,5 @@
 import Authentication
+import GDSAnalytics
 import GDSCommon
 @testable import OneLogin
 import XCTest
@@ -156,6 +157,11 @@ extension AuthenticationCoordinatorTests {
         // THEN user is returned to the intro screen
         // THEN the loginError should be a userCancelled error
         sut.loginError = LoginError.userCancelled
+        // THEN a trackButtonEvent is logged with text value "back"
+        let userCancelledEvent = ButtonEvent(textKey: "back")
+        XCTAssertEqual(mockAnalyticsService.eventsLogged, [userCancelledEvent.name.name])
+        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["text"], userCancelledEvent.parameters["text"])
+        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["type"], userCancelledEvent.parameters["type"])
     }
     
     func test_loginError_jwterror() throws {


### PR DESCRIPTION
# DCMAW-8554: iOS | Implement GA4 schema on the WebView

Fire a trackButtonEvent when the user cancels on the login modal.
Since the button itself can't be accessed, this is done when a "userCancelled" error is returned by the Authentication framework, which amounts to the same thing

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
~~- [ ] Created a `draft` pull request if it is not yet ready for review~~

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~~- [ ] Met all accessibility requirements?~~
    ~~- [ ] Checked dynamic type sizes are applied~~
    ~~- [ ] Checked VoiceOver can navigate your new code~~
    ~~- [ ] Checked a user can navigate only using a keyboard around your new code~~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
