### PR TITLE
fix: reset analytics permissions

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -2630,8 +2630,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/govuk-one-login/mobile-ios-logging.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				branch = "feature/dcmaw-9299-resetting-analytics-permissions";
+				kind = branch;
 			};
 		};
 		C8A13CAE2AFBD0F100FCBD36 /* XCRemoteSwiftPackageReference "mobile-ios-coordination" */ = {

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -2630,8 +2630,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/govuk-one-login/mobile-ios-logging.git";
 			requirement = {
-				branch = "feature/dcmaw-9299-resetting-analytics-permissions";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
 			};
 		};
 		C8A13CAE2AFBD0F100FCBD36 /* XCRemoteSwiftPackageReference "mobile-ios-coordination" */ = {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-logging.git",
       "state" : {
-        "revision" : "ffe25dcb5c03a05c6f652c334aad75f12f141f76",
-        "version" : "1.2.4"
+        "branch" : "feature/dcmaw-9299-resetting-analytics-permissions",
+        "revision" : "e326fe5e6c02babeeb89284cdba9c3146ec4bd09"
       }
     },
     {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-logging.git",
       "state" : {
-        "branch" : "feature/dcmaw-9299-resetting-analytics-permissions",
-        "revision" : "e326fe5e6c02babeeb89284cdba9c3146ec4bd09"
+        "revision" : "24a513dcfcfa3f348db13c66a60a4d2a3de125f7",
+        "version" : "1.2.6"
       }
     },
     {

--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -143,6 +143,7 @@ extension MainCoordinator: ParentCoordinator {
             updateToken()
         case _ as ProfileCoordinator:
             showLogin()
+            homeCoordinator?.baseVc?.isLoggedIn(false)
             root.selectedIndex = 0
         default:
             break

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -111,8 +111,7 @@ final class LoginCoordinator: NSObject,
     }
     
     func launchOnboardingCoordinator() {
-        if userStore.shouldPromptForAnalytics {
-            userStore.shouldPromptForAnalytics = false
+        if analyticsCenter.analyticsPreferenceStore.hasAcceptedAnalytics == nil {
             openChildModally(OnboardingCoordinator(analyticsPreferenceStore: analyticsCenter.analyticsPreferenceStore,
                                                    urlOpener: UIApplication.shared))
         }

--- a/Sources/Screens/Tabs/TabbedViewController.swift
+++ b/Sources/Screens/Tabs/TabbedViewController.swift
@@ -47,7 +47,10 @@ final class TabbedViewController: BaseViewController {
         guard let headerView = headerView as? SignInView else { return }
         headerView.userEmail = tokenHolder.idTokenPayload?.email
         resizeHeaderView()
-        viewModel.isLoggedIn = true
+    }
+    
+    func isLoggedIn(_ value: Bool) {
+        viewModel.isLoggedIn = value
     }
     
     func screenAnalytics() {

--- a/Sources/Tabs/HomeCoordinator.swift
+++ b/Sources/Tabs/HomeCoordinator.swift
@@ -36,8 +36,9 @@ final class HomeCoordinator: NSObject,
     
     func updateToken(_ token: TokenHolder) {
         baseVc?.updateToken(token)
+        baseVc?.isLoggedIn(true)
         baseVc?.screenAnalytics()
-        self.tokenHolder = token
+        tokenHolder = token
     }
     
     func showDeveloperMenu() {

--- a/Sources/Tabs/ProfileCoordinator.swift
+++ b/Sources/Tabs/ProfileCoordinator.swift
@@ -45,12 +45,10 @@ final class ProfileCoordinator: NSObject,
         let navController = UINavigationController()
         let vm = SignOutPageViewModel(analyticsService: analyticsCenter.analyticsService) { [unowned self] in
             do {
-                analyticsCenter.analyticsPreferenceStore.hasAcceptedAnalytics = false
-                analyticsCenter.analyticsService.denyAnalyticsPermission()
                 // TODO: DCMAW-8933 will handle sign out error scenarios
                 try? userStore.clearTokenInfo()
                 try? userStore.secureStoreService.delete()
-                userStore.shouldPromptForAnalytics = true
+                analyticsCenter.analyticsPreferenceStore.hasAcceptedAnalytics = nil
                 root.dismiss(animated: false) {
                     self.finish()
                 }

--- a/Sources/Tabs/ProfileCoordinator.swift
+++ b/Sources/Tabs/ProfileCoordinator.swift
@@ -49,8 +49,8 @@ final class ProfileCoordinator: NSObject,
                 try? userStore.clearTokenInfo()
                 try? userStore.secureStoreService.delete()
                 analyticsCenter.analyticsPreferenceStore.hasAcceptedAnalytics = nil
-                root.dismiss(animated: false) {
-                    self.finish()
+                root.dismiss(animated: false) { [unowned self] in
+                    finish()
                 }
             } catch {
                 print(error.localizedDescription)

--- a/Sources/Utilities/Storage/UserStorable.swift
+++ b/Sources/Utilities/Storage/UserStorable.swift
@@ -17,17 +17,6 @@ extension UserStorable {
         return accessTokenExpClaim.timeIntervalSinceNow.sign == .plus
     }
     
-    var shouldPromptForAnalytics: Bool {
-        get {
-            guard let shouldPrompt = defaultsStore.value(forKey: .shouldPromptForAnalytics) as? Bool else {
-                return true
-            }
-            return shouldPrompt
-        } set {
-            defaultsStore.set(newValue, forKey: .shouldPromptForAnalytics)
-        }
-    }
-    
     func storeTokenInfo(tokenResponse: TokenResponse) throws {
         let accessToken = tokenResponse.accessToken
         let tokenExp = tokenResponse.expiryDate

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -211,7 +211,7 @@ extension LoginCoordinatorTests {
     
     func test_launchOnboardingCoordinator_skips() throws {
         // GIVEN the user has accepted analytics permissions
-        mockUserStore.shouldPromptForAnalytics = false
+        mockAnalyticsPreferenceStore.hasAcceptedAnalytics = true
         // WHEN the LoginCoordinator's launchOnboardingCoordinator method is called
         sut.launchOnboardingCoordinator()
         // THEN the OnboardingCoordinator should not be launched

--- a/Tests/UnitTests/Tabs/ProfileCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/ProfileCoordinatorTests.swift
@@ -85,10 +85,10 @@ final class ProfileCoordinatorTests: XCTestCase {
         XCTAssertTrue(presentedVC.topViewController is GDSInstructionsViewController)
         let signOutButton: UIButton = try XCTUnwrap(presentedVC.topViewController!.view[child: "instructions-button"])
         signOutButton.sendActions(for: .touchUpInside)
-        XCTAssertFalse(try XCTUnwrap(mockAnalyticsService.hasAcceptedAnalytics!))
         XCTAssertNil(try mockUserStore.secureStoreService.readItem(itemName: .accessToken))
         XCTAssertNil(try mockUserStore.secureStoreService.readItem(itemName: .idToken))
         XCTAssertNil(mockDefaultStore.value(forKey: .accessTokenExpiry))
+        XCTAssertNil(mockAnalyticsPreference.hasAcceptedAnalytics)
     }
 }
 


### PR DESCRIPTION
# DCMAW-9299: iOS | Mobile Platform | Resetting analytics permissions

When the user signs out, the modal to select analytics permissions is only evident immediately after sign out and does not persist through the app being terminated and relaunched.
This PR amends that bug through a [fix to the logging package](https://github.com/govuk-one-login/mobile-ios-logging/pull/44) so we can effectively reset the analytics permissions for the user when they sign out of the app. Meaning they're prompted to accept/decline analytics permissions any time they come back to the app home page if they haven't set that preference

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
