### PR TITLE
feat:  dcmaw 8933 sign out error page

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -147,6 +147,7 @@
 		D03B04D32BEE734900418C0B /* IdTokenPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03B04D22BEE734900418C0B /* IdTokenPayload.swift */; };
 		D03B04D52BF221BD00418C0B /* JWTVerifierError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03B04D42BF221BD00418C0B /* JWTVerifierError.swift */; };
 		D0825A952C12F5B800E940F7 /* SignoutErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0825A942C12F5B800E940F7 /* SignoutErrorViewModel.swift */; };
+		D087BCF22C19E4BB00825F60 /* SignoutErrorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D087BCF12C19E4BB00825F60 /* SignoutErrorViewModelTests.swift */; };
 		D08B0B552BD7F84300769CEA /* DeveloperMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B532BD7F84300769CEA /* DeveloperMenuViewController.swift */; };
 		D08B0B562BD7F84300769CEA /* DeveloperMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = D08B0B542BD7F84300769CEA /* DeveloperMenu.xib */; };
 		D08B0B582BD7F97200769CEA /* DeveloperMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B572BD7F97200769CEA /* DeveloperMenuViewModel.swift */; };
@@ -350,6 +351,7 @@
 		D03B04D22BEE734900418C0B /* IdTokenPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdTokenPayload.swift; sourceTree = "<group>"; };
 		D03B04D42BF221BD00418C0B /* JWTVerifierError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWTVerifierError.swift; sourceTree = "<group>"; };
 		D0825A942C12F5B800E940F7 /* SignoutErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignoutErrorViewModel.swift; sourceTree = "<group>"; };
+		D087BCF12C19E4BB00825F60 /* SignoutErrorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignoutErrorViewModelTests.swift; sourceTree = "<group>"; };
 		D08B0B532BD7F84300769CEA /* DeveloperMenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperMenuViewController.swift; sourceTree = "<group>"; };
 		D08B0B542BD7F84300769CEA /* DeveloperMenu.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DeveloperMenu.xib; sourceTree = "<group>"; };
 		D08B0B572BD7F97200769CEA /* DeveloperMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperMenuViewModel.swift; sourceTree = "<group>"; };
@@ -684,6 +686,7 @@
 			children = (
 				413C58772BF266A200171C06 /* ProfileTabViewModelTests.swift */,
 				41279DD62BFF46DB00E16537 /* SignOutPageViewModelTests.swift */,
+				D087BCF12C19E4BB00825F60 /* SignoutErrorViewModelTests.swift */,
 			);
 			path = Profile;
 			sourceTree = "<group>";
@@ -1607,6 +1610,7 @@
 				41C5E3322B45B07D00212A12 /* NetworkConnectionErrorViewModelTests.swift in Sources */,
 				411D1FD32B73CA74002393D1 /* TouchIDEnrollmentViewModelTests.swift in Sources */,
 				C8B5EFC52B0E53EE004EA4D4 /* XCTestCase+TestExtensions.swift in Sources */,
+				D087BCF22C19E4BB00825F60 /* SignoutErrorViewModelTests.swift in Sources */,
 				1E717D732B72937500CCAF3E /* MockLAContext.swift in Sources */,
 				1E38C0E12B7CE249002B49A0 /* String+TestExtensions.swift in Sources */,
 				D08B0B5C2BD8046200769CEA /* HomeCoordinatorTests.swift in Sources */,

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -146,6 +146,7 @@
 		D03B04CF2BECDB5C00418C0B /* KeyVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03B04CE2BECDB5C00418C0B /* KeyVerifier.swift */; };
 		D03B04D32BEE734900418C0B /* IdTokenPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03B04D22BEE734900418C0B /* IdTokenPayload.swift */; };
 		D03B04D52BF221BD00418C0B /* JWTVerifierError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03B04D42BF221BD00418C0B /* JWTVerifierError.swift */; };
+		D0825A952C12F5B800E940F7 /* SignoutErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0825A942C12F5B800E940F7 /* SignoutErrorViewModel.swift */; };
 		D08B0B552BD7F84300769CEA /* DeveloperMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B532BD7F84300769CEA /* DeveloperMenuViewController.swift */; };
 		D08B0B562BD7F84300769CEA /* DeveloperMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = D08B0B542BD7F84300769CEA /* DeveloperMenu.xib */; };
 		D08B0B582BD7F97200769CEA /* DeveloperMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B572BD7F97200769CEA /* DeveloperMenuViewModel.swift */; };
