### PR TITLE
feat: reauth on expired accessToken

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -10,6 +10,7 @@ disabled_rules:
 - multiple_closures_with_trailing_closure
 - todo
 - void_function_in_ternary
+- unused_optional_binding
 
 analyzer_rules:
 - unused_import

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -92,6 +92,8 @@
 		C87913C12B275F4900545B33 /* ErrorPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C87913C02B275F4900545B33 /* ErrorPresenterTests.swift */; };
 		C87913C42B27B7A300545B33 /* ErrorAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C87913C32B27B7A300545B33 /* ErrorAnalytics.swift */; };
 		C880DDE22AEAB6C100020796 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C880DDE12AEAB6C100020796 /* AppEnvironment.swift */; };
+		C88E40E52C3421C8008A3C20 /* ReauthCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88E40E42C3421C8008A3C20 /* ReauthCoordinator.swift */; };
+		C88E40E72C34239E008A3C20 /* SignOutWarningViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88E40E62C34239E008A3C20 /* SignOutWarningViewModel.swift */; };
 		C8A13C9F2AFBD05700FCBD36 /* GDSAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = C8A13C9E2AFBD05700FCBD36 /* GDSAnalytics */; };
 		C8A13CA12AFBD05700FCBD36 /* GDSCommon in Frameworks */ = {isa = PBXBuildFile; productRef = C8A13CA02AFBD05700FCBD36 /* GDSCommon */; };
 		C8A13CA42AFBD07E00FCBD36 /* Authentication in Frameworks */ = {isa = PBXBuildFile; productRef = C8A13CA32AFBD07E00FCBD36 /* Authentication */; };
@@ -149,7 +151,7 @@
 		D03B04D32BEE734900418C0B /* IdTokenPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03B04D22BEE734900418C0B /* IdTokenPayload.swift */; };
 		D03B04D52BF221BD00418C0B /* JWTVerifierError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03B04D42BF221BD00418C0B /* JWTVerifierError.swift */; };
 		D06F49A02C20373A009D76A0 /* Wallet in Frameworks */ = {isa = PBXBuildFile; productRef = D06F499F2C20373A009D76A0 /* Wallet */; };
-		D0825A952C12F5B800E940F7 /* SignoutErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0825A942C12F5B800E940F7 /* SignoutErrorViewModel.swift */; };
+		D0825A952C12F5B800E940F7 /* SignOutErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0825A942C12F5B800E940F7 /* SignOutErrorViewModel.swift */; };
 		D087BCF22C19E4BB00825F60 /* SignoutErrorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D087BCF12C19E4BB00825F60 /* SignoutErrorViewModelTests.swift */; };
 		D08B0B552BD7F84300769CEA /* DeveloperMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B532BD7F84300769CEA /* DeveloperMenuViewController.swift */; };
 		D08B0B562BD7F84300769CEA /* DeveloperMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = D08B0B542BD7F84300769CEA /* DeveloperMenu.xib */; };
@@ -304,6 +306,8 @@
 		C87913C02B275F4900545B33 /* ErrorPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorPresenterTests.swift; sourceTree = "<group>"; };
 		C87913C32B27B7A300545B33 /* ErrorAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorAnalytics.swift; sourceTree = "<group>"; };
 		C880DDE12AEAB6C100020796 /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
+		C88E40E42C3421C8008A3C20 /* ReauthCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReauthCoordinator.swift; sourceTree = "<group>"; };
+		C88E40E62C34239E008A3C20 /* SignOutWarningViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignOutWarningViewModel.swift; sourceTree = "<group>"; };
 		C8AA11D72B29C7FA00CE718B /* UnableToLoginErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnableToLoginErrorViewModel.swift; sourceTree = "<group>"; };
 		C8AA3B342BF4CF500093A220 /* WalletCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletCoordinatorTests.swift; sourceTree = "<group>"; };
 		C8B05F442B7AA7B3009D4283 /* LocalizedEnglishStringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizedEnglishStringTests.swift; sourceTree = "<group>"; };
@@ -355,7 +359,7 @@
 		D03B04CE2BECDB5C00418C0B /* KeyVerifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyVerifier.swift; sourceTree = "<group>"; };
 		D03B04D22BEE734900418C0B /* IdTokenPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdTokenPayload.swift; sourceTree = "<group>"; };
 		D03B04D42BF221BD00418C0B /* JWTVerifierError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWTVerifierError.swift; sourceTree = "<group>"; };
-		D0825A942C12F5B800E940F7 /* SignoutErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignoutErrorViewModel.swift; sourceTree = "<group>"; };
+		D0825A942C12F5B800E940F7 /* SignOutErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignOutErrorViewModel.swift; sourceTree = "<group>"; };
 		D087BCF12C19E4BB00825F60 /* SignoutErrorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignoutErrorViewModelTests.swift; sourceTree = "<group>"; };
 		D08B0B532BD7F84300769CEA /* DeveloperMenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperMenuViewController.swift; sourceTree = "<group>"; };
 		D08B0B542BD7F84300769CEA /* DeveloperMenu.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DeveloperMenu.xib; sourceTree = "<group>"; };
@@ -577,7 +581,8 @@
 				41FF35AB2B21F1AA00419DB3 /* GenericErrorViewModel.swift */,
 				41C5E32E2B45A36E00212A12 /* NetworkConnectionErrorViewModel.swift */,
 				C8AA11D72B29C7FA00CE718B /* UnableToLoginErrorViewModel.swift */,
-				D0825A942C12F5B800E940F7 /* SignoutErrorViewModel.swift */,
+				D0825A942C12F5B800E940F7 /* SignOutErrorViewModel.swift */,
+				C88E40E62C34239E008A3C20 /* SignOutWarningViewModel.swift */,
 			);
 			path = Errors;
 			sourceTree = "<group>";
@@ -825,6 +830,7 @@
 				C8C3439A2B91F99600E92FB9 /* OnboardingCoordinator.swift */,
 				C8B320782B062F9100FECDF0 /* AuthenticationCoordinator.swift */,
 				C81ECB1A2B71709500AFC3A6 /* EnrolmentCoordinator.swift */,
+				C88E40E42C3421C8008A3C20 /* ReauthCoordinator.swift */,
 				C85E210B2ACEE92900AF8B4E /* ViewModels */,
 			);
 			path = Login;
@@ -1524,6 +1530,7 @@
 				414D98032B8DEC7100E267EF /* UnlockScreenViewController.swift in Sources */,
 				C86A0D012BF270B50023EC42 /* MockTabbedViewModel.swift in Sources */,
 				3BBF28F32A9F7D3200491BB1 /* AppDelegate.swift in Sources */,
+				C88E40E72C34239E008A3C20 /* SignOutWarningViewModel.swift in Sources */,
 				C8098B972AEFF1AB001517A0 /* LoginSessionConfiguration+OneLogin.swift in Sources */,
 				C8C343972B909A2F00E92FB9 /* String+OneLogin.swift in Sources */,
 				D03B04CF2BECDB5C00418C0B /* KeyVerifier.swift in Sources */,
@@ -1539,7 +1546,7 @@
 				C8ECA1322BB73E2E00722218 /* WindowManager.swift in Sources */,
 				D08B0B652BDA478000769CEA /* SignInView.swift in Sources */,
 				41C5E32F2B45A36E00212A12 /* NetworkConnectionErrorViewModel.swift in Sources */,
-				D0825A952C12F5B800E940F7 /* SignoutErrorViewModel.swift in Sources */,
+				D0825A952C12F5B800E940F7 /* SignOutErrorViewModel.swift in Sources */,
 				D08B0B7D2BDBF86100769CEA /* TabbedViewSectionHeader.swift in Sources */,
 				D08B0B872BDFE2DA00769CEA /* TabbedViewSectionFooter.swift in Sources */,
 				C8B825C32B98C34A00336146 /* LoginCoordinator.swift in Sources */,
@@ -1567,6 +1574,7 @@
 				C8BACAFD2B4DD93C00530419 /* FlagManager.swift in Sources */,
 				41D9DC452B55851A00FC7DDD /* NetworkMonitor.swift in Sources */,
 				C85E21182ACEECD800AF8B4E /* AnalyticsButtonViewModel.swift in Sources */,
+				C88E40E52C3421C8008A3C20 /* ReauthCoordinator.swift in Sources */,
 				C851FFA22BADA4B200A7B73D /* SceneLifecycle.swift in Sources */,
 				D08B0B812BDC0D7100769CEA /* TabbedTableViewCell.swift in Sources */,
 				C86B706B2B8E43DC00F4C9BF /* AnalyticsPreferenceViewModel.swift in Sources */,

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -94,6 +94,8 @@
 		C880DDE22AEAB6C100020796 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C880DDE12AEAB6C100020796 /* AppEnvironment.swift */; };
 		C88E40E52C3421C8008A3C20 /* ReauthCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88E40E42C3421C8008A3C20 /* ReauthCoordinator.swift */; };
 		C88E40E72C34239E008A3C20 /* SignOutWarningViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88E40E62C34239E008A3C20 /* SignOutWarningViewModel.swift */; };
+		C88E40E92C371431008A3C20 /* SignOutWarningViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88E40E82C371431008A3C20 /* SignOutWarningViewModelTests.swift */; };
+		C88E40EB2C37169B008A3C20 /* ReauthCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88E40EA2C37169B008A3C20 /* ReauthCoordinatorTests.swift */; };
 		C8A13C9F2AFBD05700FCBD36 /* GDSAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = C8A13C9E2AFBD05700FCBD36 /* GDSAnalytics */; };
 		C8A13CA12AFBD05700FCBD36 /* GDSCommon in Frameworks */ = {isa = PBXBuildFile; productRef = C8A13CA02AFBD05700FCBD36 /* GDSCommon */; };
 		C8A13CA42AFBD07E00FCBD36 /* Authentication in Frameworks */ = {isa = PBXBuildFile; productRef = C8A13CA32AFBD07E00FCBD36 /* Authentication */; };
@@ -152,7 +154,7 @@
 		D03B04D52BF221BD00418C0B /* JWTVerifierError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03B04D42BF221BD00418C0B /* JWTVerifierError.swift */; };
 		D06F49A02C20373A009D76A0 /* Wallet in Frameworks */ = {isa = PBXBuildFile; productRef = D06F499F2C20373A009D76A0 /* Wallet */; };
 		D0825A952C12F5B800E940F7 /* SignOutErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0825A942C12F5B800E940F7 /* SignOutErrorViewModel.swift */; };
-		D087BCF22C19E4BB00825F60 /* SignoutErrorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D087BCF12C19E4BB00825F60 /* SignoutErrorViewModelTests.swift */; };
+		D087BCF22C19E4BB00825F60 /* SignOutErrorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D087BCF12C19E4BB00825F60 /* SignOutErrorViewModelTests.swift */; };
 		D08B0B552BD7F84300769CEA /* DeveloperMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B532BD7F84300769CEA /* DeveloperMenuViewController.swift */; };
 		D08B0B562BD7F84300769CEA /* DeveloperMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = D08B0B542BD7F84300769CEA /* DeveloperMenu.xib */; };
 		D08B0B582BD7F97200769CEA /* DeveloperMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08B0B572BD7F97200769CEA /* DeveloperMenuViewModel.swift */; };
@@ -308,6 +310,8 @@
 		C880DDE12AEAB6C100020796 /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
 		C88E40E42C3421C8008A3C20 /* ReauthCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReauthCoordinator.swift; sourceTree = "<group>"; };
 		C88E40E62C34239E008A3C20 /* SignOutWarningViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignOutWarningViewModel.swift; sourceTree = "<group>"; };
+		C88E40E82C371431008A3C20 /* SignOutWarningViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignOutWarningViewModelTests.swift; sourceTree = "<group>"; };
+		C88E40EA2C37169B008A3C20 /* ReauthCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReauthCoordinatorTests.swift; sourceTree = "<group>"; };
 		C8AA11D72B29C7FA00CE718B /* UnableToLoginErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnableToLoginErrorViewModel.swift; sourceTree = "<group>"; };
 		C8AA3B342BF4CF500093A220 /* WalletCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletCoordinatorTests.swift; sourceTree = "<group>"; };
 		C8B05F442B7AA7B3009D4283 /* LocalizedEnglishStringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizedEnglishStringTests.swift; sourceTree = "<group>"; };
@@ -360,7 +364,7 @@
 		D03B04D22BEE734900418C0B /* IdTokenPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdTokenPayload.swift; sourceTree = "<group>"; };
 		D03B04D42BF221BD00418C0B /* JWTVerifierError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWTVerifierError.swift; sourceTree = "<group>"; };
 		D0825A942C12F5B800E940F7 /* SignOutErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignOutErrorViewModel.swift; sourceTree = "<group>"; };
-		D087BCF12C19E4BB00825F60 /* SignoutErrorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignoutErrorViewModelTests.swift; sourceTree = "<group>"; };
+		D087BCF12C19E4BB00825F60 /* SignOutErrorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignOutErrorViewModelTests.swift; sourceTree = "<group>"; };
 		D08B0B532BD7F84300769CEA /* DeveloperMenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperMenuViewController.swift; sourceTree = "<group>"; };
 		D08B0B542BD7F84300769CEA /* DeveloperMenu.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DeveloperMenu.xib; sourceTree = "<group>"; };
 		D08B0B572BD7F97200769CEA /* DeveloperMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperMenuViewModel.swift; sourceTree = "<group>"; };
@@ -561,6 +565,8 @@
 				41A0BD0F2B275168009AE51F /* GenericErrorViewModelTests.swift */,
 				41C5E3302B45AFAA00212A12 /* NetworkConnectionErrorViewModelTests.swift */,
 				410464F52B29D078000E7CB2 /* UnableToLoginErrorViewModelTests.swift */,
+				D087BCF12C19E4BB00825F60 /* SignOutErrorViewModelTests.swift */,
+				C88E40E82C371431008A3C20 /* SignOutWarningViewModelTests.swift */,
 			);
 			path = Errors;
 			sourceTree = "<group>";
@@ -697,7 +703,6 @@
 			children = (
 				413C58772BF266A200171C06 /* ProfileTabViewModelTests.swift */,
 				41279DD62BFF46DB00E16537 /* SignOutPageViewModelTests.swift */,
-				D087BCF12C19E4BB00825F60 /* SignoutErrorViewModelTests.swift */,
 			);
 			path = Profile;
 			sourceTree = "<group>";
@@ -750,6 +755,7 @@
 				C8C3439C2B921E3C00E92FB9 /* OnboardingCoordinatorTests.swift */,
 				C8B3207A2B063CA100FECDF0 /* AuthenticationCoordinatorTests.swift */,
 				C81ECB1F2B71768500AFC3A6 /* EnrolmentCoordinatorTests.swift */,
+				C88E40EA2C37169B008A3C20 /* ReauthCoordinatorTests.swift */,
 				C85DF8472AEBFE6D0064F68E /* ViewModels */,
 			);
 			path = Login;
@@ -1626,15 +1632,17 @@
 				41E1A9152BE128610034B6C7 /* MockURLOpener.swift in Sources */,
 				C8C3439D2B921E3C00E92FB9 /* OnboardingCoordinatorTests.swift in Sources */,
 				C81273A22C07412100059825 /* MockAuthenticationProvider.swift in Sources */,
+				C88E40E92C371431008A3C20 /* SignOutWarningViewModelTests.swift in Sources */,
 				D0275CC12C00951600AF9A50 /* MockTokenVerifier.swift in Sources */,
 				41C5E3322B45B07D00212A12 /* NetworkConnectionErrorViewModelTests.swift in Sources */,
 				411D1FD32B73CA74002393D1 /* TouchIDEnrollmentViewModelTests.swift in Sources */,
 				C8B5EFC52B0E53EE004EA4D4 /* XCTestCase+TestExtensions.swift in Sources */,
-				D087BCF22C19E4BB00825F60 /* SignoutErrorViewModelTests.swift in Sources */,
+				D087BCF22C19E4BB00825F60 /* SignOutErrorViewModelTests.swift in Sources */,
 				1E717D732B72937500CCAF3E /* MockLAContext.swift in Sources */,
 				1E38C0E12B7CE249002B49A0 /* String+TestExtensions.swift in Sources */,
 				D08B0B5C2BD8046200769CEA /* HomeCoordinatorTests.swift in Sources */,
 				41279DD72BFF46DB00E16537 /* SignOutPageViewModelTests.swift in Sources */,
+				C88E40EB2C37169B008A3C20 /* ReauthCoordinatorTests.swift in Sources */,
 				219602022A976305008F3427 /* MainCoordinatorTests.swift in Sources */,
 				C87913C12B275F4900545B33 /* ErrorPresenterTests.swift in Sources */,
 				C8BADD272B87AEEA00385FE7 /* MockSecureStoreService.swift in Sources */,

--- a/Sources/Application/Environment/AppEnvironment.swift
+++ b/Sources/Application/Environment/AppEnvironment.swift
@@ -161,10 +161,6 @@ extension AppEnvironment {
         isFeatureEnabled(for: .enableCallingSTS)
     }
     
-    static var extendExpClaimEnabled: Bool {
-        isFeatureEnabled(for: .extendExpClaim)
-    }
-    
     static var signoutErrorEnabled: Bool {
         isFeatureEnabled(for: .enableSignoutError)
     }

--- a/Sources/Application/Environment/FlagManager.swift
+++ b/Sources/Application/Environment/FlagManager.swift
@@ -7,7 +7,6 @@ public enum FeatureFlags: String {
     /// ```
     
     case enableCallingSTS = "EnableCallingSTS"
-    case extendExpClaim = "ExtendExpClaim"
     case enableSignoutError = "EnableSignoutError"
 }
 

--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -12,7 +12,7 @@ final class MainCoordinator: NSObject,
     var childCoordinators = [ChildCoordinator]()
     var analyticsCenter: AnalyticsCentral
     let userStore: UserStorable
-    let tokenHolder = TokenHolder()
+    let tokenHolder = TokenHolder.shared
     private var tokenVerifier: TokenVerifier
     
     private weak var loginCoordinator: LoginCoordinator?
