### PR TITLE
feat: doesn't always use unlock screen for snapshot when going to background

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -2646,8 +2646,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/govuk-one-login/mobile-ios-secure-store";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
 			};
 		};
 		D0BE243C2BEB7E5E00759529 /* XCRemoteSwiftPackageReference "jwt-kit" */ = {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "1fa7c85448908223f4eead79fe01e6cc23c9840495325eaa8c971fb885706179",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -199,5 +200,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -200,5 +200,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,4 @@
 {
-  "originHash" : "1fa7c85448908223f4eead79fe01e6cc23c9840495325eaa8c971fb885706179",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-secure-store",
       "state" : {
-        "branch" : "main",
-        "revision" : "32c462a63aeb3fee8cfeae886a0dc20e4c3ef2f5"
+        "revision" : "9d437ef2e55c8aedd41e654b5f6a52e126421625",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -44,12 +44,10 @@ final class MainCoordinator: NSObject,
             await MainActor.run {
                 if userStore.returningAuthenticatedUser {
                     do {
-                        guard let idToken = try userStore.secureStoreService.readItem(itemName: .idToken) else {
-                            throw SecureStoreError.unableToRetrieveFromUserDefaults
-                        }
+                        let idToken = try userStore.secureStoreService.readItem(itemName: .idToken)
                         tokenHolder.idTokenPayload = try tokenVerifier.extractPayload(idToken)
-                        updateToken()
                         action()
+                        updateToken()
                     } catch {
                         handleLoginError(error, action: action)
                     }
@@ -80,7 +78,7 @@ final class MainCoordinator: NSObject,
     private func refreshLogin(_ error: Error, action: () -> Void) {
         loginCoordinator?.root.dismiss(animated: false)
         tokenHolder.accessToken = nil
-        try? userStore.clearTokenInfo()
+        userStore.clearTokenInfo()
         showLogin(error)
         action()
     }

--- a/Sources/Application/SceneDelegate.swift
+++ b/Sources/Application/SceneDelegate.swift
@@ -34,11 +34,7 @@ class SceneDelegate: UIResponder,
         let tabController = UITabBarController()
         let analyticsCenter = AnalyticsCenter(analyticsService: analyticsService,
                                               analyticsPreferenceStore: UserDefaultsPreferenceStore())
-        let secureStoreService = SecureStoreService(configuration: .init(id: .oneLoginTokens,
-                                                                         accessControlLevel: .currentBiometricsOrPasscode,
-                                                                         localAuthStrings: LAContext().contextStrings))
-        let userStore = UserStorage(secureStoreService: secureStoreService,
-                                    defaultsStore: UserDefaults.standard)
+        let userStore = setUpUserStore()
         coordinator = MainCoordinator(windowManager: windowManager,
                                       root: tabController,
                                       analyticsCenter: analyticsCenter,
@@ -50,9 +46,14 @@ class SceneDelegate: UIResponder,
     }
     
     func sceneDidEnterBackground(_ scene: UIScene) {
-        displayUnlockScreen()
-    }
-    
+       let userStore = setUpUserStore()
+       if userStore.returningAuthenticatedUser {
+           displayUnlockScreen()
+       } else {
+           windowManager?.hideUnlockWindow()
+       }
+   }
+
     func sceneWillEnterForeground(_ scene: UIScene) {
         if shouldCallSceneWillEnterForeground {
             promptToUnlock()
@@ -65,5 +66,13 @@ class SceneDelegate: UIResponder,
         UITabBar.appearance().tintColor = .gdsGreen
         UITabBar.appearance().backgroundColor = .systemBackground
         UIBarButtonItem.appearance(whenContainedInInstancesOf: [UINavigationBar.self]).tintColor = .gdsGreen
+    }
+
+    private func setUpUserStore() -> UserStorable {
+        let secureStoreService = SecureStoreService(configuration: .init(id: .oneLoginTokens,
+                                                                         accessControlLevel: .currentBiometricsOrPasscode,
+                                                                         localAuthStrings: LAContext().contextStrings))
+        return UserStorage(secureStoreService: secureStoreService,
+                                    defaultsStore: UserDefaults.standard)
     }
 }

--- a/Sources/Application/SceneDelegate.swift
+++ b/Sources/Application/SceneDelegate.swift
@@ -13,7 +13,14 @@ class SceneDelegate: UIResponder,
     let analyticsService: AnalyticsService = GAnalytics()
     var windowManager: WindowManagement?
     private var shouldCallSceneWillEnterForeground = false
-    
+    private lazy var userStore: UserStorable = {
+        let secureStoreService = SecureStoreService(configuration: .init(id: .oneLoginTokens,
+                                                                         accessControlLevel: .currentBiometricsOrPasscode,
+                                                                         localAuthStrings: LAContext().contextStrings))
+        return UserStorage(secureStoreService: secureStoreService,
+                                    defaultsStore: UserDefaults.standard)
+    }()
+
     func scene(_ scene: UIScene,
                willConnectTo session: UISceneSession,
                options connectionOptions: UIScene.ConnectionOptions) {
@@ -34,7 +41,6 @@ class SceneDelegate: UIResponder,
         let tabController = UITabBarController()
         let analyticsCenter = AnalyticsCenter(analyticsService: analyticsService,
                                               analyticsPreferenceStore: UserDefaultsPreferenceStore())
-        let userStore = setUpUserStore()
         coordinator = MainCoordinator(windowManager: windowManager,
                                       root: tabController,
                                       analyticsCenter: analyticsCenter,
@@ -46,11 +52,8 @@ class SceneDelegate: UIResponder,
     }
     
     func sceneDidEnterBackground(_ scene: UIScene) {
-       let userStore = setUpUserStore()
        if userStore.returningAuthenticatedUser {
            displayUnlockScreen()
-       } else {
-           windowManager?.hideUnlockWindow()
        }
    }
 
@@ -66,13 +69,5 @@ class SceneDelegate: UIResponder,
         UITabBar.appearance().tintColor = .gdsGreen
         UITabBar.appearance().backgroundColor = .systemBackground
         UIBarButtonItem.appearance(whenContainedInInstancesOf: [UINavigationBar.self]).tintColor = .gdsGreen
-    }
-
-    private func setUpUserStore() -> UserStorable {
-        let secureStoreService = SecureStoreService(configuration: .init(id: .oneLoginTokens,
-                                                                         accessControlLevel: .currentBiometricsOrPasscode,
-                                                                         localAuthStrings: LAContext().contextStrings))
-        return UserStorage(secureStoreService: secureStoreService,
-                                    defaultsStore: UserDefaults.standard)
     }
 }

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -62,9 +62,7 @@ final class LoginCoordinator: NSObject,
         Task {
             await MainActor.run {
                 do {
-                    guard let idToken = try userStore.secureStoreService.readItem(itemName: .idToken) else {
-                        throw SecureStoreError.unableToRetrieveFromUserDefaults
-                    }
+                    let idToken = try userStore.secureStoreService.readItem(itemName: .idToken)
                     tokenHolder.idTokenPayload = try tokenVerifier.extractPayload(idToken)
                     windowManager.hideUnlockWindow()
                     root.dismiss(animated: false)

--- a/Sources/Tabs/ProfileCoordinator.swift
+++ b/Sources/Tabs/ProfileCoordinator.swift
@@ -45,15 +45,12 @@ final class ProfileCoordinator: NSObject,
         let navController = UINavigationController()
         let vm = SignOutPageViewModel(analyticsService: analyticsCenter.analyticsService) { [unowned self] in
             do {
-                // TODO: DCMAW-8933 will handle sign out error scenarios
-                try? userStore.clearTokenInfo()
-                try? userStore.secureStoreService.delete()
+                userStore.clearTokenInfo()
                 analyticsCenter.analyticsPreferenceStore.hasAcceptedAnalytics = nil
+                try? userStore.secureStoreService.delete()
                 root.dismiss(animated: false) { [unowned self] in
                     finish()
                 }
-            } catch {
-                print(error.localizedDescription)
             }
         }
         let signoutPageVC = GDSInstructionsViewController(viewModel: vm)

--- a/Sources/Utilities/Storage/UserStorable.swift
+++ b/Sources/Utilities/Storage/UserStorable.swift
@@ -32,9 +32,9 @@ extension UserStorable {
         }
     }
     
-    func clearTokenInfo() throws {
-        try secureStoreService.deleteItem(itemName: .accessToken)
-        try secureStoreService.deleteItem(itemName: .idToken)
+    func clearTokenInfo() {
+        secureStoreService.deleteItem(itemName: .accessToken)
+        secureStoreService.deleteItem(itemName: .idToken)
         defaultsStore.removeObject(forKey: .accessTokenExpiry)
     }
 }

--- a/Sources/Utilities/Storage/UserStorage.swift
+++ b/Sources/Utilities/Storage/UserStorage.swift
@@ -13,7 +13,7 @@ final class UserStorage: UserStorable {
     
     func refreshStorage(accessControlLevel: SecureStorageConfiguration.AccessControlLevel) {
         do {
-            try clearTokenInfo()
+            clearTokenInfo()
             try secureStoreService.delete()
         } catch {
             print("Deleting Secure Store error: \(error)")

--- a/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockSecureStoreService.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockSecureStoreService.swift
@@ -16,15 +16,18 @@ final class MockSecureStoreService: SecureStorable {
         }
     }
     
-    func readItem(itemName: String) throws -> String? {
+    func readItem(itemName: String) throws -> String {
         if let errorFromReadItem {
             throw errorFromReadItem
         } else {
-            savedItems[itemName]
+            guard let savedItem = savedItems[itemName] else {
+                throw SecureStoreError.unableToRetrieveFromUserDefaults
+            }
+            return savedItem
         }
     }
     
-    func deleteItem(itemName: String) throws {
+    func deleteItem(itemName: String) {
         savedItems[itemName] = nil
     }
     
@@ -32,5 +35,5 @@ final class MockSecureStoreService: SecureStorable {
         self.didCallDeleteStore = true
     }
     
-    func checkItemExists(itemName: String) throws -> Bool { true }
+    func checkItemExists(itemName: String) -> Bool { true }
 }

--- a/Tests/UnitTests/Tabs/ProfileCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/ProfileCoordinatorTests.swift
@@ -85,8 +85,8 @@ final class ProfileCoordinatorTests: XCTestCase {
         XCTAssertTrue(presentedVC.topViewController is GDSInstructionsViewController)
         let signOutButton: UIButton = try XCTUnwrap(presentedVC.topViewController!.view[child: "instructions-button"])
         signOutButton.sendActions(for: .touchUpInside)
-        XCTAssertNil(try mockUserStore.secureStoreService.readItem(itemName: .accessToken))
-        XCTAssertNil(try mockUserStore.secureStoreService.readItem(itemName: .idToken))
+        XCTAssertNil(try? mockUserStore.secureStoreService.readItem(itemName: .accessToken))
+        XCTAssertNil(try? mockUserStore.secureStoreService.readItem(itemName: .idToken))
         XCTAssertNil(mockDefaultStore.value(forKey: .accessTokenExpiry))
         XCTAssertNil(mockAnalyticsPreference.hasAcceptedAnalytics)
     }


### PR DESCRIPTION
# DCMAW-9253: Don't display unlock screen when app sent to the background if user hasn't logged in or hasn't set up local auth

This PR adds a check in sceneDidEnterBackground to see if the user is a returning user. If they are, then the unlock screen is shown when switching apps. If not, i.e they haven't logged in, then the screen the user was last on is used. 

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- <s>[ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code</s>

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