@@ -348,6 +349,7 @@
 		D03B04CE2BECDB5C00418C0B /* KeyVerifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyVerifier.swift; sourceTree = "<group>"; };
 		D03B04D22BEE734900418C0B /* IdTokenPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdTokenPayload.swift; sourceTree = "<group>"; };
 		D03B04D42BF221BD00418C0B /* JWTVerifierError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWTVerifierError.swift; sourceTree = "<group>"; };
+		D0825A942C12F5B800E940F7 /* SignoutErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignoutErrorViewModel.swift; sourceTree = "<group>"; };
 		D08B0B532BD7F84300769CEA /* DeveloperMenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperMenuViewController.swift; sourceTree = "<group>"; };
 		D08B0B542BD7F84300769CEA /* DeveloperMenu.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DeveloperMenu.xib; sourceTree = "<group>"; };
 		D08B0B572BD7F97200769CEA /* DeveloperMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperMenuViewModel.swift; sourceTree = "<group>"; };
@@ -567,6 +569,7 @@
 				41FF35AB2B21F1AA00419DB3 /* GenericErrorViewModel.swift */,
 				41C5E32E2B45A36E00212A12 /* NetworkConnectionErrorViewModel.swift */,
 				C8AA11D72B29C7FA00CE718B /* UnableToLoginErrorViewModel.swift */,
+				D0825A942C12F5B800E940F7 /* SignoutErrorViewModel.swift */,
 			);
 			path = Errors;
 			sourceTree = "<group>";
@@ -1522,6 +1525,7 @@
 				C8ECA1322BB73E2E00722218 /* WindowManager.swift in Sources */,
 				D08B0B652BDA478000769CEA /* SignInView.swift in Sources */,
 				41C5E32F2B45A36E00212A12 /* NetworkConnectionErrorViewModel.swift in Sources */,
+				D0825A952C12F5B800E940F7 /* SignoutErrorViewModel.swift in Sources */,
 				D08B0B7D2BDBF86100769CEA /* TabbedViewSectionHeader.swift in Sources */,
 				D08B0B872BDFE2DA00769CEA /* TabbedViewSectionFooter.swift in Sources */,
 				C8B825C32B98C34A00336146 /* LoginCoordinator.swift in Sources */,

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "1fa7c85448908223f4eead79fe01e6cc23c9840495325eaa8c971fb885706179",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -199,5 +200,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,4 @@
 {
-  "originHash" : "1fa7c85448908223f4eead79fe01e6cc23c9840495325eaa8c971fb885706179",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -200,5 +199,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/Sources/Application/Environment/AppEnvironment.swift
+++ b/Sources/Application/Environment/AppEnvironment.swift
@@ -164,4 +164,8 @@ extension AppEnvironment {
     static var extendExpClaimEnabled: Bool {
         isFeatureEnabled(for: .extendExpClaim)
     }
+    
+    static var signoutErrorEnabled: Bool {
+        isFeatureEnabled(for: .enableSignoutError)
+    }
 }

--- a/Sources/Application/Environment/FlagManager.swift
+++ b/Sources/Application/Environment/FlagManager.swift
@@ -8,6 +8,7 @@ public enum FeatureFlags: String {
     
     case enableCallingSTS = "EnableCallingSTS"
     case extendExpClaim = "ExtendExpClaim"
+    case enableSignoutError = "EnableSignoutError"
 }
 
 struct FlagManager {

--- a/Sources/Application/SupportingFiles/FeatureFlags/FeatureFlagsBuild.json
+++ b/Sources/Application/SupportingFiles/FeatureFlags/FeatureFlagsBuild.json
@@ -6,5 +6,9 @@
     {
         "name": "ExtendExpClaim",
         "isEnabled": false
+    },
+    {
+        "name": "EnableSignoutError",
+        "isEnabled": false
     }
 ]

--- a/Sources/Application/SupportingFiles/FeatureFlags/FeatureFlagsStaging.json
+++ b/Sources/Application/SupportingFiles/FeatureFlags/FeatureFlagsStaging.json
@@ -6,5 +6,9 @@
     {
         "name": "ExtendExpClaim",
         "isEnabled": false
+    },
+    {
+        "name": "EnableSignoutError",
+        "isEnabled": false
     }
 ]