@@ -99,8 +99,7 @@ extension MainCoordinator {
                                   root: UINavigationController(),
                                   analyticsCenter: analyticsCenter,
                                   userStore: userStore,
-                                  networkMonitor: NetworkMonitor.shared,
-                                  tokenHolder: tokenHolder)
+                                  networkMonitor: NetworkMonitor.shared)
         lc.loginError = error
         openChildModally(lc, animated: false)
         loginCoordinator = lc
@@ -113,9 +112,9 @@ extension MainCoordinator {
     }
     
     private func addHomeTab() {
-        let hc = HomeCoordinator(analyticsService: analyticsCenter.analyticsService,
-                                 userStore: userStore,
-                                 tokenHolder: tokenHolder)
+        let hc = HomeCoordinator(window: windowManager.appWindow,
+                                 analyticsService: analyticsCenter.analyticsService,
+                                 userStore: userStore)
         addTab(hc)
         homeCoordinator = hc
     }
@@ -123,8 +122,7 @@ extension MainCoordinator {
     private func addWalletTab() {
         let wc = WalletCoordinator(window: windowManager.appWindow,
                                    analyticsService: analyticsCenter.analyticsService,
-                                   secureStoreService: userStore.authenticatedStore,
-                                   tokenHolder: tokenHolder)
+                                   secureStoreService: userStore.authenticatedStore)
         addTab(wc)
         walletCoordinator = wc
     }
@@ -132,7 +130,6 @@ extension MainCoordinator {
     private func addProfileTab() {
         let pc = ProfileCoordinator(analyticsService: analyticsCenter.analyticsService,
                                     userStore: userStore,
-                                    tokenHolder: tokenHolder,
                                     urlOpener: UIApplication.shared)
         addTab(pc)
         profileCoordinator = pc

--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -58,7 +58,7 @@ final class MainCoordinator: NSObject,
                 }
             }
         } else {
-            fullLogin()
+            fullLogin(error: TokenError.expired)
         }
     }
     
@@ -68,13 +68,13 @@ final class MainCoordinator: NSObject,
             SecureStoreError.unableToRetrieveFromUserDefaults,
             SecureStoreError.cantInitialiseData,
             SecureStoreError.cantRetrieveKey:
-            fullLogin(error)
+            fullLogin(error: error)
         default:
             print("Token retrival error: \(error)")
         }
     }
     
