### PR TITLE
feat: delete wallet credential on sign out

### DIFF
--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -172,9 +172,19 @@ extension MainCoordinator: ParentCoordinator {
         case _ as LoginCoordinator:
             updateToken()
         case _ as ProfileCoordinator:
-            fullLogin()
-            homeCoordinator?.baseVc?.isLoggedIn(false)
-            root.selectedIndex = 0
+            do {
+                try walletCoordinator?.clearWallet()
+                fullLogin()
+                homeCoordinator?.baseVc?.isLoggedIn(false)
+                root.selectedIndex = 0
+            } catch {
+                let errorVC = ErrorPresenter.createSignoutError(errorDescription: error.localizedDescription,
+                                                                analyticsService: analyticsCenter.analyticsService) {
+                    exit(0)
+                }
+                errorVC.modalPresentationStyle = .overFullScreen
+                root.present(errorVC, animated: false)
+            }
         default:
             break
         }

--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -129,7 +129,7 @@ extension MainCoordinator {
     }
     
     private func addProfileTab() {
-        let pc = ProfileCoordinator(analyticsCenter: analyticsCenter,
+        let pc = ProfileCoordinator(analyticsService: analyticsCenter.analyticsService,
                                     userStore: userStore,
                                     tokenHolder: tokenHolder,
                                     urlOpener: UIApplication.shared)
@@ -174,6 +174,7 @@ extension MainCoordinator: ParentCoordinator {
         case _ as ProfileCoordinator:
             do {
                 try walletCoordinator?.clearWallet()
+                analyticsCenter.analyticsPreferenceStore.hasAcceptedAnalytics = nil
                 fullLogin()
                 homeCoordinator?.baseVc?.isLoggedIn(false)
                 root.selectedIndex = 0

--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -72,7 +72,7 @@ final class MainCoordinator: NSObject,
             return
         }
     }
-
+    
     private func fullLogin(_ error: Error? = nil) {
         tokenHolder.clearTokenHolder()
         userStore.refreshStorage(accessControlLevel: LAContext().isPasscodeOnly ? .anyBiometricsOrPasscode : .currentBiometricsOrPasscode)
@@ -191,11 +191,11 @@ extension MainCoordinator: ParentCoordinator {
                 root.selectedIndex = 0
             } catch {
                 let navController = UINavigationController()
-                let errorVC = ErrorPresenter.createSignoutError(errorDescription: error.localizedDescription,
-                                                                analyticsService: analyticsCenter.analyticsService) {
+                let signOutErrorScreen = ErrorPresenter.createSignoutError(errorDescription: error.localizedDescription,
+                                                                           analyticsService: analyticsCenter.analyticsService) {
                     exit(0)
                 }
-                navController.setViewControllers([errorVC], animated: true)
+                navController.setViewControllers([signOutErrorScreen], animated: false)
                 root.present(navController, animated: true)
             }
         }

--- a/Sources/Errors/SignoutErrorViewModel.swift
+++ b/Sources/Errors/SignoutErrorViewModel.swift
@@ -11,7 +11,7 @@ struct SignoutErrorViewModel: GDSErrorViewModel, BaseViewModel {
     let analyticsService: AnalyticsService
     let errorDescription: String
     
-    let rightBarButtonTitle: GDSLocalisedString? = nil
+    let rightBarButtonTitle: GDSLocalisedString? = "app_cancelButton"
     let backButtonIsHidden: Bool = true
     
     init(errorDescription: String, analyticsService: AnalyticsService, action: @escaping () -> Void) {

--- a/Sources/Tabs/HomeCoordinator.swift
+++ b/Sources/Tabs/HomeCoordinator.swift
@@ -44,15 +44,15 @@ final class HomeCoordinator: NSObject,
     
     func showDeveloperMenu() {
         let navController = UINavigationController()
-        let devMenuViewModel = DeveloperMenuViewModel()
+        let viewModel = DeveloperMenuViewModel()
         if tokenHolder.accessToken == nil,
             let accessToken = try? userStore.secureStoreService.readItem(itemName: .accessToken) {
             tokenHolder.accessToken = accessToken
         }
         networkClient = NetworkClient(authenticationProvider: tokenHolder)
-        let developerMenuVC = DeveloperMenuViewController(viewModel: devMenuViewModel,
+        let devMenuViewController = DeveloperMenuViewController(viewModel: viewModel,
                                                           networkClient: networkClient)
-        navController.setViewControllers([developerMenuVC], animated: true)
+        navController.setViewControllers([devMenuViewController], animated: true)
         root.present(navController, animated: true)
     }
 }

--- a/Sources/Tabs/ProfileCoordinator.swift
+++ b/Sources/Tabs/ProfileCoordinator.swift
@@ -49,25 +49,12 @@ final class ProfileCoordinator: NSObject,
     func openSignOutPage() {
         let navController = UINavigationController()
         let vm = SignOutPageViewModel(analyticsService: analyticsService) { [unowned self] in
-            do {
-                #if DEBUG
-                if AppEnvironment.signoutErrorEnabled {
-                    throw SecureStoreError.cantDeleteKey
-                }
-                #endif
-                root.dismiss(animated: false) { [unowned self] in
-                    finish()
-                }
-            } catch {
-                let errorVC = ErrorPresenter.createSignoutError(errorDescription: error.localizedDescription,
-                                                                analyticsService: analyticsService) {
-                    exit(0)
-                }
-                navController.pushViewController(errorVC, animated: true)
+            navController.dismiss(animated: true) { [unowned self] in
+                parentCoordinator?.childDidFinish(self)
             }
         }
         let signoutPageVC = GDSInstructionsViewController(viewModel: vm)
-        navController.setViewControllers([signoutPageVC], animated: true)
+        navController.setViewControllers([signoutPageVC], animated: false)
         root.present(navController, animated: true)
     }
 }

--- a/Sources/Tabs/ProfileCoordinator.swift
+++ b/Sources/Tabs/ProfileCoordinator.swift
@@ -48,13 +48,13 @@ final class ProfileCoordinator: NSObject,
     
     func openSignOutPage() {
         let navController = UINavigationController()
-        let vm = SignOutPageViewModel(analyticsService: analyticsService) { [unowned self] in
+        let viewModel = SignOutPageViewModel(analyticsService: analyticsService) { [unowned self] in
             navController.dismiss(animated: true) { [unowned self] in
                 parentCoordinator?.childDidFinish(self)
             }
         }
-        let signoutPageVC = GDSInstructionsViewController(viewModel: vm)
-        navController.setViewControllers([signoutPageVC], animated: false)
+        let signOutViewController = GDSInstructionsViewController(viewModel: viewModel)
+        navController.setViewControllers([signOutViewController], animated: false)
         root.present(navController, animated: true)
     }
 }

--- a/Sources/Tabs/ProfileCoordinator.swift
+++ b/Sources/Tabs/ProfileCoordinator.swift
@@ -11,18 +11,18 @@ final class ProfileCoordinator: NSObject,
                                 NavigationCoordinator {
     let root = UINavigationController()
     weak var parentCoordinator: ParentCoordinator?
-    var analyticsCenter: AnalyticsCentral
+    var analyticsService: AnalyticsService
     var userStore: UserStorable
     private var tokenHolder: TokenHolder
     private let urlOpener: URLOpener
     private(set) var baseVc: TabbedViewController?
     
-    init(analyticsCenter: AnalyticsCentral,
+    init(analyticsService: AnalyticsService,
          userStore: UserStorable,
          tokenHolder: TokenHolder,
          urlOpener: URLOpener,
          baseVc: TabbedViewController? = nil) {
-        self.analyticsCenter = analyticsCenter
+        self.analyticsService = analyticsService
         self.userStore = userStore
         self.tokenHolder = tokenHolder
         self.urlOpener = urlOpener
@@ -33,7 +33,7 @@ final class ProfileCoordinator: NSObject,
         root.tabBarItem = UITabBarItem(title: GDSLocalisedString(stringLiteral: "app_profileTitle").value,
                                        image: UIImage(systemName: "person.crop.circle"),
                                        tag: 2)
-        let viewModel = ProfileTabViewModel(analyticsService: analyticsCenter.analyticsService,
+        let viewModel = ProfileTabViewModel(analyticsService: analyticsService,
                                             sectionModels: TabbedViewSectionFactory.profileSections(urlOpener: urlOpener,
                                                                                                     action: openSignOutPage))
         let profileViewController = TabbedViewController(viewModel: viewModel,
@@ -48,20 +48,19 @@ final class ProfileCoordinator: NSObject,
     
     func openSignOutPage() {
         let navController = UINavigationController()
-        let vm = SignOutPageViewModel(analyticsService: analyticsCenter.analyticsService) { [unowned self] in
+        let vm = SignOutPageViewModel(analyticsService: analyticsService) { [unowned self] in
             do {
                 #if DEBUG
                 if AppEnvironment.signoutErrorEnabled {
                     throw SecureStoreError.cantDeleteKey
                 }
                 #endif
-                analyticsCenter.analyticsPreferenceStore.hasAcceptedAnalytics = nil
                 root.dismiss(animated: false) { [unowned self] in
                     finish()
                 }
             } catch {
                 let errorVC = ErrorPresenter.createSignoutError(errorDescription: error.localizedDescription,
-                                                                analyticsService: analyticsCenter.analyticsService) {
+                                                                analyticsService: analyticsService) {
                     exit(0)
                 }
                 navController.pushViewController(errorVC, animated: true)

--- a/Sources/Tabs/WalletCoordinator.swift
+++ b/Sources/Tabs/WalletCoordinator.swift
@@ -43,4 +43,8 @@ final class WalletCoordinator: NSObject,
                         persistentSecureStore: secureStoreService)
 
     }
+    
+    func clearWallet() throws {
+        try walletSDK.deleteWalletData()
+    }
 }

--- a/Tests/UnitTests/Screens/Profile/SignoutErrorViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Profile/SignoutErrorViewModelTests.swift
@@ -33,7 +33,7 @@ extension SignoutErrorViewModelTests {
         XCTAssertEqual(sut.title.stringKey, "app_signOutErrorTitle")
         XCTAssertEqual(sut.body, "app_signOutErrorBody")
         XCTAssertNil(sut.secondaryButtonViewModel)
-        XCTAssertNil(sut.rightBarButtonTitle)
+        XCTAssertEqual(sut.rightBarButtonTitle?.stringKey, "app_cancelButton")
         XCTAssertTrue(sut.backButtonIsHidden)
         XCTAssertEqual(sut.errorDescription, "Error")
     }

--- a/Tests/UnitTests/Tabs/ProfileCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/ProfileCoordinatorTests.swift
@@ -77,18 +77,9 @@ final class ProfileCoordinatorTests: XCTestCase {
         sut.start()
         sut.openSignOutPage()
         let presentedVC = try XCTUnwrap(sut.root.presentedViewController as? UINavigationController)
-        XCTAssertTrue(presentedVC.topViewController is GDSInstructionsViewController)
         // WHEN the user signs out
-        let signOutButton: UIButton = try XCTUnwrap(presentedVC.topViewController!.view[child: "instructions-button"])
+        let signOutButton: UIButton = try XCTUnwrap(presentedVC.topViewController?.view[child: "instructions-button"])
         signOutButton.sendActions(for: .touchUpInside)
         waitForTruth(self.sut.root.presentedViewController == nil, timeout: 20)
-    }
-}
-
-extension ProfileCoordinatorTests {
-    var hasAcceptedAnalytics: Bool {
-        get throws {
-            try XCTUnwrap(mockAnalyticsService.hasAcceptedAnalytics)
-        }
     }
 }

--- a/Tests/UnitTests/Tabs/ProfileCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/ProfileCoordinatorTests.swift
@@ -7,8 +7,6 @@ import XCTest
 final class ProfileCoordinatorTests: XCTestCase {
     var window: UIWindow!
     var mockAnalyticsService: MockAnalyticsService!
-    var mockAnalyticsPreference: MockAnalyticsPreferenceStore!
-    var mockAnalyticsCenter: MockAnalyticsCenter!
     var mockSecureStoreService: MockSecureStoreService!
     var mockDefaultStore: MockDefaultsStore!
     var mockUserStore: UserStorage!
@@ -21,16 +19,13 @@ final class ProfileCoordinatorTests: XCTestCase {
         
         window = .init()
         mockAnalyticsService = MockAnalyticsService()
-        mockAnalyticsPreference = MockAnalyticsPreferenceStore()
-        mockAnalyticsCenter = MockAnalyticsCenter(analyticsService: mockAnalyticsService,
-                                                  analyticsPreferenceStore: mockAnalyticsPreference)
         mockSecureStoreService = MockSecureStoreService()
         mockDefaultStore = MockDefaultsStore()
         mockUserStore = UserStorage(secureStoreService: mockSecureStoreService,
                                     defaultsStore: mockDefaultStore)
         tokenHolder = TokenHolder()
         urlOpener = MockURLOpener()
-        sut = ProfileCoordinator(analyticsCenter: mockAnalyticsCenter,
+        sut = ProfileCoordinator(analyticsService: mockAnalyticsService,
                                  userStore: mockUserStore,
                                  tokenHolder: tokenHolder,
                                  urlOpener: urlOpener)
@@ -41,8 +36,6 @@ final class ProfileCoordinatorTests: XCTestCase {
     override func tearDown() {
         window = nil
         mockAnalyticsService = nil
-        mockAnalyticsPreference = nil
-        mockAnalyticsCenter = nil
         mockSecureStoreService = nil
         mockDefaultStore = nil
         mockUserStore = nil
@@ -81,7 +74,6 @@ final class ProfileCoordinatorTests: XCTestCase {
     
     func test_tapSignoutClearsData() throws {
         // GIVEN the user is on the signout page
-        mockAnalyticsService.hasAcceptedAnalytics = true
         sut.start()
         sut.openSignOutPage()
         let presentedVC = try XCTUnwrap(sut.root.presentedViewController as? UINavigationController)
@@ -89,25 +81,7 @@ final class ProfileCoordinatorTests: XCTestCase {
         // WHEN the user signs out
         let signOutButton: UIButton = try XCTUnwrap(presentedVC.topViewController!.view[child: "instructions-button"])
         signOutButton.sendActions(for: .touchUpInside)
-        // THEN all other user information will be deleted
-        XCTAssertNil(mockAnalyticsPreference.hasAcceptedAnalytics)
-    }
-    
-    func test_signoutErrorShowsErrorScreen() throws {
-        UserDefaults.standard.set(true, forKey: "EnableSignoutError")
-        // GIVEN the user is on the signout page
-        sut.start()
-        sut.openSignOutPage()
-        let presentedVC = try XCTUnwrap(sut.root.presentedViewController as? UINavigationController)
-        XCTAssertTrue(presentedVC.topViewController is GDSInstructionsViewController)
-        // IF there is an error on deleting the keys
-        mockSecureStoreService.errorFromDeleteItem = SecureStoreError.cantDeleteKey
-        // WHEN the user signs out
-        let signOutButton: UIButton = try XCTUnwrap(presentedVC.topViewController!.view[child: "instructions-button"])
-        signOutButton.sendActions(for: .touchUpInside)
-        // THEN an error page will be shown
-        waitForTruth(presentedVC.topViewController is GDSErrorViewController, timeout: 20)
-        UserDefaults.standard.set(false, forKey: "EnableSignoutError")
+        waitForTruth(self.sut.root.presentedViewController == nil, timeout: 20)
     }
 }
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -86,6 +86,7 @@ platform :ios do
       create_keychain(
         name: "signing_temp",
         password: password,
+        timeout: 1800,
         unlock: true
       )
 


### PR DESCRIPTION
# DCMAW-9184: iOS | Delete Wallet credentials when the user Signs out

This PR implements wallet credential deletion when the user selects to sign out of the app. The token information and analytics preferences are also removed.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
