### PR TITLE
feat: send persistent session ID in `/authorize` request

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -2658,8 +2658,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/govuk-one-login/mobile-ios-authentication.git";
 			requirement = {
-				branch = "feature/dcmaw-9389-persistent-session-id-in-authorize-request";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
 			};
 		};
 		C8A13CA72AFBD0CC00FCBD36 /* XCRemoteSwiftPackageReference "mobile-ios-logging" */ = {

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -2658,8 +2658,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/govuk-one-login/mobile-ios-authentication.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				branch = "feature/dcmaw-9389-persistent-session-id-in-authorize-request";
+				kind = branch;
 			};
 		};
 		C8A13CA72AFBD0CC00FCBD36 /* XCRemoteSwiftPackageReference "mobile-ios-logging" */ = {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-authentication.git",
       "state" : {
-        "revision" : "d7e4d450744f53b5463d3d43662a5b336e4f1575",
-        "version" : "1.1.6"
+        "branch" : "feature/dcmaw-9389-persistent-session-id-in-authorize-request",
+        "revision" : "0a7e616a4007d34f96f72cadf356579864a4876e"
       }
     },
     {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-authentication.git",
       "state" : {
-        "branch" : "feature/dcmaw-9389-persistent-session-id-in-authorize-request",
-        "revision" : "0a7e616a4007d34f96f72cadf356579864a4876e"
+        "revision" : "ecf0a5614ac205c53702a691971fdfd40dcc9caf",
+        "version" : "1.3.0"
       }
     },
     {

--- a/Sources/Extensions/CustomTypes/LoginSessionConfiguration+OneLogin.swift
+++ b/Sources/Extensions/CustomTypes/LoginSessionConfiguration+OneLogin.swift
@@ -2,7 +2,7 @@ import Authentication
 import Foundation
 
 extension LoginSessionConfiguration {
-    static func oneLogin(persistentSessionId: String?) -> Self {
+    static func oneLogin(persistentSessionId: String? = nil) -> Self {
         let env = AppEnvironment.self
         return .init(authorizationEndpoint: env.callingSTSEnabled ? env.stsAuthorize : env.oneLoginAuthorize,
                      tokenEndpoint: env.callingSTSEnabled ? env.stsToken : env.oneLoginToken,

--- a/Sources/Extensions/CustomTypes/LoginSessionConfiguration+OneLogin.swift
+++ b/Sources/Extensions/CustomTypes/LoginSessionConfiguration+OneLogin.swift
@@ -2,13 +2,14 @@ import Authentication
 import Foundation
 
 extension LoginSessionConfiguration {
-    static var oneLogin: LoginSessionConfiguration {
+    static func oneLogin(persistentSessionId: String?) -> Self {
         let env = AppEnvironment.self
         return .init(authorizationEndpoint: env.callingSTSEnabled ? env.stsAuthorize : env.oneLoginAuthorize,
                      tokenEndpoint: env.callingSTSEnabled ? env.stsToken : env.oneLoginToken,
                      scopes: [.openid],
                      clientID: env.callingSTSEnabled ? env.stsClientID : env.oneLoginClientID,
                      redirectURI: env.oneLoginRedirect,
-                     locale: env.isLocaleWelsh ? .cy : .en)
+                     locale: env.isLocaleWelsh ? .cy : .en,
+                     persistentSessionId: persistentSessionId)
     }
 }

--- a/Sources/Login/AuthenticationCoordinator.swift
+++ b/Sources/Login/AuthenticationCoordinator.swift
@@ -31,7 +31,7 @@ final class AuthenticationCoordinator: NSObject,
     func start() {
         Task(priority: .userInitiated) {
             do {
-                TokenHolder.shared.tokenResponse = try await session.performLoginFlow(configuration: LoginSessionConfiguration.oneLogin)
+                TokenHolder.shared.tokenResponse = try await session.performLoginFlow(configuration: userStore.constructLoginSessionConfiguration())
                 // TODO: DCMAW-8570 This should be considered non-optional once tokenID work is completed on BE
                 if AppEnvironment.callingSTSEnabled,
                    let idToken = TokenHolder.shared.tokenResponse?.idToken {

--- a/Sources/Utilities/Storage/UserStorable.swift
+++ b/Sources/Utilities/Storage/UserStorable.swift
@@ -56,4 +56,12 @@ extension UserStorable {
             return try openStore.readItem(itemName: itemName)
         }
     }
+    
+    func constructLoginSessionConfiguration() -> LoginSessionConfiguration {
+        let persistentSessionID = try? readItem(itemName: .persistentSessionID, storage: .open)
+        if persistentSessionID == nil {
+            debugPrint("No persistentSessionID found in SecureStore")
+        }
+        return LoginSessionConfiguration.oneLogin(persistentSessionId: persistentSessionID)
+    }
 }

--- a/Tests/UnitTests/Extensions/CustomTypes/LoginSessionConfigurationTests.swift
+++ b/Tests/UnitTests/Extensions/CustomTypes/LoginSessionConfigurationTests.swift
@@ -4,14 +4,16 @@ import XCTest
 
 final class LoginSessionConfigurationTests: XCTestCase {
     func test_oneLoginSessionConfig() throws {
-        XCTAssertEqual(LoginSessionConfiguration.oneLogin.authorizationEndpoint, AppEnvironment.oneLoginAuthorize)
-        XCTAssertEqual(LoginSessionConfiguration.oneLogin.tokenEndpoint, AppEnvironment.oneLoginToken)
-        XCTAssertEqual(LoginSessionConfiguration.oneLogin.responseType, LoginSessionConfiguration.ResponseType.code)
-        XCTAssertEqual(LoginSessionConfiguration.oneLogin.scopes, [.openid])
-        XCTAssertEqual(LoginSessionConfiguration.oneLogin.clientID, AppEnvironment.oneLoginClientID)
-        XCTAssertEqual(LoginSessionConfiguration.oneLogin.prefersEphemeralWebSession, true)
-        XCTAssertEqual(LoginSessionConfiguration.oneLogin.redirectURI, AppEnvironment.oneLoginRedirect)
-        XCTAssertEqual(LoginSessionConfiguration.oneLogin.vectorsOfTrust, ["Cl.Cm.P0"])
-        XCTAssertEqual(LoginSessionConfiguration.oneLogin.locale, .en)
+        XCTAssertEqual(LoginSessionConfiguration.oneLogin().authorizationEndpoint, AppEnvironment.oneLoginAuthorize)
+        XCTAssertEqual(LoginSessionConfiguration.oneLogin().tokenEndpoint, AppEnvironment.oneLoginToken)
+        XCTAssertEqual(LoginSessionConfiguration.oneLogin().responseType, LoginSessionConfiguration.ResponseType.code)
+        XCTAssertEqual(LoginSessionConfiguration.oneLogin().scopes, [.openid])
+        XCTAssertEqual(LoginSessionConfiguration.oneLogin().clientID, AppEnvironment.oneLoginClientID)
+        XCTAssertEqual(LoginSessionConfiguration.oneLogin().prefersEphemeralWebSession, true)
+        XCTAssertEqual(LoginSessionConfiguration.oneLogin().redirectURI, AppEnvironment.oneLoginRedirect)
+        XCTAssertEqual(LoginSessionConfiguration.oneLogin().vectorsOfTrust, ["Cl.Cm.P0"])
+        XCTAssertEqual(LoginSessionConfiguration.oneLogin().locale, .en)
+        XCTAssertEqual(LoginSessionConfiguration.oneLogin(persistentSessionId: "123456789").persistentSessionId, "123456789")
+
     }
 }

--- a/Tests/UnitTests/Login/AuthenticationCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/AuthenticationCoordinatorTests.swift
@@ -69,9 +69,9 @@ extension AuthenticationCoordinatorTests {
         // and the AuthenticationCoordinator calls performLoginFlow on the session
         // and there is no error
         sut.start()
+        waitForTruth(self.mockLoginSession.didCallPerformLoginFlow, timeout: 20)
         // THEN the session configuration should have the persistent session ID
         XCTAssertEqual(mockLoginSession.sessionConfiguration?.persistentSessionId, "123456789")
-        waitForTruth(self.mockLoginSession.didCallPerformLoginFlow, timeout: 20)
         // THEN the tokens are returned
         XCTAssertEqual(TokenHolder.shared.tokenResponse?.accessToken, "accessTokenResponse")
         XCTAssertEqual(TokenHolder.shared.tokenResponse?.refreshToken, "refreshTokenResponse")

--- a/Tests/UnitTests/Screens/DeveloperMenuViewControllerTests.swift
+++ b/Tests/UnitTests/Screens/DeveloperMenuViewControllerTests.swift
@@ -118,6 +118,8 @@ extension DeveloperMenuViewControllerTests {
     }
     
     func test_happyPathButton_invalidAccessTokenActionCalled() throws {
+        mockDefaultsStore.removeObject(forKey: .accessTokenExpiry)
+        TokenHolder.shared.tokenResponse = nil
         try sut.happyPathButton.sendActions(for: .touchUpInside)
         XCTAssertTrue(MainCoordinator.isReauthing)
         XCTAssertTrue(homeCoordinator.childCoordinators.last is ReauthCoordinator)
@@ -139,6 +141,8 @@ extension DeveloperMenuViewControllerTests {
     }
     
     func test_unhappyPathButton_invalidAccessTokenActionCalled() throws {
+        mockDefaultsStore.removeObject(forKey: .accessTokenExpiry)
+        TokenHolder.shared.tokenResponse = nil
         try sut.errorPathButton.sendActions(for: .touchUpInside)
         XCTAssertTrue(MainCoordinator.isReauthing)
         XCTAssertTrue(homeCoordinator.childCoordinators.last is ReauthCoordinator)
@@ -160,6 +164,8 @@ extension DeveloperMenuViewControllerTests {
     }
     
     func test_unsuccessfulPathButton_invalidAccessTokenActionCalled() throws {
+        mockDefaultsStore.removeObject(forKey: .accessTokenExpiry)
+        TokenHolder.shared.tokenResponse = nil
         try sut.unauthorizedPathButton.sendActions(for: .touchUpInside)
         XCTAssertTrue(MainCoordinator.isReauthing)
         XCTAssertTrue(homeCoordinator.childCoordinators.last is ReauthCoordinator)


### PR DESCRIPTION
# DCMAW-9389: iOS | Retrieve & extract persistent session ID and send in STS /authorize request

Send the persistentSessionId as a `govuk_signin_session_id` query parameter in the STS /authorize request if it exists in open secure store, if not, don't include it.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