-    private func fullLogin(_ error: Error? = nil) {
+    private func fullLogin(error: Error? = nil) {
         tokenHolder.clearTokenHolder()
         userStore.refreshStorage(accessControlLevel: LAContext().isPasscodeOnly ? .anyBiometricsOrPasscode : .currentBiometricsOrPasscode)
         showLogin(error)

--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -126,7 +126,7 @@ extension MainCoordinator {
     private func addWalletTab() {
         let wc = WalletCoordinator(window: windowManager.appWindow,
                                    analyticsService: analyticsCenter.analyticsService,
-                                   secureStoreService: userStore.authenticatedStore)
+                                   secureStoreService: userStore.openStore)
         addTab(wc)
         walletCoordinator = wc
     }
@@ -152,11 +152,11 @@ extension MainCoordinator: UITabBarControllerDelegate {
         var event: IconEvent? {
             switch viewController.tabBarItem.tag {
             case 0:
-                    .init(textKey: "app_homeTitle")
+                .init(textKey: "app_homeTitle")
             case 1:
-                    .init(textKey: "app_walletTitle")
+                .init(textKey: "app_walletTitle")
             case 2:
-                    .init(textKey: "app_profileTitle")
+                .init(textKey: "app_profileTitle")
             default:
                 nil
             }

--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -14,7 +14,7 @@ final class MainCoordinator: NSObject,
     let userStore: UserStorable
     let tokenHolder = TokenHolder.shared
     private var tokenVerifier: TokenVerifier
-    var reauth = false
+    static var reauth = false
     
     private weak var loginCoordinator: LoginCoordinator?
     private weak var homeCoordinator: HomeCoordinator?
@@ -88,7 +88,7 @@ final class MainCoordinator: NSObject,
     func handleUniversalLink(_ url: URL) {
         switch UniversalLinkQualifier.qualifyOneLoginUniversalLink(url) {
         case .login:
-            if reauth {
+            if MainCoordinator.reauth {
                 homeCoordinator?.handleUniversalLink(url)
             } else {
                 loginCoordinator?.handleUniversalLink(url)
@@ -205,6 +205,7 @@ extension MainCoordinator: ParentCoordinator {
             }
         case _ as HomeCoordinator:
             updateToken()
+            MainCoordinator.reauth = false
         default:
             break
         }

--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -43,26 +43,26 @@ final class MainCoordinator: NSObject,
     }
     
     func evaluateRevisit() {
-        if userStore.validAuthenticatedUser {
-            Task(priority: .userInitiated) {
-                await MainActor.run {
-                    do {
-                        let idToken = try userStore.readItem(itemName: .idToken,
-                                                             storage: .authenticated)
-                        tokenHolder.idTokenPayload = try tokenVerifier.extractPayload(idToken)
-                        updateToken()
-                        windowManager.hideUnlockWindow()
-                    } catch {
-                        handleLoginError(error)
+        if userStore.previouslyAuthenticatedUser != nil {
+            if userStore.validAuthenticatedUser {
+                Task(priority: .userInitiated) {
+                    await MainActor.run {
+                        do {
+                            let idToken = try userStore.readItem(itemName: .idToken,
+                                                                 storage: .authenticated)
+                            tokenHolder.idTokenPayload = try tokenVerifier.extractPayload(idToken)
+                            updateToken()
+                            windowManager.hideUnlockWindow()
+                        } catch {
+                            handleLoginError(error)
+                        }
                     }
                 }
-            }
-        } else {
-            if userStore.tokenExpiryShown {
-                fullLogin()
             } else {
                 fullLogin(error: TokenError.expired)
             }
+        } else {
+            fullLogin()
         }
     }
     

--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -14,7 +14,7 @@ final class MainCoordinator: NSObject,
     let userStore: UserStorable
     let tokenHolder = TokenHolder.shared
     private var tokenVerifier: TokenVerifier
-    var reauth: Bool = false
+    var reauth = false
     
     private weak var loginCoordinator: LoginCoordinator?
     private weak var homeCoordinator: HomeCoordinator?
@@ -71,7 +71,6 @@ final class MainCoordinator: NSObject,
             fullLogin(error)
         default:
             print("Token retrival error: \(error)")
-            return
         }
     }
     
@@ -171,11 +170,8 @@ extension MainCoordinator: UITabBarControllerDelegate {
 
 extension MainCoordinator: ParentCoordinator {
     func didRegainFocus(fromChild child: ChildCoordinator?) {
-        switch child {
-        case _ as LoginCoordinator:
+        if child is LoginCoordinator {
             updateToken()
-        default:
-            break
         }
     }
     
@@ -203,9 +199,7 @@ extension MainCoordinator: ParentCoordinator {
                 root.present(navController, animated: true)
             }
         case _ as HomeCoordinator:
-            reauth = true
-            tokenHolder.clearTokenHolder()
-            userStore.refreshStorage(accessControlLevel: LAContext().isPasscodeOnly ? .anyBiometricsOrPasscode : .currentBiometricsOrPasscode)
+            updateToken()
         default:
             break
         }

--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -82,17 +82,17 @@ final class MainCoordinator: NSObject,
     }
     
     func handleUniversalLink(_ url: URL) {
-        if reauth {
-            homeCoordinator?.handleUniversalLink(url)
-        } else {
-            switch UniversalLinkQualifier.qualifyOneLoginUniversalLink(url) {
-            case .login:
+        switch UniversalLinkQualifier.qualifyOneLoginUniversalLink(url) {
+        case .login:
+            if reauth {
+                homeCoordinator?.handleUniversalLink(url)
+            } else {
                 loginCoordinator?.handleUniversalLink(url)
-            case .wallet:
-                walletCoordinator?.walletSDK.deeplink(with: url.absoluteString)
-            case .unknown:
-                return
             }
+        case .wallet:
+            walletCoordinator?.walletSDK.deeplink(with: url.absoluteString)
+        case .unknown:
+            return
         }
     }
 }
@@ -152,11 +152,11 @@ extension MainCoordinator: UITabBarControllerDelegate {
         var event: IconEvent? {
             switch viewController.tabBarItem.tag {
             case 0:
-                .init(textKey: "app_homeTitle")
+                    .init(textKey: "app_homeTitle")
             case 1:
-                .init(textKey: "app_walletTitle")
+                    .init(textKey: "app_walletTitle")
             case 2:
-                .init(textKey: "app_profileTitle")
+                    .init(textKey: "app_profileTitle")
             default:
                 nil
             }
@@ -191,10 +191,11 @@ extension MainCoordinator: ParentCoordinator {
                 root.selectedIndex = 0
             } catch {
                 let navController = UINavigationController()
-                let signOutErrorScreen = ErrorPresenter.createSignoutError(errorDescription: error.localizedDescription,
-                                                                           analyticsService: analyticsCenter.analyticsService) {
-                    exit(0)
-                }
+                let signOutErrorScreen = ErrorPresenter
+                    .createSignOutError(errorDescription: error.localizedDescription,
+                                        analyticsService: analyticsCenter.analyticsService) {
+                        exit(0)
+                    }
                 navController.setViewControllers([signOutErrorScreen], animated: false)
                 root.present(navController, animated: true)
             }

--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -58,7 +58,11 @@ final class MainCoordinator: NSObject,
                 }
             }
         } else {
-            fullLogin(error: TokenError.expired)
+            if userStore.tokenExpiryShown {
+                fullLogin()
+            } else {
+                fullLogin(error: TokenError.expired)
+            }
         }
     }
     

--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -88,7 +88,7 @@ final class MainCoordinator: NSObject,
     func handleUniversalLink(_ url: URL) {
         switch UniversalLinkQualifier.qualifyOneLoginUniversalLink(url) {
         case .login:
-            if MainCoordinator.reauth {
+            if Self.reauth {
                 homeCoordinator?.handleUniversalLink(url)
             } else {
                 loginCoordinator?.handleUniversalLink(url)
@@ -205,7 +205,7 @@ extension MainCoordinator: ParentCoordinator {
             }
         case _ as HomeCoordinator:
             updateToken()
-            MainCoordinator.reauth = false
+            Self.reauth = false
         default:
             break
         }

--- a/Sources/Application/SupportingFiles/FeatureFlags/FeatureFlagsBuild.json
+++ b/Sources/Application/SupportingFiles/FeatureFlags/FeatureFlagsBuild.json
@@ -4,10 +4,6 @@
         "isEnabled": false
     },
     {
-        "name": "ExtendExpClaim",
-        "isEnabled": false
-    },
-    {
         "name": "EnableSignoutError",
         "isEnabled": false
     }

--- a/Sources/Application/SupportingFiles/FeatureFlags/FeatureFlagsStaging.json
+++ b/Sources/Application/SupportingFiles/FeatureFlags/FeatureFlagsStaging.json
@@ -4,10 +4,6 @@
         "isEnabled": false
     },
     {
-        "name": "ExtendExpClaim",
-        "isEnabled": false
-    },
-    {
         "name": "EnableSignoutError",
         "isEnabled": false
     }

--- a/Sources/Application/TokenHolder.swift
+++ b/Sources/Application/TokenHolder.swift
@@ -16,7 +16,8 @@ class TokenHolder: AuthenticationProvider {
     
     var accessToken: String?
     var validAccessToken: Bool {
-        tokenResponse?.expiryDate.timeIntervalSinceNow.sign == .plus
+//        tokenResponse?.expiryDate.timeIntervalSinceNow.sign == .plus
+        false
     }
     
     var bearerToken: String {

--- a/Sources/Application/TokenHolder.swift
+++ b/Sources/Application/TokenHolder.swift
@@ -9,7 +9,7 @@ enum TokenError: Error {
 class TokenHolder: AuthenticationProvider {
     static let shared = TokenHolder()
     
-    private init() { }
+    private init() { /* Empty private initialiser to ensure singleton */ }
     
     var tokenResponse: TokenResponse? {
         didSet {

--- a/Sources/Application/TokenHolder.swift
+++ b/Sources/Application/TokenHolder.swift
@@ -32,6 +32,7 @@ class TokenHolder: AuthenticationProvider {
     var idTokenPayload: IdTokenPayload?
     
     func clearTokenHolder() {
+        tokenResponse = nil
         accessToken = nil
         idTokenPayload = nil
     }

--- a/Sources/Application/TokenHolder.swift
+++ b/Sources/Application/TokenHolder.swift
@@ -6,6 +6,8 @@ enum TokenError: Error {
 }
 
 class TokenHolder: AuthenticationProvider {
+    static let shared = TokenHolder()
+    
     var tokenResponse: TokenResponse? {
         didSet {
             accessToken = tokenResponse?.accessToken
@@ -13,6 +15,10 @@ class TokenHolder: AuthenticationProvider {
     }
     
     var accessToken: String?
+    var validAccessToken: Bool {
+        tokenResponse?.expiryDate.timeIntervalSinceNow.sign == .plus
+    }
+    
     var bearerToken: String {
         get throws {
             guard let accessToken else {
@@ -23,10 +29,6 @@ class TokenHolder: AuthenticationProvider {
     }
     
     var idTokenPayload: IdTokenPayload?
-    
-    var validAccessToken: Bool {
-        tokenResponse?.expiryDate.timeIntervalSinceNow.sign == .plus
-    }
     
     func clearTokenHolder() {
         accessToken = nil

--- a/Sources/Application/TokenHolder.swift
+++ b/Sources/Application/TokenHolder.swift
@@ -16,8 +16,7 @@ class TokenHolder: AuthenticationProvider {
     
     var accessToken: String?
     var validAccessToken: Bool {
-//        tokenResponse?.expiryDate.timeIntervalSinceNow.sign == .plus
-        false
+        tokenResponse?.expiryDate.timeIntervalSinceNow.sign == .plus
     }
     
     var bearerToken: String {

--- a/Sources/Application/TokenHolder.swift
+++ b/Sources/Application/TokenHolder.swift
@@ -9,6 +9,8 @@ enum TokenError: Error {
 class TokenHolder: AuthenticationProvider {
     static let shared = TokenHolder()
     
+    private init() { }
+    
     var tokenResponse: TokenResponse? {
         didSet {
             accessToken = tokenResponse?.accessToken

--- a/Sources/Application/TokenHolder.swift
+++ b/Sources/Application/TokenHolder.swift
@@ -3,6 +3,7 @@ import Networking
 
 enum TokenError: Error {
     case bearerNotPresent
+    case expired
 }
 
 class TokenHolder: AuthenticationProvider {

--- a/Sources/Errors/SignOutErrorViewModel.swift
+++ b/Sources/Errors/SignOutErrorViewModel.swift
@@ -2,7 +2,7 @@ import GDSAnalytics
 import GDSCommon
 import Logging
 
-struct SignoutErrorViewModel: GDSErrorViewModel, BaseViewModel {
+struct SignOutErrorViewModel: GDSErrorViewModel, BaseViewModel {
     let image: String = "exclamationmark.circle"
     let title: GDSLocalisedString = "app_signOutErrorTitle"
     let body: GDSLocalisedString = "app_signOutErrorBody"
@@ -14,7 +14,9 @@ struct SignoutErrorViewModel: GDSErrorViewModel, BaseViewModel {
     let rightBarButtonTitle: GDSLocalisedString? = "app_cancelButton"
     let backButtonIsHidden: Bool = true
     
-    init(errorDescription: String, analyticsService: AnalyticsService, action: @escaping () -> Void) {
+    init(errorDescription: String,
+         analyticsService: AnalyticsService,
+         action: @escaping () -> Void) {
         self.errorDescription = errorDescription
         self.analyticsService = analyticsService
         self.primaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "app_exitButton",

--- a/Sources/Errors/SignOutWarningViewModel.swift
+++ b/Sources/Errors/SignOutWarningViewModel.swift
@@ -4,8 +4,8 @@ import Logging
 
 struct SignOutWarningViewModel: GDSErrorViewModel, BaseViewModel {
     let image: String = "exclamationmark.circle"
-    let title: GDSLocalisedString = "You’ve been signed-out"
-    let body: GDSLocalisedString = "You will need to reauthenticate"
+    let title: GDSLocalisedString = "app_signOutWarningTitle"
+    let body: GDSLocalisedString = "app_signOutWarningBody"
     let primaryButtonViewModel: ButtonViewModel
     let secondaryButtonViewModel: ButtonViewModel? = nil
     let analyticsService: AnalyticsService

--- a/Sources/Errors/SignOutWarningViewModel.swift
+++ b/Sources/Errors/SignOutWarningViewModel.swift
@@ -16,7 +16,7 @@ struct SignOutWarningViewModel: GDSErrorViewModel, BaseViewModel {
     init(analyticsService: AnalyticsService,
          action: @escaping () -> Void) {
         self.analyticsService = analyticsService
-        self.primaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "Sign in",
+        self.primaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "app_signInButton",
                                                                analyticsService: analyticsService) {
             action()
         }

--- a/Sources/Errors/SignOutWarningViewModel.swift
+++ b/Sources/Errors/SignOutWarningViewModel.swift
@@ -1,0 +1,28 @@
+import GDSAnalytics
+import GDSCommon
+import Logging
+
+struct SignOutWarningViewModel: GDSErrorViewModel, BaseViewModel {
+    let image: String = "exclamationmark.circle"
+    let title: GDSLocalisedString = "You’ve been signed-out"
+    let body: GDSLocalisedString = "You will need to reauthenticate"
+    let primaryButtonViewModel: ButtonViewModel
+    let secondaryButtonViewModel: ButtonViewModel? = nil
+    let analyticsService: AnalyticsService
+    
+    let rightBarButtonTitle: GDSLocalisedString? = nil
+    let backButtonIsHidden: Bool = true
+    
+    init(analyticsService: AnalyticsService,
+         action: @escaping () -> Void) {
+        self.analyticsService = analyticsService
+        self.primaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "Sign in",
+                                                               analyticsService: analyticsService) {
+            action()
+        }
+    }
+    
+    func didAppear() { /* BaseViewModel compliance */ }
+    
+    func didDismiss() { /* BaseViewModel compliance */ }
+}

--- a/Sources/Extensions/String+OneLogin.swift
+++ b/Sources/Extensions/String+OneLogin.swift
@@ -4,6 +4,7 @@ extension String {
     static let accessTokenExpiry = "accessTokenExpiry"
     static let idToken = "idToken"
     static let oneLoginTokens = "oneLoginTokens"
+    static let tokenExpireyShown = "tokenExpiryShown"
     static let persistentSessionID = "persistentSessionID"
     static let shouldPromptForAnalytics = "shouldPromptForAnalytics"
     

--- a/Sources/Extensions/String+OneLogin.swift
+++ b/Sources/Extensions/String+OneLogin.swift
@@ -4,7 +4,6 @@ extension String {
     static let accessTokenExpiry = "accessTokenExpiry"
     static let idToken = "idToken"
     static let oneLoginTokens = "oneLoginTokens"
-    static let tokenExpireyShown = "tokenExpiryShown"
     static let persistentSessionID = "persistentSessionID"
     static let shouldPromptForAnalytics = "shouldPromptForAnalytics"
     

--- a/Sources/Login/AuthenticationCoordinator.swift
+++ b/Sources/Login/AuthenticationCoordinator.swift
@@ -14,21 +14,19 @@ final class AuthenticationCoordinator: NSObject,
     let session: LoginSession
     let userStore: UserStorable
     let errorPresenter = ErrorPresenter.self
-    var tokenHolder: TokenHolder
-    private var tokenVerifier: TokenVerifier
+    let tokenHolder = TokenHolder.shared
+    private let tokenVerifier: TokenVerifier
     var authError: Error?
     
     init(root: UINavigationController,
          analyticsService: AnalyticsService,
          userStore: UserStorable,
          session: LoginSession,
-         tokenHolder: TokenHolder,
          tokenVerifier: TokenVerifier = JWTVerifier()) {
         self.root = root
         self.analyticsService = analyticsService
         self.userStore = userStore
         self.session = session
-        self.tokenHolder = tokenHolder
         self.tokenVerifier = tokenVerifier
     }
     

--- a/Sources/Login/AuthenticationCoordinator.swift
+++ b/Sources/Login/AuthenticationCoordinator.swift
@@ -13,7 +13,6 @@ final class AuthenticationCoordinator: NSObject,
     let analyticsService: AnalyticsService
     let session: LoginSession
     let userStore: UserStorable
-    let errorPresenter = ErrorPresenter.self
     let tokenHolder = TokenHolder.shared
     private let tokenVerifier: TokenVerifier
     var authError: Error?
@@ -44,7 +43,7 @@ final class AuthenticationCoordinator: NSObject,
                 }
                 finish()
             } catch let error as LoginError where error == .network {
-                let networkErrorScreen = errorPresenter
+                let networkErrorScreen = ErrorPresenter
                     .createNetworkConnectionError(analyticsService: analyticsService) { [unowned self] in
                         returnFromErrorScreen()
                     }
@@ -82,7 +81,7 @@ final class AuthenticationCoordinator: NSObject,
 
 extension AuthenticationCoordinator {
     private func showUnableToLoginErrorScreen(_ error: Error) {
-        let unableToLoginErrorScreen = errorPresenter
+        let unableToLoginErrorScreen = ErrorPresenter
             .createUnableToLoginError(errorDescription: error.localizedDescription,
                                       analyticsService: analyticsService) { [unowned self] in
                 returnFromErrorScreen()
@@ -92,7 +91,7 @@ extension AuthenticationCoordinator {
     }
     
     private func showGenericErrorScreen(_ error: Error) {
-        let genericErrorScreen = errorPresenter
+        let genericErrorScreen = ErrorPresenter
             .createGenericError(errorDescription: error.localizedDescription,
                                 analyticsService: analyticsService) { [unowned self] in
                 returnFromErrorScreen()

--- a/Sources/Login/AuthenticationCoordinator.swift
+++ b/Sources/Login/AuthenticationCoordinator.swift
@@ -13,7 +13,6 @@ final class AuthenticationCoordinator: NSObject,
     let analyticsService: AnalyticsService
     let session: LoginSession
     let userStore: UserStorable
-    let tokenHolder = TokenHolder.shared
     private let tokenVerifier: TokenVerifier
     var authError: Error?
     
@@ -32,12 +31,12 @@ final class AuthenticationCoordinator: NSObject,
     func start() {
         Task(priority: .userInitiated) {
             do {
-                tokenHolder.tokenResponse = try await session.performLoginFlow(configuration: LoginSessionConfiguration.oneLogin)
+                TokenHolder.shared.tokenResponse = try await session.performLoginFlow(configuration: LoginSessionConfiguration.oneLogin)
                 // TODO: DCMAW-8570 This should be considered non-optional once tokenID work is completed on BE
                 if AppEnvironment.callingSTSEnabled,
-                   let idToken = tokenHolder.tokenResponse?.idToken {
-                    tokenHolder.idTokenPayload = try await tokenVerifier.verifyToken(idToken)
-                    try userStore.saveItem(tokenHolder.idTokenPayload?.persistentId,
+                   let idToken = TokenHolder.shared.tokenResponse?.idToken {
+                    TokenHolder.shared.idTokenPayload = try await tokenVerifier.verifyToken(idToken)
+                    try userStore.saveItem(TokenHolder.shared.idTokenPayload?.persistentId,
                                            itemName: .persistentSessionID,
                                            storage: .open)
                 }

--- a/Sources/Login/EnrolmentCoordinator.swift
+++ b/Sources/Login/EnrolmentCoordinator.swift
@@ -12,7 +12,6 @@ final class EnrolmentCoordinator: NSObject,
     let analyticsService: AnalyticsService
     let userStore: UserStorable
     var localAuth: LAContexting
-    private let viewControllerFactory = OnboardingViewControllerFactory.self
     let tokenHolder = TokenHolder.shared
     
     init(root: UINavigationController,
@@ -47,7 +46,7 @@ final class EnrolmentCoordinator: NSObject,
     private func showEnrolmentGuidance() {
         switch localAuth.biometryType {
         case .touchID:
-            let touchIDEnrollmentScreen = viewControllerFactory
+            let touchIDEnrollmentScreen = OnboardingViewControllerFactory
                 .createTouchIDEnrollmentScreen(analyticsService: analyticsService) { [unowned self] in
                     storeAccessTokenInfo()
                     finish()
@@ -56,7 +55,7 @@ final class EnrolmentCoordinator: NSObject,
                 }
             root.pushViewController(touchIDEnrollmentScreen, animated: true)
         case .faceID:
-            let faceIDEnrollmentScreen = viewControllerFactory
+            let faceIDEnrollmentScreen = OnboardingViewControllerFactory
                 .createFaceIDEnrollmentScreen(analyticsService: analyticsService) { [unowned self] in
                     Task { await enrolLocalAuth(reason: "app_faceId_subtitle") }
                 } secondaryButtonAction: { [unowned self] in
@@ -71,7 +70,7 @@ final class EnrolmentCoordinator: NSObject,
     }
     
     private func showPasscodeInfo() {
-        let passcodeInformationScreen = viewControllerFactory
+        let passcodeInformationScreen = OnboardingViewControllerFactory
             .createPasscodeInformationScreen(analyticsService: analyticsService) { [unowned self] in
                 finish()
             }

--- a/Sources/Login/EnrolmentCoordinator.swift
+++ b/Sources/Login/EnrolmentCoordinator.swift
@@ -13,18 +13,16 @@ final class EnrolmentCoordinator: NSObject,
     let userStore: UserStorable
     var localAuth: LAContexting
     private let viewControllerFactory = OnboardingViewControllerFactory.self
-    let tokenHolder: TokenHolder
+    let tokenHolder = TokenHolder.shared
     
     init(root: UINavigationController,
          analyticsService: AnalyticsService,
          userStore: UserStorable,
-         localAuth: LAContexting,
-         tokenHolder: TokenHolder) {
+         localAuth: LAContexting) {
         self.root = root
         self.analyticsService = analyticsService
         self.userStore = userStore
         self.localAuth = localAuth
-        self.tokenHolder = tokenHolder
     }
     
     func start() {

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -17,7 +17,6 @@ final class LoginCoordinator: NSObject,
     let analyticsCenter: AnalyticsCentral
     var userStore: UserStorable
     let networkMonitor: NetworkMonitoring
-    let tokenHolder = TokenHolder.shared
     private var tokenVerifier: TokenVerifier
     var loginError: Error?
     
@@ -67,7 +66,9 @@ final class LoginCoordinator: NSObject,
            error == .expired {
             let signOutWarningScreen = ErrorPresenter
                 .createSignOutWarning(analyticsService: analyticsCenter.analyticsService) { [unowned self] in
-                    root.dismiss(animated: true)
+                    root.dismiss(animated: true) { [unowned self] in
+                        launchAuthenticationCoordinator()
+                    }
                 }
             signOutWarningScreen.modalPresentationStyle = .overFullScreen
             root.present(signOutWarningScreen, animated: false)

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -21,9 +21,6 @@ final class LoginCoordinator: NSObject,
     private var tokenVerifier: TokenVerifier
     var loginError: Error?
     
-    private let viewControllerFactory = OnboardingViewControllerFactory.self
-    private let errorPresenter = ErrorPresenter.self
-    
     weak var introViewController: IntroViewController?
     private weak var authCoordinator: AuthenticationCoordinator?
     
@@ -43,12 +40,12 @@ final class LoginCoordinator: NSObject,
     }
     
     func start() {
-        let rootViewController = viewControllerFactory
+        let rootViewController = OnboardingViewControllerFactory
             .createIntroViewController(analyticsService: analyticsCenter.analyticsService) { [unowned self] in
                 if networkMonitor.isConnected {
                     launchAuthenticationCoordinator()
                 } else {
-                    let networkErrorScreen = errorPresenter
+                    let networkErrorScreen = ErrorPresenter
                         .createNetworkConnectionError(analyticsService: analyticsCenter.analyticsService) { [unowned self] in
                             introViewController?.enableIntroButton()
                             root.popViewController(animated: true)
@@ -89,8 +86,6 @@ final class LoginCoordinator: NSObject,
     }
     
     func handleUniversalLink(_ url: URL) {
-        // WHEN the handleUniversalLink method is called
-        // This test is purely to get test coverage atm as we will not be able to test for effects on unmocked subcoordinators
         authCoordinator?.handleUniversalLink(url)
     }
     

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -17,7 +17,7 @@ final class LoginCoordinator: NSObject,
     let analyticsCenter: AnalyticsCentral
     var userStore: UserStorable
     let networkMonitor: NetworkMonitoring
-    let tokenHolder: TokenHolder
+    let tokenHolder = TokenHolder.shared
     private var tokenVerifier: TokenVerifier
     var loginError: Error?
     
@@ -32,14 +32,12 @@ final class LoginCoordinator: NSObject,
          analyticsCenter: AnalyticsCentral,
          userStore: UserStorable,
          networkMonitor: NetworkMonitoring,
-         tokenHolder: TokenHolder,
          tokenVerifier: TokenVerifier = JWTVerifier()) {
         self.windowManager = windowManager
         self.root = root
         self.analyticsCenter = analyticsCenter
         self.userStore = userStore
         self.networkMonitor = networkMonitor
-        self.tokenHolder = tokenHolder
         self.tokenVerifier = tokenVerifier
         root.modalPresentationStyle = .overFullScreen
     }
@@ -85,8 +83,7 @@ final class LoginCoordinator: NSObject,
         let ac = AuthenticationCoordinator(root: root,
                                            analyticsService: analyticsCenter.analyticsService,
                                            userStore: userStore,
-                                           session: AppAuthSession(window: windowManager.appWindow),
-                                           tokenHolder: tokenHolder)
+                                           session: AppAuthSession(window: windowManager.appWindow))
         openChildInline(ac)
         authCoordinator = ac
     }
@@ -101,8 +98,7 @@ final class LoginCoordinator: NSObject,
         openChildInline(EnrolmentCoordinator(root: root,
                                              analyticsService: analyticsCenter.analyticsService,
                                              userStore: userStore,
-                                             localAuth: localAuth,
-                                             tokenHolder: tokenHolder))
+                                             localAuth: localAuth))
     }
 }
 

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -70,6 +70,7 @@ final class LoginCoordinator: NSObject,
                     root.popViewController(animated: true)
                 }
             root.pushViewController(signOutWarningScreen, animated: true)
+            userStore.tokenExpiryShown = true
         } else if let loginError {
             let unableToLoginErrorScreen = ErrorPresenter
                 .createUnableToLoginError(errorDescription: loginError.localizedDescription,

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -57,11 +57,11 @@ final class LoginCoordinator: NSObject,
             }
         root.setViewControllers([rootViewController], animated: true)
         introViewController = rootViewController
-        showIfLoginErrorScreens()
+        showLoginErrorIfNecessary()
         launchOnboardingCoordinator()
     }
     
-    private func showIfLoginErrorScreens() {
+    private func showLoginErrorIfNecessary() {
         if let error = loginError as? TokenError,
            error == .expired {
             let signOutWarningScreen = ErrorPresenter

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -65,11 +65,11 @@ final class LoginCoordinator: NSObject,
     private func showAdditionalLoginScreens() {
         if let error = loginError as? TokenError,
            error == .expired {
-            let signOutWarning = ErrorPresenter
+            let signOutWarningScreen = ErrorPresenter
                 .createSignOutWarning(analyticsService: analyticsCenter.analyticsService) { [unowned self] in
                     root.popViewController(animated: true)
                 }
-            root.pushViewController(signOutWarning, animated: true)
+            root.pushViewController(signOutWarningScreen, animated: true)
         } else if let loginError {
             let unableToLoginErrorScreen = ErrorPresenter
                 .createUnableToLoginError(errorDescription: loginError.localizedDescription,

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -67,10 +67,10 @@ final class LoginCoordinator: NSObject,
            error == .expired {
             let signOutWarningScreen = ErrorPresenter
                 .createSignOutWarning(analyticsService: analyticsCenter.analyticsService) { [unowned self] in
-                    root.popViewController(animated: true)
+                    root.dismiss(animated: true)
                 }
-            root.pushViewController(signOutWarningScreen, animated: true)
-            userStore.tokenExpiryShown = true
+            signOutWarningScreen.modalPresentationStyle = .overFullScreen
+            root.present(signOutWarningScreen, animated: false)
         } else if let loginError {
             let unableToLoginErrorScreen = ErrorPresenter
                 .createUnableToLoginError(errorDescription: loginError.localizedDescription,

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -104,7 +104,6 @@ extension LoginCoordinator: ParentCoordinator {
             return
         case let child as AuthenticationCoordinator where child.authError != nil:
             introViewController?.enableIntroButton()
-            return
         case let child as AuthenticationCoordinator where child.authError == nil:
             launchEnrolmentCoordinator(localAuth: LAContext())
         case _ as EnrolmentCoordinator:

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -58,7 +58,19 @@ final class LoginCoordinator: NSObject,
             }
         root.setViewControllers([rootViewController], animated: true)
         introViewController = rootViewController
-        if let loginError {
+        showAdditionalLoginScreens()
+        launchOnboardingCoordinator()
+    }
+    
+    private func showAdditionalLoginScreens() {
+        if let error = loginError as? TokenError,
+           error == .expired {
+            let signOutWarning = ErrorPresenter
+                .createSignOutWarning(analyticsService: analyticsCenter.analyticsService) { [unowned self] in
+                    root.popViewController(animated: true)
+                }
+            root.pushViewController(signOutWarning, animated: true)
+        } else if let loginError {
             let unableToLoginErrorScreen = ErrorPresenter
                 .createUnableToLoginError(errorDescription: loginError.localizedDescription,
                                           analyticsService: analyticsCenter.analyticsService) { [unowned self] in
@@ -66,7 +78,6 @@ final class LoginCoordinator: NSObject,
                 }
             root.pushViewController(unableToLoginErrorScreen, animated: true)
         }
-        launchOnboardingCoordinator()
     }
     
     private func launchOnboardingCoordinator() {

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -58,11 +58,11 @@ final class LoginCoordinator: NSObject,
             }
         root.setViewControllers([rootViewController], animated: true)
         introViewController = rootViewController
-        showAdditionalLoginScreens()
+        showIfLoginErrorScreens()
         launchOnboardingCoordinator()
     }
     
-    private func showAdditionalLoginScreens() {
+    private func showIfLoginErrorScreens() {
         if let error = loginError as? TokenError,
            error == .expired {
             let signOutWarningScreen = ErrorPresenter

--- a/Sources/Login/OnboardingCoordinator.swift
+++ b/Sources/Login/OnboardingCoordinator.swift
@@ -10,7 +10,6 @@ final class OnboardingCoordinator: NSObject,
     weak var parentCoordinator: ParentCoordinator?
     private var analyticsPreferenceStore: AnalyticsPreferenceStore
     private let urlOpener: URLOpener
-    private let viewControllerFactory = OnboardingViewControllerFactory.self
     
     init(analyticsPreferenceStore: AnalyticsPreferenceStore,
          urlOpener: URLOpener) {
@@ -19,7 +18,7 @@ final class OnboardingCoordinator: NSObject,
     }
     
     func start() {
-        let analyticsPreferenceScreen = viewControllerFactory
+        let analyticsPreferenceScreen = OnboardingViewControllerFactory
             .createAnalyticsPeferenceScreen { [unowned self] in
                 analyticsPreferenceStore.hasAcceptedAnalytics = true
                 root.dismiss(animated: true)

--- a/Sources/Login/ReauthCoordinator.swift
+++ b/Sources/Login/ReauthCoordinator.swift
@@ -13,6 +13,7 @@ final class ReauthCoordinator: NSObject,
     var childCoordinators = [ChildCoordinator]()
     let analyticsService: AnalyticsService
     let userStore: UserStorable
+    
     private weak var authCoordinator: AuthenticationCoordinator?
     
     init(window: UIWindow,
@@ -40,15 +41,6 @@ final class ReauthCoordinator: NSObject,
     func handleUniversalLink(_ url: URL) {
         authCoordinator?.handleUniversalLink(url)
     }
-    
-    private func storeAccessTokenInfo() {
-        guard let tokenResponse = TokenHolder.shared.tokenResponse else { return }
-        do {
-            try userStore.storeTokenInfo(tokenResponse: tokenResponse)
-        } catch {
-            print("Storing Token Info error: \(error)")
-        }
-    }
 }
 
 extension ReauthCoordinator: ParentCoordinator {
@@ -57,7 +49,7 @@ extension ReauthCoordinator: ParentCoordinator {
         case let child as AuthenticationCoordinator where child.authError != nil:
             return
         case let child as AuthenticationCoordinator where child.authError == nil:
-            storeAccessTokenInfo()
+            userStore.storeTokenInfo()
             finish()
             root.dismiss(animated: true)
         default:

--- a/Sources/Login/ReauthCoordinator.swift
+++ b/Sources/Login/ReauthCoordinator.swift
@@ -1,0 +1,48 @@
+import Authentication
+import Coordination
+import Logging
+import UIKit
+
+final class ReauthCoordinator: NSObject,
+                               AnyCoordinator,
+                               NavigationCoordinator,
+                               ChildCoordinator {
+    let window: UIWindow
+    let root = UINavigationController()
+    weak var parentCoordinator: ParentCoordinator?
+    var childCoordinators = [ChildCoordinator]()
+    let analyticsService: AnalyticsService
+    let userStore: UserStorable
+    private weak var authCoordinator: AuthenticationCoordinator?
+
+    init(window: UIWindow,
+         analyticsService: AnalyticsService,
+         userStore: UserStorable) {
+        self.window = window
+        self.analyticsService = analyticsService
+        self.userStore = userStore
+        root.modalPresentationStyle = .overFullScreen
+    }
+    
+    func start() {
+        let signOutWarning = ErrorPresenter.createSignoutWarning(analyticsService: analyticsService) { [unowned self] in
+            let ac = AuthenticationCoordinator(root: root,
+                                               analyticsService: analyticsService,
+                                               userStore: userStore,
+                                               session: AppAuthSession(window: window))
+            openChildInline(ac)
+            authCoordinator = ac
+        }
+        root.setViewControllers([signOutWarning], animated: false)
+    }
+    
+    func handleUniversalLink(_ url: URL) {
+        authCoordinator?.handleUniversalLink(url)
+    }
+}
+
+extension ReauthCoordinator: ParentCoordinator {
+    func didRegainFocus(fromChild child: ChildCoordinator?) {
+        root.dismiss(animated: true)
+    }
+}

--- a/Sources/Login/ReauthCoordinator.swift
+++ b/Sources/Login/ReauthCoordinator.swift
@@ -26,7 +26,7 @@ final class ReauthCoordinator: NSObject,
     
     func start() {
         let signOutWarning = ErrorPresenter
-            .createSignoutWarning(analyticsService: analyticsService) { [unowned self] in
+            .createSignOutWarning(analyticsService: analyticsService) { [unowned self] in
                 let ac = AuthenticationCoordinator(root: root,
                                                    analyticsService: analyticsService,
                                                    userStore: userStore,

--- a/Sources/Resources/cy-GB.lproj/Localizable.strings
+++ b/Sources/Resources/cy-GB.lproj/Localizable.strings
@@ -123,6 +123,7 @@
 
 "app_signOutButton" = "Allgofnodi";
 
+
 // Mark: Sign Out Confirmation screen
 "app_signOutConfirmationTitle" = "Bydd allgofnodi yn dileu data eich ap";
 
@@ -140,9 +141,16 @@
 
 "app_signOutAndDeleteAppDataButton" = "Allgofnodwch a dileu data yr ap";
 
+
 // Mark: Sign Out Error screen
 "app_signOutErrorTitle" = "Roedd problem wrth eich allgofnodi";
 
 "app_signOutErrorBody" = "Gallwch orfodi allgofnodi trwy ddileu'r ap o'ch dyfais.";
 
 "app_exitButton" = "Gadael";
+
+
+// Mark: Sign Out Warning screen
+"app_signOutWarningTitle" = "TYou’ve been signed-out";
+
+"app_signOutWarningBody" = "You will need to reauthenticate";

--- a/Sources/Resources/cy-GB.lproj/Localizable.strings
+++ b/Sources/Resources/cy-GB.lproj/Localizable.strings
@@ -17,6 +17,8 @@
 
 "app_enterPasscodeButton" = "Rhowch god mynediad";
 
+"app_exitButton" = "Gadael";
+
 
 // MARK: Local Auth prompt (Face ID)
 "app_faceId_subtitle" = "Rhowch god mynediad iPhone";
@@ -147,10 +149,8 @@
 
 "app_signOutErrorBody" = "Gallwch orfodi allgofnodi trwy ddileu'r ap o'ch dyfais.";
 
-"app_exitButton" = "Gadael";
-
 
 // Mark: Sign Out Warning screen
-"app_signOutWarningTitle" = "TYou’ve been signed-out";
+"app_signOutWarningTitle" = "You’ve been signed-out";
 
 "app_signOutWarningBody" = "You will need to reauthenticate";

--- a/Sources/Resources/en.lproj/Localizable.strings
+++ b/Sources/Resources/en.lproj/Localizable.strings
@@ -123,6 +123,7 @@
 
 "app_signOutButton" = "Sign out";
 
+
 // Mark: Sign Out Confirmation screen
 "app_signOutConfirmationTitle" = "Signing out will delete your app data";
 
@@ -140,9 +141,16 @@
 
 "app_signOutAndDeleteAppDataButton" = "Sign out and delete app data";
 
+
 // Mark: Sign Out Error screen
 "app_signOutErrorTitle" = "There was a problem signing you out";
 
 "app_signOutErrorBody" = "You can force sign out by deleting the app from your device.";
 
 "app_exitButton" = "Exit";
+
+
+// Mark: Sign Out Warning screen
+"app_signOutWarningTitle" = "TYou’ve been signed-out";
+
+"app_signOutWarningBody" = "You will need to reauthenticate";

--- a/Sources/Resources/en.lproj/Localizable.strings
+++ b/Sources/Resources/en.lproj/Localizable.strings
@@ -17,6 +17,8 @@
 
 "app_enterPasscodeButton" = "Enter passcode";
 
+"app_exitButton" = "Exit";
+
 
 // MARK: Local Auth prompt (Face ID)
 "app_faceId_subtitle" = "Enter iPhone passcode";
@@ -147,10 +149,8 @@
 
 "app_signOutErrorBody" = "You can force sign out by deleting the app from your device.";
 
-"app_exitButton" = "Exit";
-
 
 // Mark: Sign Out Warning screen
-"app_signOutWarningTitle" = "TYou’ve been signed-out";
+"app_signOutWarningTitle" = "You’ve been signed-out";
 
 "app_signOutWarningBody" = "You will need to reauthenticate";

--- a/Sources/Screens/DeveloperMenu/DeveloperMenuViewController.swift
+++ b/Sources/Screens/DeveloperMenu/DeveloperMenuViewController.swift
@@ -5,13 +5,16 @@ import UIKit
 final class DeveloperMenuViewController: BaseViewController {
     override var nibName: String? { "DeveloperMenu" }
     
+    weak var parentCoordinator: HomeCoordinator?
     let viewModel: DeveloperMenuViewModel
     let userStore: UserStorable
     let networkClient: NetworkClient
         
-    init(viewModel: DeveloperMenuViewModel,
+    init(parentCoordinator: HomeCoordinator,
+         viewModel: DeveloperMenuViewModel,
          userStore: UserStorable,
          networkClient: NetworkClient) {
+        self.parentCoordinator = parentCoordinator
         self.viewModel = viewModel
         self.userStore = userStore
         self.networkClient = networkClient
@@ -43,7 +46,7 @@ final class DeveloperMenuViewController: BaseViewController {
     
     // Makes a successful request to the hello-world endpoint as long as the access token is valid
     private func helloWorldHappyPath() {
-        if userStore.validAuthenticatedUser {
+        if userStore.validAuthenticatedUser || TokenHolder.shared.validAccessToken {
             Task {
                 do {
                     let data = try await networkClient.makeAuthorizedRequest(exchangeRequest: URLRequest(url: AppEnvironment.stsToken),
@@ -58,7 +61,7 @@ final class DeveloperMenuViewController: BaseViewController {
                 happyPathButton.isLoading = false
             }
         } else {
-            viewModel.invalidAccessTokenAction()
+            parentCoordinator?.accessTokenInvalidAction()
         }
     }
     
@@ -89,7 +92,7 @@ final class DeveloperMenuViewController: BaseViewController {
     
     // Makes an unsuccessful request to the hello-world endpoint, the scope is invalid for this so a 400 response is returned
     private func helloWorldErrorPath() {
-        if userStore.validAuthenticatedUser {
+        if userStore.validAuthenticatedUser || TokenHolder.shared.validAccessToken {
             Task {
                 do {
                     _ = try await networkClient.makeAuthorizedRequest(exchangeRequest: URLRequest(url: AppEnvironment.stsToken),
@@ -103,7 +106,7 @@ final class DeveloperMenuViewController: BaseViewController {
                 errorPathButton.isLoading = false
             }
         } else {
-            viewModel.invalidAccessTokenAction()
+            parentCoordinator?.accessTokenInvalidAction()
         }
     }
     
@@ -134,7 +137,7 @@ final class DeveloperMenuViewController: BaseViewController {
     
     // Makes an unsuccessful request to the hello-world endpoint, the endpoint returns a 401 unauthorized response
     private func helloWorldUnauthorizedPath() {
-        if userStore.validAuthenticatedUser {
+        if userStore.validAuthenticatedUser || TokenHolder.shared.validAccessToken {
             Task {
                 do {
                     _ = try await networkClient.makeAuthorizedRequest(exchangeRequest: URLRequest(url: AppEnvironment.stsToken),
@@ -148,7 +151,7 @@ final class DeveloperMenuViewController: BaseViewController {
                 unauthorizedPathButton.isLoading = false
             }
         } else {
-            viewModel.invalidAccessTokenAction()
+            parentCoordinator?.accessTokenInvalidAction()
         }
     }
     

--- a/Sources/Screens/DeveloperMenu/DeveloperMenuViewController.swift
+++ b/Sources/Screens/DeveloperMenu/DeveloperMenuViewController.swift
@@ -6,15 +6,15 @@ final class DeveloperMenuViewController: BaseViewController {
     override var nibName: String? { "DeveloperMenu" }
     
     let viewModel: DeveloperMenuViewModel
+    let userStore: UserStorable
     let networkClient: NetworkClient
-    let invalidAccessTokenAction: () -> Void
-    
+        
     init(viewModel: DeveloperMenuViewModel,
-         networkClient: NetworkClient,
-         invalidAccessTokenAction: @escaping () -> Void) {
+         userStore: UserStorable,
+         networkClient: NetworkClient) {
         self.viewModel = viewModel
+        self.userStore = userStore
         self.networkClient = networkClient
-        self.invalidAccessTokenAction = invalidAccessTokenAction
         super.init(viewModel: viewModel,
                    nibName: "DeveloperMenu",
                    bundle: nil)
@@ -43,7 +43,7 @@ final class DeveloperMenuViewController: BaseViewController {
     
     // Makes a successful request to the hello-world endpoint as long as the access token is valid
     private func helloWorldHappyPath() {
-        if TokenHolder.shared.validAccessToken {
+        if userStore.validAuthenticatedUser1 {
             Task {
                 do {
                     let data = try await networkClient.makeAuthorizedRequest(exchangeRequest: URLRequest(url: AppEnvironment.stsToken),
@@ -55,11 +55,11 @@ final class DeveloperMenuViewController: BaseViewController {
                 } catch {
                     happyPathResultLabel.showErrorMessage()
                 }
+                happyPathButton.isLoading = false
             }
         } else {
-            invalidAccessTokenAction()
+            viewModel.invalidAccessTokenAction()
         }
-        happyPathButton.isLoading = false
     }
     
     @IBOutlet private var happyPathResultLabel: UILabel! {
@@ -89,7 +89,7 @@ final class DeveloperMenuViewController: BaseViewController {
     
     // Makes an unsuccessful request to the hello-world endpoint, the scope is invalid for this so a 400 response is returned
     private func helloWorldErrorPath() {
-        if TokenHolder.shared.validAccessToken {
+        if userStore.validAuthenticatedUser {
             Task {
                 do {
                     _ = try await networkClient.makeAuthorizedRequest(exchangeRequest: URLRequest(url: AppEnvironment.stsToken),
@@ -100,11 +100,11 @@ final class DeveloperMenuViewController: BaseViewController {
                 } catch {
                     errorPathResultLabel.showErrorMessage()
                 }
+                errorPathButton.isLoading = false
             }
         } else {
-            invalidAccessTokenAction()
+            viewModel.invalidAccessTokenAction()
         }
-        errorPathButton.isLoading = false
     }
     
     @IBOutlet private var errorPathResultLabel: UILabel! {
@@ -134,7 +134,7 @@ final class DeveloperMenuViewController: BaseViewController {
     
     // Makes an unsuccessful request to the hello-world endpoint, the endpoint returns a 401 unauthorized response
     private func helloWorldUnauthorizedPath() {
-        if TokenHolder.shared.validAccessToken {
+        if userStore.validAuthenticatedUser {
             Task {
                 do {
                     _ = try await networkClient.makeAuthorizedRequest(exchangeRequest: URLRequest(url: AppEnvironment.stsToken),
@@ -145,11 +145,11 @@ final class DeveloperMenuViewController: BaseViewController {
                 } catch {
                     unauthorizedPathResultLabel.showErrorMessage()
                 }
+                unauthorizedPathButton.isLoading = false
             }
         } else {
-            invalidAccessTokenAction()
+            viewModel.invalidAccessTokenAction()
         }
-        unauthorizedPathButton.isLoading = false
     }
     
     @IBOutlet private var unauthorizedPathResultLabel: UILabel! {

--- a/Sources/Screens/DeveloperMenu/DeveloperMenuViewController.swift
+++ b/Sources/Screens/DeveloperMenu/DeveloperMenuViewController.swift
@@ -6,10 +6,10 @@ final class DeveloperMenuViewController: BaseViewController {
     override var nibName: String? { "DeveloperMenu" }
     
     let viewModel: DeveloperMenuViewModel
-    let networkClient: NetworkClient?
+    let networkClient: NetworkClient
     
     init(viewModel: DeveloperMenuViewModel,
-         networkClient: NetworkClient?) {
+         networkClient: NetworkClient) {
         self.viewModel = viewModel
         self.networkClient = networkClient
         super.init(viewModel: viewModel,
@@ -42,10 +42,10 @@ final class DeveloperMenuViewController: BaseViewController {
     private func helloWorldHappyPath() {
         Task {
             do {
-                let data = try await networkClient?.makeAuthorizedRequest(exchangeRequest: URLRequest(url: AppEnvironment.stsToken),
-                                                                          scope: "sts-test.hello-world.read",
-                                                                          request: URLRequest(url: AppEnvironment.stsHelloWorld))
-                happyPathResultLabel.showSuccessMessage("Success: \(String(decoding: data!, as: UTF8.self))")
+                let data = try await networkClient.makeAuthorizedRequest(exchangeRequest: URLRequest(url: AppEnvironment.stsToken),
+                                                                         scope: "sts-test.hello-world.read",
+                                                                         request: URLRequest(url: AppEnvironment.stsHelloWorld))
+                happyPathResultLabel.showSuccessMessage("Success: \(String(decoding: data, as: UTF8.self))")
             } catch let error as ServerError {
                 happyPathResultLabel.showErrorMessage(error)
             } catch {
@@ -84,9 +84,9 @@ final class DeveloperMenuViewController: BaseViewController {
     private func helloWorldErrorPath() {
         Task {
             do {
-                _ = try await networkClient?.makeAuthorizedRequest(exchangeRequest: URLRequest(url: AppEnvironment.stsToken),
-                                                                   scope: "sts-test.hello-world",
-                                                                   request: URLRequest(url: AppEnvironment.stsHelloWorld))
+                _ = try await networkClient.makeAuthorizedRequest(exchangeRequest: URLRequest(url: AppEnvironment.stsToken),
+                                                                  scope: "sts-test.hello-world",
+                                                                  request: URLRequest(url: AppEnvironment.stsHelloWorld))
             } catch let error as ServerError {
                 errorPathResultLabel.showErrorMessage(error)
             } catch {
@@ -125,9 +125,9 @@ final class DeveloperMenuViewController: BaseViewController {
     private func helloWorldUnauthorizedPath() {
         Task {
             do {
-                _ = try await networkClient?.makeAuthorizedRequest(exchangeRequest: URLRequest(url: AppEnvironment.stsToken),
-                                                                   scope: "sts-test.hello-world.read",
-                                                                   request: URLRequest(url: AppEnvironment.stsHelloWorldError))
+                _ = try await networkClient.makeAuthorizedRequest(exchangeRequest: URLRequest(url: AppEnvironment.stsToken),
+                                                                  scope: "sts-test.hello-world.read",
+                                                                  request: URLRequest(url: AppEnvironment.stsHelloWorldError))
             } catch let error as ServerError {
                 unauthorizedPathResultLabel.showErrorMessage(error)
             } catch {
@@ -156,7 +156,7 @@ fileprivate extension UILabel {
             text = "Error"
         }
     }
-
+    
     func showSuccessMessage(_ message: String) {
         textColor = .gdsGreen
         isHidden = false

--- a/Sources/Screens/DeveloperMenu/DeveloperMenuViewController.swift
+++ b/Sources/Screens/DeveloperMenu/DeveloperMenuViewController.swift
@@ -43,7 +43,7 @@ final class DeveloperMenuViewController: BaseViewController {
     
     // Makes a successful request to the hello-world endpoint as long as the access token is valid
     private func helloWorldHappyPath() {
-        if userStore.validAuthenticatedUser1 {
+        if userStore.validAuthenticatedUser {
             Task {
                 do {
                     let data = try await networkClient.makeAuthorizedRequest(exchangeRequest: URLRequest(url: AppEnvironment.stsToken),

--- a/Sources/Screens/DeveloperMenu/DeveloperMenuViewModel.swift
+++ b/Sources/Screens/DeveloperMenu/DeveloperMenuViewModel.swift
@@ -4,6 +4,8 @@ struct DeveloperMenuViewModel: BaseViewModel {
     let rightBarButtonTitle: GDSLocalisedString? = "app_cancelButton"
     let backButtonIsHidden: Bool = true
     
+    let invalidAccessTokenAction: () -> Void
+    
     func didAppear() { /* protocol conformance */ }
     
     func didDismiss() { /* protocol conformance */ }

--- a/Sources/Screens/DeveloperMenu/DeveloperMenuViewModel.swift
+++ b/Sources/Screens/DeveloperMenu/DeveloperMenuViewModel.swift
@@ -4,8 +4,6 @@ struct DeveloperMenuViewModel: BaseViewModel {
     let rightBarButtonTitle: GDSLocalisedString? = "app_cancelButton"
     let backButtonIsHidden: Bool = true
     
-    let invalidAccessTokenAction: () -> Void
-    
     func didAppear() { /* protocol conformance */ }
     
     func didDismiss() { /* protocol conformance */ }

--- a/Sources/Tabs/HomeCoordinator.swift
+++ b/Sources/Tabs/HomeCoordinator.swift
@@ -8,20 +8,20 @@ final class HomeCoordinator: NSObject,
                              AnyCoordinator,
                              ChildCoordinator,
                              NavigationCoordinator {
+    let window: UIWindow
     weak var parentCoordinator: ParentCoordinator?
     let root = UINavigationController()
     let analyticsService: AnalyticsService
     private let userStore: UserStorable
-    var networkClient: NetworkClient?
-    private var tokenHolder: TokenHolder
+    private let tokenHolder = TokenHolder.shared
     private(set) var baseVc: TabbedViewController?
     
-    init(analyticsService: AnalyticsService,
-         userStore: UserStorable,
-         tokenHolder: TokenHolder) {
+    init(window: UIWindow,
+         analyticsService: AnalyticsService,
+         userStore: UserStorable) {
+        self.window = window
         self.analyticsService = analyticsService
         self.userStore = userStore
-        self.tokenHolder = tokenHolder
     }
     
     func start() {
@@ -49,9 +49,9 @@ final class HomeCoordinator: NSObject,
            let accessToken = try? userStore.readItem(itemName: .accessToken, storage: .authenticated) {
             tokenHolder.accessToken = accessToken
         }
-        networkClient = NetworkClient(authenticationProvider: tokenHolder)
+        let networkClient = NetworkClient(authenticationProvider: tokenHolder)
         let devMenuViewController = DeveloperMenuViewController(viewModel: viewModel,
-                                                          networkClient: networkClient)
+                                                                networkClient: networkClient)
         navController.setViewControllers([devMenuViewController], animated: true)
         root.present(navController, animated: true)
     }

--- a/Sources/Tabs/HomeCoordinator.swift
+++ b/Sources/Tabs/HomeCoordinator.swift
@@ -67,11 +67,11 @@ final class HomeCoordinator: NSObject,
         root.dismiss(animated: true)
         TokenHolder.shared.clearTokenHolder()
         userStore.refreshStorage(accessControlLevel: nil)
-        let ra = ReauthCoordinator(window: window,
+        let rc = ReauthCoordinator(window: window,
                                    analyticsService: analyticsService,
                                    userStore: userStore)
-        openChildModally(ra, animated: true)
-        reauthCoordinator = ra
+        openChildModally(rc, animated: true)
+        reauthCoordinator = rc
     }
     
     func handleUniversalLink(_ url: URL) {

--- a/Sources/Tabs/HomeCoordinator.swift
+++ b/Sources/Tabs/HomeCoordinator.swift
@@ -17,6 +17,7 @@ final class HomeCoordinator: NSObject,
     let analyticsService: AnalyticsService
     private let userStore: UserStorable
     private let tokenHolder = TokenHolder.shared
+    
     private(set) var baseVc: TabbedViewController?
     private weak var reauthCoordinator: ReauthCoordinator?
     
@@ -53,9 +54,7 @@ final class HomeCoordinator: NSObject,
         }
         let networkClient = NetworkClient(authenticationProvider: tokenHolder)
         let viewModel = DeveloperMenuViewModel { [unowned self] in
-            if let mainCoordinator = parentCoordinator as? MainCoordinator {
-                mainCoordinator.reauth = true
-            }
+            MainCoordinator.reauth = true
             root.dismiss(animated: true)
             tokenHolder.clearTokenHolder()
             userStore.refreshStorage(accessControlLevel: LAContext().isPasscodeOnly ? .anyBiometricsOrPasscode : .currentBiometricsOrPasscode)

--- a/Sources/Tabs/ProfileCoordinator.swift
+++ b/Sources/Tabs/ProfileCoordinator.swift
@@ -13,7 +13,6 @@ final class ProfileCoordinator: NSObject,
     weak var parentCoordinator: ParentCoordinator?
     var analyticsService: AnalyticsService
     var userStore: UserStorable
-    private let tokenHolder = TokenHolder.shared
     private let urlOpener: URLOpener
     private(set) var baseVc: TabbedViewController?
     
@@ -41,7 +40,7 @@ final class ProfileCoordinator: NSObject,
     }
     
     func updateToken() {
-        baseVc?.updateToken(tokenHolder)
+        baseVc?.updateToken(TokenHolder.shared)
     }
     
     func openSignOutPage() {

--- a/Sources/Tabs/ProfileCoordinator.swift
+++ b/Sources/Tabs/ProfileCoordinator.swift
@@ -13,18 +13,16 @@ final class ProfileCoordinator: NSObject,
     weak var parentCoordinator: ParentCoordinator?
     var analyticsService: AnalyticsService
     var userStore: UserStorable
-    private var tokenHolder: TokenHolder
+    private let tokenHolder = TokenHolder.shared
     private let urlOpener: URLOpener
     private(set) var baseVc: TabbedViewController?
     
     init(analyticsService: AnalyticsService,
          userStore: UserStorable,
-         tokenHolder: TokenHolder,
          urlOpener: URLOpener,
          baseVc: TabbedViewController? = nil) {
         self.analyticsService = analyticsService
         self.userStore = userStore
-        self.tokenHolder = tokenHolder
         self.urlOpener = urlOpener
         self.baseVc = baseVc
     }

--- a/Sources/Tabs/WalletCoordinator.swift
+++ b/Sources/Tabs/WalletCoordinator.swift
@@ -15,17 +15,15 @@ final class WalletCoordinator: NSObject,
     weak var parentCoordinator: ParentCoordinator?
     let analyticsService: AnalyticsService
     private let secureStoreService: SecureStorable
-    private var tokenHolder: TokenHolder
+    private let tokenHolder = TokenHolder.shared
     let walletSDK = WalletSDK()
     
     init(window: UIWindow,
          analyticsService: AnalyticsService,
-         secureStoreService: SecureStorable,
-         tokenHolder: TokenHolder) {
+         secureStoreService: SecureStorable) {
         self.window = window
         self.analyticsService = analyticsService
         self.secureStoreService = secureStoreService
-        self.tokenHolder = tokenHolder
     }
     
     func start() {

--- a/Sources/Tabs/WalletCoordinator.swift
+++ b/Sources/Tabs/WalletCoordinator.swift
@@ -15,7 +15,6 @@ final class WalletCoordinator: NSObject,
     weak var parentCoordinator: ParentCoordinator?
     let analyticsService: AnalyticsService
     private let secureStoreService: SecureStorable
-    private let tokenHolder = TokenHolder.shared
     let walletSDK = WalletSDK()
     
     init(window: UIWindow,
@@ -33,7 +32,7 @@ final class WalletCoordinator: NSObject,
     }
     
     func updateToken() {
-        let networkClient = NetworkClient(authenticationProvider: tokenHolder)
+        let networkClient = NetworkClient(authenticationProvider: TokenHolder.shared)
         walletSDK.start(in: window,
                         with: root,
                         networkClient: networkClient,

--- a/Sources/Utilities/Factories/ErrorPresenter.swift
+++ b/Sources/Utilities/Factories/ErrorPresenter.swift
@@ -31,7 +31,7 @@ final class ErrorPresenter {
     }
     
     
-    static func createSignoutError(errorDescription: String,
+    static func createSignOutError(errorDescription: String,
                                    analyticsService: AnalyticsService,
                                    action: @escaping () -> Void) -> GDSErrorViewController {
         let viewModel = SignOutErrorViewModel(errorDescription: errorDescription,
@@ -41,7 +41,7 @@ final class ErrorPresenter {
         return GDSErrorViewController(viewModel: viewModel)
     }
     
-    static func createSignoutWarning(analyticsService: AnalyticsService,
+    static func createSignOutWarning(analyticsService: AnalyticsService,
                                      action: @escaping () -> Void) -> GDSErrorViewController {
         let viewModel = SignOutWarningViewModel(analyticsService: analyticsService) {
             action()

--- a/Sources/Utilities/Factories/ErrorPresenter.swift
+++ b/Sources/Utilities/Factories/ErrorPresenter.swift
@@ -34,8 +34,16 @@ final class ErrorPresenter {
     static func createSignoutError(errorDescription: String,
                                    analyticsService: AnalyticsService,
                                    action: @escaping () -> Void) -> GDSErrorViewController {
-        let viewModel = SignoutErrorViewModel(errorDescription: errorDescription,
-                                                    analyticsService: analyticsService) {
+        let viewModel = SignOutErrorViewModel(errorDescription: errorDescription,
+                                              analyticsService: analyticsService) {
+            action()
+        }
+        return GDSErrorViewController(viewModel: viewModel)
+    }
+    
+    static func createSignoutWarning(analyticsService: AnalyticsService,
+                                     action: @escaping () -> Void) -> GDSErrorViewController {
+        let viewModel = SignOutWarningViewModel(analyticsService: analyticsService) {
             action()
         }
         return GDSErrorViewController(viewModel: viewModel)

--- a/Sources/Utilities/Network/NetworkMonitor.swift
+++ b/Sources/Utilities/Network/NetworkMonitor.swift
@@ -1,7 +1,7 @@
 import Network
 
 final class NetworkMonitor: NetworkMonitoring {
-    static let shared: NetworkMonitoring = NetworkMonitor()
+    static let shared = NetworkMonitor()
     private let monitor = NWPathMonitor()
     var isConnected: Bool = false
 

--- a/Sources/Utilities/Storage/UserStorable.swift
+++ b/Sources/Utilities/Storage/UserStorable.swift
@@ -25,16 +25,17 @@ extension UserStorable {
         return previouslyAuthenticatedUser.timeIntervalSinceNow.sign == .plus
     }
     
-    func storeTokenInfo(tokenResponse: TokenResponse) throws {
+    func storeTokenInfo() {
+        guard let tokenResponse = TokenHolder.shared.tokenResponse else { return }
         let accessToken = tokenResponse.accessToken
         let tokenExp = tokenResponse.expiryDate
-        try saveItem(accessToken, itemName: .accessToken, storage: .authenticated)
+        try? saveItem(accessToken, itemName: .accessToken, storage: .authenticated)
         if AppEnvironment.extendExpClaimEnabled {
             defaultsStore.set(tokenExp + 27 * 60, forKey: .accessTokenExpiry)
         } else {
-            defaultsStore.set(tokenExp, forKey: .accessTokenExpiry)
+            defaultsStore.set(Date(), forKey: .accessTokenExpiry)
         }
-        try saveItem(tokenResponse.idToken, itemName: .idToken, storage: .authenticated)
+        try? saveItem(tokenResponse.idToken, itemName: .idToken, storage: .authenticated)
     }
     
     func clearTokenInfo() {

--- a/Sources/Utilities/Storage/UserStorable.swift
+++ b/Sources/Utilities/Storage/UserStorable.swift
@@ -27,6 +27,15 @@ extension UserStorable {
         return previouslyAuthenticatedUser.timeIntervalSinceNow.sign == .plus
     }
     
+    var tokenExpiryShown: Bool {
+        get {
+            guard let value = defaultsStore.value(forKey: .tokenExpireyShown) as? Bool else { return false }
+            return value
+        } set {
+            defaultsStore.set(newValue, forKey: .tokenExpireyShown)
+        }
+    }
+    
     func storeTokenInfo(tokenResponse: TokenResponse) throws {
         let accessToken = tokenResponse.accessToken
         let tokenExp = tokenResponse.expiryDate

--- a/Sources/Utilities/Storage/UserStorable.swift
+++ b/Sources/Utilities/Storage/UserStorable.swift
@@ -27,8 +27,8 @@ extension UserStorable {
     
     func storeTokenInfo() {
         guard let tokenResponse = TokenHolder.shared.tokenResponse else { return }
-        if let accessToken = try? saveItem(tokenResponse.accessToken, itemName: .accessToken, storage: .authenticated),
-           let idToken = try? saveItem(tokenResponse.idToken, itemName: .idToken, storage: .authenticated) {
+        if let _ = try? saveItem(tokenResponse.accessToken, itemName: .accessToken, storage: .authenticated),
+           let _ = try? saveItem(tokenResponse.idToken, itemName: .idToken, storage: .authenticated) {
             defaultsStore.set(tokenResponse.expiryDate, forKey: .accessTokenExpiry)
         }
         

--- a/Sources/Utilities/Storage/UserStorable.swift
+++ b/Sources/Utilities/Storage/UserStorable.swift
@@ -12,7 +12,7 @@ protocol UserStorable {
     var openStore: SecureStorable { get set }
     var defaultsStore: DefaultsStorable { get }
     
-    func refreshStorage(accessControlLevel: SecureStorageConfiguration.AccessControlLevel)
+    func refreshStorage(accessControlLevel: SecureStorageConfiguration.AccessControlLevel?)
 }
 
 extension UserStorable {
@@ -21,8 +21,7 @@ extension UserStorable {
     }
     
     var validAuthenticatedUser: Bool {
-        guard let previouslyAuthenticatedUser else { return false }
-        return previouslyAuthenticatedUser.timeIntervalSinceNow.sign == .plus
+        previouslyAuthenticatedUser?.timeIntervalSinceNow.sign == .plus
     }
     
     func storeTokenInfo() {
@@ -31,7 +30,6 @@ extension UserStorable {
            let _ = try? saveItem(tokenResponse.idToken, itemName: .idToken, storage: .authenticated) {
             defaultsStore.set(tokenResponse.expiryDate, forKey: .accessTokenExpiry)
         }
-        
     }
     
     func clearTokenInfo() {

--- a/Sources/Utilities/Storage/UserStorable.swift
+++ b/Sources/Utilities/Storage/UserStorable.swift
@@ -21,19 +21,8 @@ extension UserStorable {
     }
     
     var validAuthenticatedUser: Bool {
-        guard let previouslyAuthenticatedUser else {
-            return false
-        }
+        guard let previouslyAuthenticatedUser else { return false }
         return previouslyAuthenticatedUser.timeIntervalSinceNow.sign == .plus
-    }
-    
-    var tokenExpiryShown: Bool {
-        get {
-            guard let value = defaultsStore.value(forKey: .tokenExpireyShown) as? Bool else { return false }
-            return value
-        } set {
-            defaultsStore.set(newValue, forKey: .tokenExpireyShown)
-        }
     }
     
     func storeTokenInfo(tokenResponse: TokenResponse) throws {

--- a/Sources/Utilities/Storage/UserStorable.swift
+++ b/Sources/Utilities/Storage/UserStorable.swift
@@ -27,15 +27,11 @@ extension UserStorable {
     
     func storeTokenInfo() {
         guard let tokenResponse = TokenHolder.shared.tokenResponse else { return }
-        let accessToken = tokenResponse.accessToken
-        let tokenExp = tokenResponse.expiryDate
-        try? saveItem(accessToken, itemName: .accessToken, storage: .authenticated)
-        if AppEnvironment.extendExpClaimEnabled {
-            defaultsStore.set(tokenExp + 27 * 60, forKey: .accessTokenExpiry)
-        } else {
-            defaultsStore.set(Date(), forKey: .accessTokenExpiry)
+        if let accessToken = try? saveItem(tokenResponse.accessToken, itemName: .accessToken, storage: .authenticated),
+           let idToken = try? saveItem(tokenResponse.idToken, itemName: .idToken, storage: .authenticated) {
+            defaultsStore.set(tokenResponse.expiryDate, forKey: .accessTokenExpiry)
         }
-        try? saveItem(tokenResponse.idToken, itemName: .idToken, storage: .authenticated)
+        
     }
     
     func clearTokenInfo() {

--- a/Sources/Utilities/Storage/UserStorable.swift
+++ b/Sources/Utilities/Storage/UserStorable.swift
@@ -20,8 +20,6 @@ extension UserStorable {
         defaultsStore.value(forKey: .accessTokenExpiry) as? Date
     }
     
-    var validAuthenticatedUser1: Bool { false }
-    
     var validAuthenticatedUser: Bool {
         guard let previouslyAuthenticatedUser else {
             return false

--- a/Sources/Utilities/Storage/UserStorable.swift
+++ b/Sources/Utilities/Storage/UserStorable.swift
@@ -20,6 +20,8 @@ extension UserStorable {
         defaultsStore.value(forKey: .accessTokenExpiry) as? Date
     }
     
+    var validAuthenticatedUser1: Bool { false }
+    
     var validAuthenticatedUser: Bool {
         guard let previouslyAuthenticatedUser else {
             return false
@@ -57,9 +59,9 @@ extension UserStorable {
     
     func readItem(itemName: String, storage: Storage) throws -> String {
         switch storage {
-        case.authenticated:
+        case .authenticated:
             return try authenticatedStore.readItem(itemName: itemName)
-        case.open:
+        case .open:
             return try openStore.readItem(itemName: itemName)
         }
     }

--- a/Sources/Utilities/Storage/UserStorage.swift
+++ b/Sources/Utilities/Storage/UserStorage.swift
@@ -14,15 +14,22 @@ final class UserStorage: UserStorable {
         self.defaultsStore = defaultsStore
     }
     
-    func refreshStorage(accessControlLevel: SecureStorageConfiguration.AccessControlLevel) {
+    func refreshStorage(accessControlLevel: SecureStorageConfiguration.AccessControlLevel?) {
         clearTokenInfo()
         do {
             try authenticatedStore.delete()
         } catch {
             print("Deleting Secure Store error: \(error)")
         }
-        authenticatedStore = SecureStoreService(configuration: .init(id: .oneLoginTokens,
-                                                                     accessControlLevel: accessControlLevel,
-                                                                     localAuthStrings: LAContext().contextStrings))
+        let laContext = LAContext()
+        if let accessControlLevel {
+            authenticatedStore = SecureStoreService(configuration: .init(id: .oneLoginTokens,
+                                                                         accessControlLevel: accessControlLevel,
+                                                                         localAuthStrings: laContext.contextStrings))
+        } else {
+            authenticatedStore = SecureStoreService(configuration: .init(id: .oneLoginTokens,
+                                                                         accessControlLevel: laContext.isPasscodeOnly ? .anyBiometricsOrPasscode : .currentBiometricsOrPasscode,
+                                                                         localAuthStrings: laContext.contextStrings))
+        }
     }
 }

--- a/Tests/UnitTests/Application/MainCoordinatorTests.swift
+++ b/Tests/UnitTests/Application/MainCoordinatorTests.swift
@@ -364,7 +364,7 @@ extension MainCoordinatorTests {
         let presentedVC = try XCTUnwrap(sut.root.presentedViewController as? UINavigationController)
         XCTAssertTrue(presentedVC.topViewController is GDSErrorViewController)
         let errroVC = try XCTUnwrap(presentedVC.topViewController as? GDSErrorViewController)
-        XCTAssertTrue(errroVC.viewModel is SignoutErrorViewModel)
+        XCTAssertTrue(errroVC.viewModel is SignOutErrorViewModel)
         // THEN the tokens shouldn't be deleted and the analytics shouldn't be reset; the app shouldn't be reset
         XCTAssertTrue(mockAnalyticsPreferenceStore.hasAcceptedAnalytics == true)
         try appNotReset()

--- a/Tests/UnitTests/Application/MainCoordinatorTests.swift
+++ b/Tests/UnitTests/Application/MainCoordinatorTests.swift
@@ -64,8 +64,8 @@ final class MainCoordinatorTests: XCTestCase {
     
     func returningAuthenticatedUser(expired: Bool = false) throws {
         let accessToken = try MockTokenResponse().getJSONData().accessToken
-        sut.tokenHolder.accessToken = accessToken
-        sut.tokenHolder.idTokenPayload = try MockTokenVerifier().extractPayload("test")
+        TokenHolder.shared.accessToken = accessToken
+        TokenHolder.shared.idTokenPayload = try MockTokenVerifier().extractPayload("test")
         try mockUserStore.saveItem(accessToken,
                                    itemName: .accessToken,
                                    storage: .authenticated)
@@ -82,8 +82,8 @@ final class MainCoordinatorTests: XCTestCase {
     }
     
     func appNotReset() throws {
-        XCTAssertNotNil(sut.tokenHolder.accessToken)
-        XCTAssertNotNil(sut.tokenHolder.idTokenPayload)
+        XCTAssertNotNil(TokenHolder.shared.accessToken)
+        XCTAssertNotNil(TokenHolder.shared.idTokenPayload)
         XCTAssertNotNil(try mockSecureStore.readItem(itemName: .accessToken))
         XCTAssertNotNil(try mockSecureStore.readItem(itemName: .idToken))
         XCTAssertNotNil(mockDefaultStore.value(forKey: .accessTokenExpiry))
@@ -91,8 +91,8 @@ final class MainCoordinatorTests: XCTestCase {
     }
     
     func appReset() throws {
-        XCTAssertNil(sut.tokenHolder.accessToken)
-        XCTAssertNil(sut.tokenHolder.idTokenPayload)
+        XCTAssertNil(TokenHolder.shared.accessToken)
+        XCTAssertNil(TokenHolder.shared.idTokenPayload)
         XCTAssertThrowsError(try mockSecureStore.readItem(itemName: .accessToken))
         XCTAssertThrowsError(try mockSecureStore.readItem(itemName: .idToken))
         XCTAssertNil(mockDefaultStore.value(forKey: .accessTokenExpiry))
@@ -300,7 +300,7 @@ extension MainCoordinatorTests {
     
     func test_didRegainFocus_fromLoginCoordinator_withBearerToken() throws {
         // GIVEN access token has been stored in the token holder
-        sut.tokenHolder.accessToken = "testAccessToken"
+        TokenHolder.shared.accessToken = "testAccessToken"
         let loginCoordinator = LoginCoordinator(windowManager: mockWindowManager,
                                                 root: UINavigationController(),
                                                 analyticsCenter: mockAnalyticsCenter,
@@ -313,6 +313,7 @@ extension MainCoordinatorTests {
     }
     
     func test_didRegainFocus_fromLoginCoordinator_withoutBearerToken() throws {
+        TokenHolder.shared.accessToken = nil
         let loginCoordinator = LoginCoordinator(windowManager: mockWindowManager,
                                                 root: UINavigationController(),
                                                 analyticsCenter: mockAnalyticsCenter,
@@ -324,7 +325,7 @@ extension MainCoordinatorTests {
         XCTAssertEqual(sut.childCoordinators.count, 0)
         // THEN the token holders bearer token should not have the access token
         do {
-            _ = try sut.tokenHolder.bearerToken
+            _ = try TokenHolder.shared.bearerToken
             XCTFail("Should throw TokenError error")
         } catch {
             XCTAssertTrue(error is TokenError)

--- a/Tests/UnitTests/Application/MainCoordinatorTests.swift
+++ b/Tests/UnitTests/Application/MainCoordinatorTests.swift
@@ -242,7 +242,7 @@ extension MainCoordinatorTests {
         // This test is purely to get test coverage atm as we will not be able to test for effects on unmocked subcoordinators
         sut.handleUniversalLink(URL(string: "google.co.uk/wallet/123456789")!)
         sut.handleUniversalLink(URL(string: "google.co.uk/redirect/123456789")!)
-        MainCoordinator.reauth = true
+        MainCoordinator.isReauthing = true
         sut.handleUniversalLink(URL(string: "google.co.uk/redirect/123456789")!)
     }
     
@@ -371,12 +371,12 @@ extension MainCoordinatorTests {
     }
     
     func test_performChildCleanup_fromHomeCoordinator() throws {
-        MainCoordinator.reauth = true
+        MainCoordinator.isReauthing = true
         let homeCoordinator = HomeCoordinator(window: mockWindowManager.appWindow,
                                               analyticsService: mockAnalyticsService,
                                               userStore: mockUserStore)
         // WHEN the MainCoordinator's performChildCleanup method is called from HomeCoordinator (on user reauth)
         sut.performChildCleanup(child: homeCoordinator)
-        XCTAssertFalse(MainCoordinator.reauth)
+        XCTAssertFalse(MainCoordinator.isReauthing)
     }
 }

--- a/Tests/UnitTests/Application/MainCoordinatorTests.swift
+++ b/Tests/UnitTests/Application/MainCoordinatorTests.swift
@@ -313,7 +313,7 @@ extension MainCoordinatorTests {
     }
     
     func test_didRegainFocus_fromLoginCoordinator_withoutBearerToken() throws {
-        TokenHolder.shared.accessToken = nil
+        TokenHolder.shared.clearTokenHolder()
         let loginCoordinator = LoginCoordinator(windowManager: mockWindowManager,
                                                 root: UINavigationController(),
                                                 analyticsCenter: mockAnalyticsCenter,

--- a/Tests/UnitTests/Application/MainCoordinatorTests.swift
+++ b/Tests/UnitTests/Application/MainCoordinatorTests.swift
@@ -305,8 +305,7 @@ extension MainCoordinatorTests {
                                                 root: UINavigationController(),
                                                 analyticsCenter: mockAnalyticsCenter,
                                                 userStore: mockUserStore,
-                                                networkMonitor: MockNetworkMonitor(),
-                                                tokenHolder: TokenHolder())
+                                                networkMonitor: MockNetworkMonitor())
         // WHEN the MainCoordinator didRegainFocus from the LoginCoordinator
         sut.didRegainFocus(fromChild: loginCoordinator)
         // THEN no coordinator should be launched
@@ -318,8 +317,7 @@ extension MainCoordinatorTests {
                                                 root: UINavigationController(),
                                                 analyticsCenter: mockAnalyticsCenter,
                                                 userStore: mockUserStore,
-                                                networkMonitor: MockNetworkMonitor(),
-                                                tokenHolder: TokenHolder())
+                                                networkMonitor: MockNetworkMonitor())
         // WHEN the MainCoordinator didRegainFocus from the LoginCoordinator
         sut.didRegainFocus(fromChild: loginCoordinator)
         // THEN no coordinator should be launched
@@ -339,7 +337,6 @@ extension MainCoordinatorTests {
         try returningAuthenticatedUser()
         let profileCoordinator = ProfileCoordinator(analyticsService: mockAnalyticsService,
                                                     userStore: mockUserStore,
-                                                    tokenHolder: TokenHolder(),
                                                     urlOpener: mockURLOpener)
         // WHEN the MainCoordinator's performChildCleanup method is called from ProfileCoordinator (on user sign out)
         sut.performChildCleanup(child: profileCoordinator)
@@ -355,7 +352,6 @@ extension MainCoordinatorTests {
         try returningAuthenticatedUser()
         let profileCoordinator = ProfileCoordinator(analyticsService: mockAnalyticsService,
                                                     userStore: mockUserStore,
-                                                    tokenHolder: TokenHolder(),
                                                     urlOpener: mockURLOpener)
         // WHEN the MainCoordinator's performChildCleanup method is called from ProfileCoordinator (on user sign out)
         // but there was an error in signing out

--- a/Tests/UnitTests/Application/MainCoordinatorTests.swift
+++ b/Tests/UnitTests/Application/MainCoordinatorTests.swift
@@ -242,6 +242,8 @@ extension MainCoordinatorTests {
         // This test is purely to get test coverage atm as we will not be able to test for effects on unmocked subcoordinators
         sut.handleUniversalLink(URL(string: "google.co.uk/wallet/123456789")!)
         sut.handleUniversalLink(URL(string: "google.co.uk/redirect/123456789")!)
+        MainCoordinator.reauth = true
+        sut.handleUniversalLink(URL(string: "google.co.uk/redirect/123456789")!)
     }
     
     func test_didSelect_tabBarItem_home() {
@@ -366,5 +368,15 @@ extension MainCoordinatorTests {
         XCTAssertTrue(mockAnalyticsPreferenceStore.hasAcceptedAnalytics == true)
         try appNotReset()
         UserDefaults.standard.set(false, forKey: "EnableSignoutError")
+    }
+    
+    func test_performChildCleanup_fromHomeCoordinator() throws {
+        MainCoordinator.reauth = true
+        let homeCoordinator = HomeCoordinator(window: mockWindowManager.appWindow,
+                                              analyticsService: mockAnalyticsService,
+                                              userStore: mockUserStore)
+        // WHEN the MainCoordinator's performChildCleanup method is called from HomeCoordinator (on user reauth)
+        sut.performChildCleanup(child: homeCoordinator)
+        XCTAssertFalse(MainCoordinator.reauth)
     }
 }

--- a/Tests/UnitTests/Application/TokenHolderTests.swift
+++ b/Tests/UnitTests/Application/TokenHolderTests.swift
@@ -2,7 +2,7 @@
 import XCTest
 
 final class TokenHolderTests: XCTestCase {
-    var sut = TokenHolder()
+    var sut = TokenHolder.shared
 }
 
 extension TokenHolderTests {
@@ -12,6 +12,7 @@ extension TokenHolderTests {
     }
     
     func test_bearerToken_errors() throws {
+        sut.accessToken = nil
         do {
             _ = try sut.bearerToken
             XCTFail("Should throw TokenError error")

--- a/Tests/UnitTests/Errors/SignOutErrorViewModelTests.swift
+++ b/Tests/UnitTests/Errors/SignOutErrorViewModelTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 import Foundation
 
-final class SignoutErrorViewModelTests: XCTestCase {
+final class SignOutErrorViewModelTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
     var sut: SignOutErrorViewModel!
     
@@ -28,8 +28,9 @@ final class SignoutErrorViewModelTests: XCTestCase {
     }
 }
 
-extension SignoutErrorViewModelTests {
+extension SignOutErrorViewModelTests {
     func test_pageConfiguration() throws {
+        XCTAssertEqual(sut.image, "exclamationmark.circle")
         XCTAssertEqual(sut.title.stringKey, "app_signOutErrorTitle")
         XCTAssertEqual(sut.body, "app_signOutErrorBody")
         XCTAssertNil(sut.secondaryButtonViewModel)

--- a/Tests/UnitTests/Errors/SignOutWarningViewModelTests.swift
+++ b/Tests/UnitTests/Errors/SignOutWarningViewModelTests.swift
@@ -1,0 +1,52 @@
+import GDSAnalytics
+import GDSCommon
+@testable import OneLogin
+import XCTest
+
+import Foundation
+
+final class SignOutWarningViewModelTests: XCTestCase {
+    var mockAnalyticsService: MockAnalyticsService!
+    var sut: SignOutWarningViewModel!
+    
+    var didCallButtonAction = false
+    
+    override func setUp() {
+        super.setUp()
+        
+        mockAnalyticsService = MockAnalyticsService()
+        sut = SignOutWarningViewModel(analyticsService: mockAnalyticsService) {
+            self.didCallButtonAction = true
+        }
+    }
+    
+    override func tearDown() {
+        mockAnalyticsService = nil
+        sut = nil
+        didCallButtonAction = false
+    }
+}
+
+extension SignOutWarningViewModelTests {
+    func test_pageConfiguration() throws {
+        XCTAssertEqual(sut.image, "exclamationmark.circle")
+        XCTAssertEqual(sut.title.stringKey, "app_signOutWarningTitle")
+        XCTAssertEqual(sut.body, "app_signOutWarningBody")
+        XCTAssertNil(sut.secondaryButtonViewModel)
+        XCTAssertNil(sut.rightBarButtonTitle)
+        XCTAssertTrue(sut.backButtonIsHidden)
+    }
+    
+    func test_buttonConfiuration() throws {
+        XCTAssertTrue(sut.primaryButtonViewModel is AnalyticsButtonViewModel)
+        XCTAssertEqual(sut.primaryButtonViewModel.title, GDSLocalisedString(stringLiteral: "app_signInButton"))
+        let button = try XCTUnwrap(sut.primaryButtonViewModel as? AnalyticsButtonViewModel)
+        XCTAssertEqual(button.backgroundColor, .gdsGreen)
+    }
+    
+    func test_buttonAction() throws {
+        XCTAssertFalse(didCallButtonAction)
+        sut.primaryButtonViewModel.action()
+        XCTAssertTrue(didCallButtonAction)
+    }
+}

--- a/Tests/UnitTests/Errors/SignOutWarningViewModelTests.swift
+++ b/Tests/UnitTests/Errors/SignOutWarningViewModelTests.swift
@@ -3,8 +3,6 @@ import GDSCommon
 @testable import OneLogin
 import XCTest
 
-import Foundation
-
 final class SignOutWarningViewModelTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
     var sut: SignOutWarningViewModel!

--- a/Tests/UnitTests/Login/AuthenticationCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/AuthenticationCoordinatorTests.swift
@@ -15,7 +15,6 @@ final class AuthenticationCoordinatorTests: XCTestCase {
     var mockUserStore: UserStorage!
     var mockLoginSession: MockLoginSession!
     var mockTokenVerifier: MockTokenVerifier!
-    var tokenHolder: TokenHolder!
     var sut: AuthenticationCoordinator!
     
     
@@ -33,12 +32,10 @@ final class AuthenticationCoordinatorTests: XCTestCase {
                                     openStore: mockOpenSecureStore,
                                     defaultsStore: mockDefaultStore)
         mockTokenVerifier = MockTokenVerifier()
-        tokenHolder = TokenHolder()
         sut = AuthenticationCoordinator(root: navigationController,
                                         analyticsService: mockAnalyticsService,
                                         userStore: mockUserStore,
                                         session: mockLoginSession,
-                                        tokenHolder: tokenHolder,
                                         tokenVerifier: mockTokenVerifier)
         UserDefaults.standard.setValue(true, forKey: FeatureFlags.enableCallingSTS.rawValue)
     }
@@ -53,7 +50,6 @@ final class AuthenticationCoordinatorTests: XCTestCase {
         mockDefaultStore = nil
         mockUserStore = nil
         mockTokenVerifier = nil
-        tokenHolder = nil
         sut = nil
         UserDefaults.standard.removeObject(forKey: FeatureFlags.enableCallingSTS.rawValue)
         super.tearDown()
@@ -72,11 +68,11 @@ extension AuthenticationCoordinatorTests {
         sut.start()
         waitForTruth(self.mockLoginSession.didCallPerformLoginFlow, timeout: 20)
         // THEN the tokens are returned
-        XCTAssertEqual(tokenHolder.tokenResponse?.accessToken, "accessTokenResponse")
-        XCTAssertEqual(tokenHolder.tokenResponse?.refreshToken, "refreshTokenResponse")
-        XCTAssertEqual(tokenHolder.tokenResponse?.idToken, "idTokenResponse")
+        XCTAssertEqual(TokenHolder.shared.tokenResponse?.accessToken, "accessTokenResponse")
+        XCTAssertEqual(TokenHolder.shared.tokenResponse?.refreshToken, "refreshTokenResponse")
+        XCTAssertEqual(TokenHolder.shared.tokenResponse?.idToken, "idTokenResponse")
         // THEN the persistentSessionID is stored.
-        XCTAssertEqual(try mockUserStore.readItem(itemName: .persistentSessionID, storage: .open), tokenHolder.idTokenPayload?.persistentId)
+        XCTAssertEqual(try mockUserStore.readItem(itemName: .persistentSessionID, storage: .open), TokenHolder.shared.idTokenPayload?.persistentId)
     }
     
     func test_start_loginError_network() throws {

--- a/Tests/UnitTests/Login/AuthenticationCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/AuthenticationCoordinatorTests.swift
@@ -52,6 +52,7 @@ final class AuthenticationCoordinatorTests: XCTestCase {
         mockTokenVerifier = nil
         sut = nil
         UserDefaults.standard.removeObject(forKey: FeatureFlags.enableCallingSTS.rawValue)
+        
         super.tearDown()
     }
     

--- a/Tests/UnitTests/Login/EnrolmentCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/EnrolmentCoordinatorTests.swift
@@ -59,7 +59,7 @@ extension EnrolmentCoordinatorTests {
         // GIVEN the local authentication context returned true for canEvaluatePolicy for authentication
         mockLAContext.returnedFromCanEvaluatePolicyForAuthentication = false
         // GIVEN the token holder's token response has tokens
-        sut.tokenHolder.tokenResponse = try MockTokenResponse().getJSONData()
+        TokenHolder.shared.tokenResponse = try MockTokenResponse().getJSONData()
         // WHEN the EnrolmentCoordinator is started
         sut.start()
         // THEN the 'passcode information' screen is shown
@@ -73,13 +73,13 @@ extension EnrolmentCoordinatorTests {
         mockLAContext.returnedFromCanEvaluatePolicyForAuthentication = true
         // GIVEN the token holder's token response has tokens
         let tokenResponse = try MockTokenResponse().getJSONData()
-        sut.tokenHolder.tokenResponse = tokenResponse
+        TokenHolder.shared.tokenResponse = tokenResponse
         // WHEN the EnrolmentCoordinator is started
         sut.start()
         // THEN the journey should be saved in user defaults
-        XCTAssertEqual(mockDefaultsStore.savedData["accessTokenExpiry"] as? Date, tokenResponse.expiryDate)
-        XCTAssertEqual(mockSecureStore.savedItems["accessToken"], tokenResponse.accessToken)
-        XCTAssertEqual(mockSecureStore.savedItems["idToken"], tokenResponse.idToken)
+        XCTAssertEqual(mockDefaultsStore.savedData[.accessTokenExpiry] as? Date, tokenResponse.expiryDate)
+        XCTAssertEqual(mockSecureStore.savedItems[.accessToken], tokenResponse.accessToken)
+        XCTAssertEqual(mockSecureStore.savedItems[.idToken], tokenResponse.idToken)
     }
 
     func test_start_deviceLocalAuthSet_passcode_fails() throws {
@@ -88,20 +88,20 @@ extension EnrolmentCoordinatorTests {
         // GIVEN the secure store returns an error from saving an item
         mockSecureStore.errorFromSaveItem = SecureStoreError.generic
         // GIVEN the token holder's token response has tokens
-        sut.tokenHolder.tokenResponse = try MockTokenResponse().getJSONData()
+        TokenHolder.shared.tokenResponse = try MockTokenResponse().getJSONData()
         // WHEN the EnrolmentCoordinator is started
         sut.start()
         // THEN the journey should be saved in user defaults
-        XCTAssertEqual(mockDefaultsStore.savedData["accessTokenExpiry"] as? Date, nil)
-        XCTAssertEqual(mockSecureStore.savedItems["accessToken"], nil)
-        XCTAssertEqual(mockSecureStore.savedItems["idToken"], nil)
+        XCTAssertEqual(mockDefaultsStore.savedData[.accessTokenExpiry] as? Date, nil)
+        XCTAssertEqual(mockSecureStore.savedItems[.accessToken], nil)
+        XCTAssertEqual(mockSecureStore.savedItems[.idToken], nil)
     }
 
     func test_start_deviceLocalAuthSet_touchID() throws {
         // GIVEN the local authentication context returned true for canEvaluatePolicy for biometrics
         mockLAContext.returnedFromCanEvaluatePolicyForBiometrics = true
         // GIVEN the token holder's token response has tokens
-        sut.tokenHolder.tokenResponse = try MockTokenResponse().getJSONData()
+        TokenHolder.shared.tokenResponse = try MockTokenResponse().getJSONData()
         // WHEN the EnrolmentCoordinator is started
         sut.start()
         // THEN the 'touch id information' screen is shown
@@ -114,7 +114,7 @@ extension EnrolmentCoordinatorTests {
         // GIVEN the local authentication context returned true for canEvaluatePolicy for biometrics
         mockLAContext.returnedFromCanEvaluatePolicyForBiometrics = true
         // GIVEN the token holder's token response has tokens
-        sut.tokenHolder.tokenResponse = try MockTokenResponse().getJSONData()
+        TokenHolder.shared.tokenResponse = try MockTokenResponse().getJSONData()
         // GIVEN the local authentication's biometry type is face id
         mockLAContext.biometryType = .faceID
         // WHEN the EnrolmentCoordinator is started
@@ -129,7 +129,7 @@ extension EnrolmentCoordinatorTests {
         // GIVEN the local authentication context returned true for canEvaluatePolicy for biometrics
         mockLAContext.returnedFromCanEvaluatePolicyForBiometrics = true
         // GIVEN the token holder's token response has tokens
-        sut.tokenHolder.tokenResponse = try MockTokenResponse().getJSONData()
+        TokenHolder.shared.tokenResponse = try MockTokenResponse().getJSONData()
         // GIVEN the local authentication's biometry type is optic id
         if #available(iOS 17.0, *) {
             mockLAContext.biometryType = .opticID
@@ -145,13 +145,13 @@ extension EnrolmentCoordinatorTests {
         mockLAContext.returnedFromEvaluatePolicy = true
         // GIVEN the token holder's token response has tokens
         let tokenResponse = try MockTokenResponse().getJSONData()
-        sut.tokenHolder.tokenResponse = tokenResponse
+        TokenHolder.shared.tokenResponse = tokenResponse
         // WHEN the EnrolmentCoordinator's enrolLocalAuth method is called
         Task { await sut.enrolLocalAuth(reason: "") }
         // THEN the journey should be saved in user defaults
-        waitForTruth(self.mockDefaultsStore.savedData["accessTokenExpiry"] as? Date == tokenResponse.expiryDate, timeout: 20)
-        XCTAssertEqual(mockSecureStore.savedItems["accessToken"], tokenResponse.accessToken)
-        XCTAssertEqual(mockSecureStore.savedItems["idToken"], tokenResponse.idToken)
+        waitForTruth(self.mockDefaultsStore.savedData[.accessTokenExpiry] as? Date == tokenResponse.expiryDate, timeout: 20)
+        XCTAssertEqual(mockSecureStore.savedItems[.accessToken], tokenResponse.accessToken)
+        XCTAssertEqual(mockSecureStore.savedItems[.idToken], tokenResponse.idToken)
         XCTAssertEqual(mockLAContext.localizedFallbackTitle, "Enter passcode")
         XCTAssertEqual(mockLAContext.localizedCancelTitle, "Cancel")
     }
@@ -160,25 +160,25 @@ extension EnrolmentCoordinatorTests {
         // GIVEN the local authentication context returned false for evaluatePolicy
         mockLAContext.returnedFromEvaluatePolicy = false
         // GIVEN the token holder's token response has tokens
-        sut.tokenHolder.tokenResponse = try MockTokenResponse().getJSONData()
+        TokenHolder.shared.tokenResponse = try MockTokenResponse().getJSONData()
         // WHEN the EnrolmentCoordinator's enrolLocalAuth method is called
         Task { await sut.enrolLocalAuth(reason: "") }
         // THEN the journey should be saved in user defaults
-        waitForTruth(self.mockDefaultsStore.savedData["accessTokenExpiry"] as? Date == nil, timeout: 20)
-        XCTAssertEqual(mockSecureStore.savedItems["accessToken"], nil)
-        XCTAssertEqual(mockSecureStore.savedItems["idToken"], nil)
+        waitForTruth(self.mockDefaultsStore.savedData[.accessTokenExpiry] as? Date == nil, timeout: 20)
+        XCTAssertEqual(mockSecureStore.savedItems[.accessToken], nil)
+        XCTAssertEqual(mockSecureStore.savedItems[.idToken], nil)
     }
     
     func test_enrolLocalAuth_errors() throws {
         // GIVEN the local authentication context returned an error for evaluatePolicy
         mockLAContext.errorFromEvaluatePolicy = LocalAuthError.generic
         // GIVEN the token holder's token response has tokens
-        sut.tokenHolder.tokenResponse = try MockTokenResponse().getJSONData()
+        TokenHolder.shared.tokenResponse = try MockTokenResponse().getJSONData()
         // WHEN the EnrolmentCoordinator's enrolLocalAuth method is called
         Task { await sut.enrolLocalAuth(reason: "") }
         // THEN the journey should be saved in user defaults
-        waitForTruth(self.mockDefaultsStore.savedData["accessTokenExpiry"] as? Date == nil, timeout: 20)
-        XCTAssertEqual(mockSecureStore.savedItems["accessToken"], nil)
-        XCTAssertEqual(mockSecureStore.savedItems["idToken"], nil)
+        waitForTruth(self.mockDefaultsStore.savedData[.accessTokenExpiry] as? Date == nil, timeout: 20)
+        XCTAssertEqual(mockSecureStore.savedItems[.accessToken], nil)
+        XCTAssertEqual(mockSecureStore.savedItems[.idToken], nil)
     }
 }

--- a/Tests/UnitTests/Login/EnrolmentCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/EnrolmentCoordinatorTests.swift
@@ -12,7 +12,6 @@ final class EnrolmentCoordinatorTests: XCTestCase {
     var mockDefaultsStore: MockDefaultsStore!
     var mockUserStore: MockUserStore!
     var mockLAContext: MockLAContext!
-    var tokenHolder: TokenHolder!
     var sut: EnrolmentCoordinator!
     
     override func setUp() {
@@ -27,12 +26,10 @@ final class EnrolmentCoordinatorTests: XCTestCase {
                                       openStore: mockOpenSecureStore,
                                       defaultsStore: mockDefaultsStore)
         mockLAContext = MockLAContext()
-        tokenHolder = TokenHolder()
         sut = EnrolmentCoordinator(root: navigationController,
                                    analyticsService: mockAnalyticsService,
                                    userStore: mockUserStore,
-                                   localAuth: mockLAContext,
-                                   tokenHolder: tokenHolder)
+                                   localAuth: mockLAContext)
     }
 
     override func tearDown() {
@@ -43,7 +40,6 @@ final class EnrolmentCoordinatorTests: XCTestCase {
         mockDefaultsStore = nil
         mockUserStore = nil
         mockLAContext = nil
-        tokenHolder = nil
         sut = nil
 
         super.tearDown()

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -15,7 +15,6 @@ final class LoginCoordinatorTests: XCTestCase {
     var mockOpenSecureStore: MockSecureStoreService!
     var mockDefaultStore: MockDefaultsStore!
     var mockUserStore: UserStorage!
-    var mockTokenHolder: TokenHolder!
     var mockTokenVerifier: MockTokenVerifier!
     var sut: LoginCoordinator!
     
@@ -35,7 +34,6 @@ final class LoginCoordinatorTests: XCTestCase {
         mockUserStore = UserStorage(authenticatedStore: mockSecureStore,
                                     openStore: mockOpenSecureStore,
                                     defaultsStore: mockDefaultStore)
-        mockTokenHolder = TokenHolder()
         mockTokenVerifier = MockTokenVerifier()
         mockWindowManager.appWindow.rootViewController = navigationController
         mockWindowManager.appWindow.makeKeyAndVisible()
@@ -44,7 +42,6 @@ final class LoginCoordinatorTests: XCTestCase {
                                analyticsCenter: mockAnalyticsCenter,
                                userStore: mockUserStore,
                                networkMonitor: mockNetworkMonitor,
-                               tokenHolder: mockTokenHolder,
                                tokenVerifier: mockTokenVerifier)
     }
     
@@ -59,7 +56,6 @@ final class LoginCoordinatorTests: XCTestCase {
         mockOpenSecureStore = nil
         mockDefaultStore = nil
         mockUserStore = nil
-        mockTokenHolder = nil
         sut = nil
         
         super.tearDown()
@@ -160,8 +156,7 @@ extension LoginCoordinatorTests {
         let authCoordinator = AuthenticationCoordinator(root: navigationController,
                                                         analyticsService: mockAnalyticsService,
                                                         userStore: mockUserStore,
-                                                        session: MockLoginSession(),
-                                                        tokenHolder: mockTokenHolder)
+                                                        session: MockLoginSession())
         authCoordinator.authError = AuthenticationError.generic
         // GIVEN the LoginCoordinator has started and set it's view controllers
         sut.start()

--- a/Tests/UnitTests/Login/ReauthCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/ReauthCoordinatorTests.swift
@@ -57,6 +57,18 @@ extension ReauthCoordinatorTests {
         XCTAssertTrue(errorVc.viewModel is SignOutWarningViewModel)
     }
     
+    func test_start_signOutWarningScreen_primaryButton_launchesAuthentticationCoordinator() throws {
+        // WHEN the ReauthCoordinator starts
+        window.rootViewController = sut.root
+        sut.start()
+        // THEN the root view controller should be the sign out warning screen
+        XCTAssertTrue(sut.root.topViewController is GDSErrorViewController)
+        let errorVc = try XCTUnwrap(sut.root.topViewController as? GDSErrorViewController)
+        let errorButton: UIButton = try XCTUnwrap(errorVc.view[child: "error-primary-button"])
+        errorButton.sendActions(for: .touchUpInside)
+        XCTAssertTrue(sut.childCoordinators.last is AuthenticationCoordinator)
+    }
+    
     func test_didRegainFocus_fromAuthenticationCoordinator_succeeds() throws {
         let tokenResponse = try MockTokenResponse().getJSONData()
         TokenHolder.shared.tokenResponse = tokenResponse
@@ -90,7 +102,7 @@ extension ReauthCoordinatorTests {
         sut.didRegainFocus(fromChild: authCoordinator)
         // THEN the ReauthCoordinator should still have IntroViewController as it's top view controller
         XCTAssertTrue(sut.root.topViewController is GDSErrorViewController)
-        let introButton: UIButton = try XCTUnwrap(vc.view[child: "error-primary-button"])
-        XCTAssertTrue(introButton.isEnabled)
+        let errorButton: UIButton = try XCTUnwrap(vc.view[child: "error-primary-button"])
+        XCTAssertTrue(errorButton.isEnabled)
     }
 }

--- a/Tests/UnitTests/Login/ReauthCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/ReauthCoordinatorTests.swift
@@ -1,0 +1,96 @@
+import Authentication
+import GDSAnalytics
+import GDSCommon
+@testable import OneLogin
+import XCTest
+
+@MainActor
+final class ReauthCoordinatorTests: XCTestCase {
+    var window: UIWindow!
+    var mockAnalyticsService: MockAnalyticsService!
+    var mockAuthenticatedSecureStore: MockSecureStoreService!
+    var mockOpenSecureStore: MockSecureStoreService!
+    var mockDefaultsStore: MockDefaultsStore!
+    var mockUserStore: MockUserStore!
+    var sut: ReauthCoordinator!
+    
+    override func setUp() {
+        super.setUp()
+        
+        window = UIWindow()
+        mockAnalyticsService = MockAnalyticsService()
+        mockAuthenticatedSecureStore = MockSecureStoreService()
+        mockOpenSecureStore = MockSecureStoreService()
+        mockDefaultsStore = MockDefaultsStore()
+        mockUserStore = MockUserStore(authenticatedStore: mockAuthenticatedSecureStore,
+                                      openStore: mockOpenSecureStore,
+                                      defaultsStore: mockDefaultsStore)
+        sut = ReauthCoordinator(window: window,
+                                analyticsService: mockAnalyticsService,
+                                userStore: mockUserStore)
+    }
+    
+    override func tearDown() {
+        window = nil
+        mockAnalyticsService = nil
+        mockAuthenticatedSecureStore = nil
+        mockOpenSecureStore = nil
+        mockDefaultsStore = nil
+        mockUserStore = nil
+        sut = nil
+        
+        super.tearDown()
+    }
+    
+    private enum AuthenticationError: Error {
+        case generic
+    }
+}
+
+extension ReauthCoordinatorTests {
+    func test_start_showsSignOutWarningScreen() throws {
+        // WHEN the ReauthCoordinator starts
+        sut.start()
+        // THEN the root view controller should be the sign out warning screen
+        XCTAssertTrue(sut.root.topViewController is GDSErrorViewController)
+        let errorVc = try XCTUnwrap(sut.root.topViewController as? GDSErrorViewController)
+        XCTAssertTrue(errorVc.viewModel is SignOutWarningViewModel)
+    }
+    
+    func test_didRegainFocus_fromAuthenticationCoordinator_succeeds() throws {
+        let tokenResponse = try MockTokenResponse().getJSONData()
+        TokenHolder.shared.tokenResponse = tokenResponse
+        let authCoordinator = AuthenticationCoordinator(root: UINavigationController(),
+                                                        analyticsService: mockAnalyticsService,
+                                                        userStore: mockUserStore,
+                                                        session: MockLoginSession())
+        // GIVEN the ReauthCoordinator has started and set it's view controllers
+        sut.start()
+        let vc = try XCTUnwrap(sut.root.topViewController as? GDSErrorViewController)
+        vc.loadView()
+        // GIVEN the ReauthCoordinator regained focus from the AuthenticationCoordinator
+        sut.didRegainFocus(fromChild: authCoordinator)
+        // THEN the ReauthCoordinator should still have IntroViewController as it's top view controller
+        XCTAssertEqual(mockDefaultsStore.savedData[.accessTokenExpiry] as? Date, tokenResponse.expiryDate)
+        XCTAssertEqual(mockAuthenticatedSecureStore.savedItems[.accessToken], tokenResponse.accessToken)
+        XCTAssertEqual(mockAuthenticatedSecureStore.savedItems[.idToken], tokenResponse.idToken)
+    }
+    
+    func test_didRegainFocus_fromAuthenticationCoordinator_withError() throws {
+        let authCoordinator = AuthenticationCoordinator(root: UINavigationController(),
+                                                        analyticsService: mockAnalyticsService,
+                                                        userStore: mockUserStore,
+                                                        session: MockLoginSession())
+        authCoordinator.authError = AuthenticationError.generic
+        // GIVEN the ReauthCoordinator has started and set it's view controllers
+        sut.start()
+        let vc = try XCTUnwrap(sut.root.topViewController as? GDSErrorViewController)
+        vc.loadView()
+        // GIVEN the ReauthCoordinator regained focus from the AuthenticationCoordinator
+        sut.didRegainFocus(fromChild: authCoordinator)
+        // THEN the ReauthCoordinator should still have IntroViewController as it's top view controller
+        XCTAssertTrue(sut.root.topViewController is GDSErrorViewController)
+        let introButton: UIButton = try XCTUnwrap(vc.view[child: "error-primary-button"])
+        XCTAssertTrue(introButton.isEnabled)
+    }
+}

--- a/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockUserStore.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockUserStore.swift
@@ -16,5 +16,5 @@ class MockUserStore: UserStorable {
         self.defaultsStore = defaultsStore
     }
     
-    func refreshStorage(accessControlLevel: SecureStorageConfiguration.AccessControlLevel) { }
+    func refreshStorage(accessControlLevel: SecureStorageConfiguration.AccessControlLevel?) { }
 }

--- a/Tests/UnitTests/Resources/LocalizedEnglishStringTests.swift
+++ b/Tests/UnitTests/Resources/LocalizedEnglishStringTests.swift
@@ -23,6 +23,8 @@ final class LocalizedEnglishStringTests: XCTestCase {
                        "Maybe later")
         XCTAssertEqual("app_enterPasscodeButton".getEnglishString(),
                        "Enter passcode")
+        XCTAssertEqual("app_exitButton".getEnglishString(),
+                       "Exit")
     }
     
     func test_localAuthPrompt_keys() throws {
@@ -158,6 +160,20 @@ final class LocalizedEnglishStringTests: XCTestCase {
                        "Any deleted documents will still be available online for you to add to your GOV.UK Wallet again.")
         XCTAssertEqual("app_signOutAndDeleteAppDataButton".getEnglishString(),
                        "Sign out and delete app data")
+    }
+    
+    func test_signOutErrorPageKeys() {
+        XCTAssertEqual("app_signOutErrorTitle".getEnglishString(),
+                       "There was a problem signing you out")
+        XCTAssertEqual("app_signOutErrorBody".getEnglishString(),
+                       "You can force sign out by deleting the app from your device.")
+    }
+    
+    func test_signOutWarningPageKeys() {
+        XCTAssertEqual("app_signOutWarningTitle".getEnglishString(),
+                       "You’ve been signed-out")
+        XCTAssertEqual("app_signOutWarningBody".getEnglishString(),
+                       "You will need to reauthenticate")
     }
 }
 

--- a/Tests/UnitTests/Resources/LocalizedWelshStringTests.swift
+++ b/Tests/UnitTests/Resources/LocalizedWelshStringTests.swift
@@ -23,6 +23,8 @@ final class LocalizedWelshStringTests: XCTestCase {
                        "Efallai nes ymlaen")
         XCTAssertEqual("app_enterPasscodeButton".getWelshString(),
                        "Rhowch god mynediad")
+        XCTAssertEqual("app_exitButton".getWelshString(),
+                       "Gadael")
     }
     
     func test_localAuthPrompt_keys() throws {
@@ -158,6 +160,20 @@ final class LocalizedWelshStringTests: XCTestCase {
                        "Bydd unrhyw ddogfennau sydd wedi'u dileu yn dal i fod ar gael ar-lein i chi eu hychwanegu at eich GOV.UK Wallet eto.")
         XCTAssertEqual("app_signOutAndDeleteAppDataButton".getWelshString(),
                        "Allgofnodwch a dileu data yr ap")
+    }
+    
+    func test_signOutErrorPageKeys() {
+        XCTAssertEqual("app_signOutErrorTitle".getWelshString(),
+                       "Roedd problem wrth eich allgofnodi")
+        XCTAssertEqual("app_signOutErrorBody".getWelshString(),
+                       "Gallwch orfodi allgofnodi trwy ddileu'r ap o'ch dyfais.")
+    }
+    
+    func test_signOutWarningPageKeys() {
+        XCTAssertEqual("app_signOutWarningTitle".getWelshString(),
+                       "You’ve been signed-out")
+        XCTAssertEqual("app_signOutWarningBody".getWelshString(),
+                       "You will need to reauthenticate")
     }
 }
 

--- a/Tests/UnitTests/Screens/DeveloperMenuViewControllerTests.swift
+++ b/Tests/UnitTests/Screens/DeveloperMenuViewControllerTests.swift
@@ -1,11 +1,16 @@
 import MockNetworking
 @testable import Networking
 @testable import OneLogin
+import SecureStore
 import XCTest
 
 final class DeveloperMenuViewControllerTests: XCTestCase {
-    var networkClient: NetworkClient!
     var devMenuViewModel: DeveloperMenuViewModel!
+    var mockAuthenicatedSecureStore: SecureStorable!
+    var mockOpenSecureStore: SecureStorable!
+    var mockDefaultsStore: MockDefaultsStore!
+    var mockUserStore: MockUserStore!
+    var networkClient: NetworkClient!
     var sut: DeveloperMenuViewController!
     
     var requestFinished = false
@@ -16,10 +21,19 @@ final class DeveloperMenuViewControllerTests: XCTestCase {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [MockURLProtocol.self]
         
+        devMenuViewModel = DeveloperMenuViewModel {
+            
+        }
+        mockAuthenicatedSecureStore = MockSecureStoreService()
+        mockOpenSecureStore = MockSecureStoreService()
+        mockDefaultsStore = MockDefaultsStore()
+        mockUserStore = MockUserStore(authenticatedStore: mockAuthenicatedSecureStore,
+                                      openStore: mockOpenSecureStore,
+                                      defaultsStore: mockDefaultsStore)
         networkClient = NetworkClient(configuration: configuration,
                                       authenticationProvider: MockAuthenticationProvider())
-        devMenuViewModel = DeveloperMenuViewModel()
         sut = DeveloperMenuViewController(viewModel: devMenuViewModel,
+                                          userStore: mockUserStore,
                                           networkClient: networkClient)
     }
     

--- a/Tests/UnitTests/Screens/DeveloperMenuViewControllerTests.swift
+++ b/Tests/UnitTests/Screens/DeveloperMenuViewControllerTests.swift
@@ -4,6 +4,7 @@ import MockNetworking
 import SecureStore
 import XCTest
 
+@MainActor
 final class DeveloperMenuViewControllerTests: XCTestCase {
     var window: UIWindow!
     var mockAnalyticsService: MockAnalyticsService!
@@ -18,7 +19,6 @@ final class DeveloperMenuViewControllerTests: XCTestCase {
     
     var requestFinished = false
     
-    @MainActor
     override func setUp() {
         super.setUp()
         
@@ -70,7 +70,6 @@ enum MockNetworkClientError: Error {
     case genericError
 }
 
-@MainActor
 extension DeveloperMenuViewControllerTests {
     func test_labelContents_STSEnabled() throws {
         XCTAssertEqual(try sut.happyPathButton.title(for: .normal), "Hello World Happy")

--- a/Tests/UnitTests/Screens/Profile/SignoutErrorViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Profile/SignoutErrorViewModelTests.swift
@@ -7,7 +7,7 @@ import Foundation
 
 final class SignoutErrorViewModelTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
-    var sut: SignoutErrorViewModel!
+    var sut: SignOutErrorViewModel!
     
     var didCallButtonAction = false
     
@@ -15,7 +15,7 @@ final class SignoutErrorViewModelTests: XCTestCase {
         super.setUp()
         
         mockAnalyticsService = MockAnalyticsService()
-        sut = SignoutErrorViewModel(errorDescription: "Error",
+        sut = SignOutErrorViewModel(errorDescription: "Error",
                                     analyticsService: mockAnalyticsService) {
             self.didCallButtonAction = true
         }

--- a/Tests/UnitTests/Tabs/HomeCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/HomeCoordinatorTests.swift
@@ -9,7 +9,6 @@ final class HomeCoordinatorTests: XCTestCase {
     var mockOpenSecureStore: MockSecureStoreService!
     var mockDefaultsStore: MockDefaultsStore!
     var mockUserStore: MockUserStore!
-    var mockTokenHolder: TokenHolder!
     var sut: HomeCoordinator!
     
     override func setUp() {
@@ -23,10 +22,9 @@ final class HomeCoordinatorTests: XCTestCase {
         mockUserStore = MockUserStore(authenticatedStore: mockSecureStoreService,
                                       openStore: mockOpenSecureStore,
                                       defaultsStore: mockDefaultsStore)
-        mockTokenHolder = TokenHolder()
-        sut = HomeCoordinator(analyticsService: mockAnalyticsService,
-                              userStore: mockUserStore,
-                              tokenHolder: mockTokenHolder)
+        sut = HomeCoordinator(window: window,
+                              analyticsService: mockAnalyticsService,
+                              userStore: mockUserStore)
     }
     
     override func tearDown() {
@@ -36,7 +34,6 @@ final class HomeCoordinatorTests: XCTestCase {
         mockOpenSecureStore = nil
         mockDefaultsStore = nil
         mockUserStore = nil
-        mockTokenHolder = nil
         sut = nil
         
         super.tearDown()
@@ -63,23 +60,21 @@ final class HomeCoordinatorTests: XCTestCase {
     
     func test_networkClientInitialized() throws {
         sut.start()
-        XCTAssertNil(sut.networkClient)
         // GIVEN we have a non-nil tokenHolder and access token
-        mockTokenHolder.idTokenPayload = MockTokenVerifier.mockPayload
+        TokenHolder.shared.idTokenPayload = MockTokenVerifier.mockPayload
         sut.updateToken()
         try mockUserStore.saveItem("accessToken",
                                    itemName: .accessToken,
                                    storage: .authenticated)
         // THEN the networkClieint will be initialized when the developer menu is shown
         sut.showDeveloperMenu()
-        XCTAssertNotNil(sut.networkClient)
     }
     
     func test_updateToken() throws {
         sut.start()
         let vc = try XCTUnwrap(sut.baseVc)
         XCTAssertEqual(try vc.emailLabel.text, "")
-        mockTokenHolder.idTokenPayload = MockTokenVerifier.mockPayload
+        TokenHolder.shared.idTokenPayload = MockTokenVerifier.mockPayload
         sut.updateToken()
         XCTAssertEqual(try vc.emailLabel.text, "You’re signed in as\nmock@email.com")
     }

--- a/Tests/UnitTests/Tabs/HomeCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/HomeCoordinatorTests.swift
@@ -50,12 +50,12 @@ final class HomeCoordinatorTests: XCTestCase {
     }
     
     func test_showDeveloperMenu() throws {
-        sut.start()
         window.rootViewController = sut.root
         window.makeKeyAndVisible()
+        sut.start()
         sut.showDeveloperMenu()
         let presentedViewController = try XCTUnwrap(sut.root.presentedViewController as? UINavigationController)
-        XCTAssertTrue( presentedViewController.topViewController is DeveloperMenuViewController)
+        XCTAssertTrue(presentedViewController.topViewController is DeveloperMenuViewController)
     }
     
     func test_networkClientInitialized() throws {

--- a/Tests/UnitTests/Tabs/HomeCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/HomeCoordinatorTests.swift
@@ -78,4 +78,13 @@ final class HomeCoordinatorTests: XCTestCase {
         sut.updateToken()
         XCTAssertEqual(try vc.emailLabel.text, "You’re signed in as\nmock@email.com")
     }
+    
+    func test_performChildCleanup_fromReauthCoordinator() {
+        // WHEN the performChildCleanup method is called
+        // This test is purely to get test coverage atm as we will not be able to test for effects on unmocked subcoordinators
+        let reauthCoordinator = ReauthCoordinator(window: window,
+                                                  analyticsService: mockAnalyticsService,
+                                                  userStore: mockUserStore)
+        sut.performChildCleanup(child: reauthCoordinator)
+    }
 }

--- a/Tests/UnitTests/Tabs/ProfileCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/ProfileCoordinatorTests.swift
@@ -11,7 +11,6 @@ final class ProfileCoordinatorTests: XCTestCase {
     var mockOpenSecureStoreService: MockSecureStoreService!
     var mockDefaultStore: MockDefaultsStore!
     var mockUserStore: UserStorage!
-    var tokenHolder: TokenHolder!
     var urlOpener: URLOpener!
     var sut: ProfileCoordinator!
     
@@ -26,11 +25,9 @@ final class ProfileCoordinatorTests: XCTestCase {
         mockUserStore = UserStorage(authenticatedStore: mockSecureStoreService,
                                     openStore: mockOpenSecureStoreService,
                                     defaultsStore: mockDefaultStore)
-        tokenHolder = TokenHolder()
         urlOpener = MockURLOpener()
         sut = ProfileCoordinator(analyticsService: mockAnalyticsService,
                                  userStore: mockUserStore,
-                                 tokenHolder: tokenHolder,
                                  urlOpener: urlOpener)
         window.rootViewController = sut.root
         window.makeKeyAndVisible()
@@ -43,7 +40,6 @@ final class ProfileCoordinatorTests: XCTestCase {
         mockOpenSecureStoreService = nil
         mockDefaultStore = nil
         mockUserStore = nil
-        tokenHolder = nil
         urlOpener = nil
         sut = nil
         
@@ -64,7 +60,7 @@ final class ProfileCoordinatorTests: XCTestCase {
         sut.start()
         let vc = try XCTUnwrap(sut.baseVc)
         XCTAssertEqual(try vc.emailLabel.text, "")
-        tokenHolder.idTokenPayload = MockTokenVerifier.mockPayload
+        TokenHolder.shared.idTokenPayload = MockTokenVerifier.mockPayload
         sut.updateToken()
         XCTAssertEqual(try vc.emailLabel.text, "You’re signed in as\nmock@email.com")
     }

--- a/Tests/UnitTests/Tabs/WalletCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/WalletCoordinatorTests.swift
@@ -6,7 +6,6 @@ final class WalletCoordinatorTests: XCTestCase {
     var window: UIWindow!
     var mockAnalyticsService: MockAnalyticsService!
     var mockSecureStoreService: MockSecureStoreService!
-    var mockTokenHolder: TokenHolder!
 
     var sut: WalletCoordinator!
     
@@ -16,18 +15,15 @@ final class WalletCoordinatorTests: XCTestCase {
         window = UIWindow()
         mockAnalyticsService = MockAnalyticsService()
         mockSecureStoreService = MockSecureStoreService()
-        mockTokenHolder = TokenHolder()
         sut = WalletCoordinator(window: window,
                                 analyticsService: mockAnalyticsService,
-                                secureStoreService: mockSecureStoreService,
-                                tokenHolder: mockTokenHolder)
+                                secureStoreService: mockSecureStoreService)
     }
     
     override func tearDown() {
         window = nil
         mockAnalyticsService = nil
         mockSecureStoreService = nil
-        mockTokenHolder = nil
         sut = nil
         
         super.tearDown()

--- a/Tests/UnitTests/Utilities/ErrorPresenterTests.swift
+++ b/Tests/UnitTests/Utilities/ErrorPresenterTests.swift
@@ -16,6 +16,7 @@ final class ErrorPresenterTests: XCTestCase {
     override func tearDown() {
         mockAnalyticsService = nil
         sut = nil
+        didCallAction = false
         
         super.tearDown()
     }
@@ -51,7 +52,7 @@ extension ErrorPresenterTests {
         XCTAssertTrue(didCallAction)
     }
     
-    func test_signoutError_callsAction() throws {
+    func test_signOutError_callsAction() throws {
         let errorView = sut.createSignOutError(errorDescription: "error description",
                                                analyticsService: mockAnalyticsService) {
             self.didCallAction = true
@@ -59,6 +60,14 @@ extension ErrorPresenterTests {
         let exitButton: UIButton = try XCTUnwrap(errorView.view[child: "error-primary-button"])
         exitButton.sendActions(for: .touchUpInside)
         XCTAssertTrue(didCallAction)
-
+    }
+    
+    func test_signOutWarning_callsAction() throws {
+        let errorView = sut.createSignOutWarning(analyticsService: mockAnalyticsService) {
+            self.didCallAction = true
+        }
+        let exitButton: UIButton = try XCTUnwrap(errorView.view[child: "error-primary-button"])
+        exitButton.sendActions(for: .touchUpInside)
+        XCTAssertTrue(didCallAction)
     }
 }

--- a/Tests/UnitTests/Utilities/ErrorPresenterTests.swift
+++ b/Tests/UnitTests/Utilities/ErrorPresenterTests.swift
@@ -52,7 +52,7 @@ extension ErrorPresenterTests {
     }
     
     func test_signoutError_callsAction() throws {
-        let errorView = sut.createSignoutError(errorDescription: "error description",
+        let errorView = sut.createSignOutError(errorDescription: "error description",
                                                analyticsService: mockAnalyticsService) {
             self.didCallAction = true
         }


### PR DESCRIPTION
# DCMAW-9511: iOS | User sees 'You have been signed out' re-auth page when user's access token expires (whilst in-app)

When a user’s access token has expired and they call the hello-world API, they will need to re-authenticate using the One Login WebView in order to get a new access token. Once the user has successfully re-authenticated, they will be returned to their current place in-app.
Additionally, when a user returns to the app with an expired access token, the same behaviour should occur but infront of the intro screen.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