--- a/Sources/Errors/SignoutErrorViewModel.swift
+++ b/Sources/Errors/SignoutErrorViewModel.swift
@@ -1,0 +1,29 @@
+import GDSAnalytics
+import GDSCommon
+import Logging
+
+struct SignoutErrorViewModel: GDSErrorViewModel, BaseViewModel {
+    let image: String = "exclamationmark.circle"
+    let title: GDSLocalisedString = "app_signOutErrorTitle"
+    let body: GDSLocalisedString = "app_signOutErrorBody"
+    let primaryButtonViewModel: ButtonViewModel
+    let secondaryButtonViewModel: ButtonViewModel? = nil
+    let analyticsService: AnalyticsService
+    let errorDescription: String
+    
+    let rightBarButtonTitle: GDSLocalisedString? = nil
+    let backButtonIsHidden: Bool = true
+    
+    init(errorDescription: String, analyticsService: AnalyticsService, action: @escaping () -> Void) {
+        self.errorDescription = errorDescription
+        self.analyticsService = analyticsService
+        self.primaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "app_exitButton",
+                                                               analyticsService: analyticsService) {
+            action()
+        }
+    }
+    
+    func didAppear() { /* BaseViewModel compliance */ }
+    
+    func didDismiss() { /* BaseViewModel compliance */ }
+}

--- a/Sources/Resources/cy-GB.lproj/Localizable.strings
+++ b/Sources/Resources/cy-GB.lproj/Localizable.strings
@@ -139,3 +139,10 @@
 "app_signOutConfirmationBody3" = "Bydd unrhyw ddogfennau sydd wedi'u dileu yn dal i fod ar gael ar-lein i chi eu hychwanegu at eich GOV.UK Wallet eto.";
 
 "app_signOutAndDeleteAppDataButton" = "Allgofnodwch a dileu data yr ap";
+
+// Mark: Sign Out Error screen
+"app_signOutErrorTitle" = "Roedd problem wrth eich allgofnodi";
+
+"app_signOutErrorBody" = "Gallwch orfodi allgofnodi trwy ddileu'r ap o'ch dyfais.";
+
+"app_exitButton" = "Gadael";

--- a/Sources/Resources/en.lproj/Localizable.strings
+++ b/Sources/Resources/en.lproj/Localizable.strings
@@ -139,3 +139,10 @@
 "app_signOutConfirmationBody3" = "Any deleted documents will still be available online for you to add to your GOV.UK Wallet again.";
 
 "app_signOutAndDeleteAppDataButton" = "Sign out and delete app data";
+
+// Mark: Sign Out Error screen
+"app_signOutErrorTitle" = "There was a problem signing you out";
+
+"app_signOutErrorBody" = "You can force sign out by deleting the app from your device.";
+
+"app_exitButton" = "Exit";

--- a/Sources/Tabs/ProfileCoordinator.swift
+++ b/Sources/Tabs/ProfileCoordinator.swift
@@ -59,9 +59,8 @@ final class ProfileCoordinator: NSObject,
                     finish()
                 }
             } catch {
-                print(error.localizedDescription)
-                let errorVC = ErrorPresenter.createSignoutError(errorDescription: error.localizedDescription
-                                                                , analyticsService: analyticsCenter.analyticsService) {
+                let errorVC = ErrorPresenter.createSignoutError(errorDescription: error.localizedDescription,
+                                                                analyticsService: analyticsCenter.analyticsService) {
                     exit(0)
                 }
                 navController.pushViewController(errorVC, animated: true)

--- a/Sources/Utilities/Factories/ErrorPresenter.swift
+++ b/Sources/Utilities/Factories/ErrorPresenter.swift
@@ -29,4 +29,15 @@ final class ErrorPresenter {
         }
         return GDSErrorViewController(viewModel: viewModel)
     }
+    
+    
+    static func createSignoutError(errorDescription: String,
+                                   analyticsService: AnalyticsService,
+                                   action: @escaping () -> Void) -> GDSErrorViewController {
+        let viewModel = SignoutErrorViewModel(errorDescription: errorDescription,
+                                                    analyticsService: analyticsService) {
+            action()
+        }
+        return GDSErrorViewController(viewModel: viewModel)
+    }
 }

