### PR TITLE
fix:  dcmaw-9297 Handle errors in a more granular manner

### DIFF
--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -70,10 +70,7 @@ final class LoginCoordinator: NSObject,
                     root.dismiss(animated: false)
                     finish()
                 } catch {
-                    userStore.refreshStorage(accessControlLevel: LAContext().isPasscodeOnly ? .anyBiometricsOrPasscode : .currentBiometricsOrPasscode)
-                    windowManager.hideUnlockWindow()
-                    tokenReadError = error
-                    start()
+                    handleError(error)
                 }
             }
         }
@@ -137,6 +134,29 @@ final class LoginCoordinator: NSObject,
                                              userStore: userStore,
                                              localAuth: localAuth,
                                              tokenHolder: tokenHolder))
+    }
+}
+
+extension LoginCoordinator {
+    private func handleError(_ error: Error) {
+        tokenReadError = error
+        switch error {
+        case SecureStoreError.unableToRetrieveFromUserDefaults,
+            SecureStoreError.cantInitialiseData,
+            SecureStoreError.cantRetrieveKey:
+            restartLoginJourney()
+        case is JWTVerifierError:
+            restartLoginJourney()
+        default:
+            print("Token retrival error: \(error)")
+        }
+    }
+    
+    private func restartLoginJourney() {
+        tokenHolder.accessToken = nil
+        userStore.refreshStorage(accessControlLevel: LAContext().isPasscodeOnly ? .anyBiometricsOrPasscode : .currentBiometricsOrPasscode)
+        windowManager.hideUnlockWindow()
+        start()
     }
 }
 

--- a/Sources/Utilities/JWT/JWTVerifier.swift
+++ b/Sources/Utilities/JWT/JWTVerifier.swift
@@ -20,14 +20,22 @@ extension JWTVerifier {
             throw JWTVerifierError.invalidKID
         }
         
-        let verifier = try ES256KeyVerifier(jsonWebKey: jwk)
-        
-        return try verifier.verify(jwt: token)
+        do {
+            let verifier = try ES256KeyVerifier(jsonWebKey: jwk)
+            
+            return try verifier.verify(jwt: token)
+        } catch {
+            throw JWTVerifierError.invalidJWTFormat
+        }
     }
     
     func extractPayload(_ token: String) throws -> IdTokenPayload? {
         let extractor = try ES256KeyVerifier()
-        return try extractor.extract(jwt: token)
+        do {
+            return try extractor.extract(jwt: token)
+        } catch {
+            throw JWTVerifierError.invalidJWTFormat
+        }
     }
 }
 


### PR DESCRIPTION
# DCMAW-9297: iOS | Failed/Cancelled Login causes error screen instead of Unlock screen

Refactor to handle errors in a more granular manner, restoring previous secure store handling scheme and adding JWT verification errors.

Add unit tests to cover new scenarios

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
~~- [ ] Created a `draft` pull request if it is not yet ready for review~~

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~~- [ ] Met all accessibility requirements?~~
    ~~- [ ] Checked dynamic type sizes are applied~~
    ~~- [ ] Checked VoiceOver can navigate your new code~~
    ~~- [ ] Checked a user can navigate only using a keyboard around your new code~~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