--- a/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockSecureStoreService.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockSecureStoreService.swift
@@ -7,6 +7,7 @@ final class MockSecureStoreService: SecureStorable {
     
     var errorFromSaveItem: Error?
     var errorFromReadItem: Error?
+    var errorFromDeleteItem: Error?
     
     func saveItem(item: String, itemName: String) throws {
         if let errorFromSaveItem {
@@ -33,6 +34,9 @@ final class MockSecureStoreService: SecureStorable {
     
     func delete() throws {
         self.didCallDeleteStore = true
+        if let errorFromDeleteItem {
+            throw errorFromDeleteItem
+        }
     }
     
     func checkItemExists(itemName: String) -> Bool { true }

--- a/Tests/UnitTests/Screens/Profile/SignoutErrorViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Profile/SignoutErrorViewModelTests.swift
@@ -1,0 +1,53 @@
+import GDSAnalytics
+import GDSCommon
+@testable import OneLogin
+import XCTest
+
+import Foundation
+
+final class SignoutErrorViewModelTests: XCTestCase {
+    var mockAnalyticsService: MockAnalyticsService!
+    var sut: SignoutErrorViewModel!
+    
+    var didCallButtonAction = false
+    
+    override func setUp() {
+        super.setUp()
+        
+        mockAnalyticsService = MockAnalyticsService()
+        sut = SignoutErrorViewModel(errorDescription: "Error",
+                                    analyticsService: mockAnalyticsService) {
+            self.didCallButtonAction = true
+        }
+    }
+    
+    override func tearDown() {
+        mockAnalyticsService = nil
+        sut = nil
+        didCallButtonAction = false
+    }
+}
+
+extension SignoutErrorViewModelTests {
+    func test_pageConfiguration() throws {
+        XCTAssertEqual(sut.title.stringKey, "app_signOutErrorTitle")
+        XCTAssertEqual(sut.body, "app_signOutErrorBody")
+        XCTAssertNil(sut.secondaryButtonViewModel)
+        XCTAssertNil(sut.rightBarButtonTitle)
+        XCTAssertTrue(sut.backButtonIsHidden)
+        XCTAssertEqual(sut.errorDescription, "Error")
+    }
+    
+    func test_buttonConfiuration() throws {
+        XCTAssertTrue(sut.primaryButtonViewModel is AnalyticsButtonViewModel)
+        XCTAssertEqual(sut.primaryButtonViewModel.title, GDSLocalisedString(stringLiteral: "app_exitButton"))
+        let button = try XCTUnwrap(sut.primaryButtonViewModel as? AnalyticsButtonViewModel)
+        XCTAssertEqual(button.backgroundColor, .gdsGreen)
+    }
+    
+    func test_buttonAction() throws {
+        XCTAssertFalse(didCallButtonAction)
+        sut.primaryButtonViewModel.action()
+        XCTAssertTrue(didCallButtonAction)
+    }
+}

--- a/Tests/UnitTests/Utilities/ErrorPresenterTests.swift
+++ b/Tests/UnitTests/Utilities/ErrorPresenterTests.swift
@@ -50,4 +50,15 @@ extension ErrorPresenterTests {
         introButton.sendActions(for: .touchUpInside)
         XCTAssertTrue(didCallAction)
     }
+    
+    func test_signoutError_callsAction() throws {
+        let errorView = sut.createSignoutError(errorDescription: "error description",
+                                               analyticsService: mockAnalyticsService) {
+            self.didCallAction = true
+        }
+        let exitButton: UIButton = try XCTUnwrap(errorView.view[child: "error-primary-button"])
+        exitButton.sendActions(for: .touchUpInside)
+        XCTAssertTrue(didCallAction)
+
+    }
 }


### PR DESCRIPTION
# DCMAW-8933 | iOS | sign out error page

If sign out fails due to an error on deletion, present an error page with a button exiting the app
For testing, I have added a feature flag that can toggle the deletion error being thrown, as the actual likelihood it will fail is close to zero.  This likelihood will change (slightly) once wallet integration is completed.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
