### PR TITLE
fix: non-local auth user reauth flow

### DIFF
--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -86,12 +86,11 @@ final class MainCoordinator: NSObject,
     }
     
     private func fullLogin(loginError: Error? = nil) {
+        TokenHolder.shared.clearTokenHolder()
+        userStore.clearTokens()
         if loginError as? TokenError != .expired {
             userStore.refreshStorage(accessControlLevel: nil)
-        } else {
-            userStore.clearTokens()
         }
-        TokenHolder.shared.clearTokenHolder()
         showLogin(loginError)
         windowManager.hideUnlockWindow()
     }

--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -86,10 +86,10 @@ final class MainCoordinator: NSObject,
     }
     
     private func fullLogin(loginError: Error? = nil) {
-        if let error = loginError as? TokenError, error == .expired {
-            userStore.clearTokens()
-        } else {
+        if loginError as? TokenError != .expired {
             userStore.refreshStorage(accessControlLevel: nil)
+        } else {
+            userStore.clearTokens()
         }
         TokenHolder.shared.clearTokenHolder()
         showLogin(loginError)

--- a/Sources/Application/SceneDelegate.swift
+++ b/Sources/Application/SceneDelegate.swift
@@ -57,8 +57,8 @@ class SceneDelegate: UIResponder,
     }
     
     func sceneDidEnterBackground(_ scene: UIScene) {
-        if userStore.authenticatedStore.checkItemExists(itemName: .accessToken) &&
-            userStore.authenticatedStore.checkItemExists(itemName: .idToken) {
+        if userStore.authenticatedStore.checkItemExists(itemName: .accessToken),
+           userStore.authenticatedStore.checkItemExists(itemName: .idToken) {
             shouldCallSceneWillEnterForeground = true
             displayUnlockScreen()
         } else {

--- a/Sources/Application/SceneDelegate.swift
+++ b/Sources/Application/SceneDelegate.swift
@@ -24,7 +24,7 @@ class SceneDelegate: UIResponder,
                            openStore: openStore,
                            defaultsStore: UserDefaults.standard)
     }()
-
+    
     func scene(_ scene: UIScene,
                willConnectTo session: UISceneSession,
                options connectionOptions: UIScene.ConnectionOptions) {
@@ -57,14 +57,15 @@ class SceneDelegate: UIResponder,
     }
     
     func sceneDidEnterBackground(_ scene: UIScene) {
-       if userStore.previouslyAuthenticatedUser != nil {
-           shouldCallSceneWillEnterForeground = true
-           displayUnlockScreen()
-       } else {
-           shouldCallSceneWillEnterForeground = false
-       }
-   }
-
+        if userStore.authenticatedStore.checkItemExists(itemName: .accessToken) &&
+            userStore.authenticatedStore.checkItemExists(itemName: .idToken) {
+            shouldCallSceneWillEnterForeground = true
+            displayUnlockScreen()
+        } else {
+            shouldCallSceneWillEnterForeground = false
+        }
+    }
+    
     func sceneWillEnterForeground(_ scene: UIScene) {
         if shouldCallSceneWillEnterForeground {
             coordinator?.evaluateRevisit()

--- a/Sources/Errors/GenericErrorViewModel.swift
+++ b/Sources/Errors/GenericErrorViewModel.swift
@@ -36,7 +36,5 @@ struct GenericErrorViewModel: GDSErrorViewModel, BaseViewModel {
         analyticsService.trackScreen(screen)
     }
     
-    func didDismiss() {
-        // Here for BaseViewModel compliance
-    }
+    func didDismiss() { /* BaseViewModel compliance */ }
 }

--- a/Sources/Errors/NetworkConnectionErrorViewModel.swift
+++ b/Sources/Errors/NetworkConnectionErrorViewModel.swift
@@ -29,7 +29,5 @@ struct NetworkConnectionErrorViewModel: GDSErrorViewModel, BaseViewModel {
         analyticsService.trackScreen(screen)
     }
     
-    func didDismiss() {
-        // Here for BaseViewModel compliance
-    }
+    func didDismiss() { /* BaseViewModel compliance */ }
 }

--- a/Sources/Errors/UnableToLoginErrorViewModel.swift
+++ b/Sources/Errors/UnableToLoginErrorViewModel.swift
@@ -31,7 +31,5 @@ struct UnableToLoginErrorViewModel: GDSErrorViewModel, BaseViewModel {
         analyticsService.trackScreen(screen)
     }
     
-    func didDismiss() {
-        // Here for BaseViewModel compliance
-    }
+    func didDismiss() { /* BaseViewModel compliance */ }
 }

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -139,7 +139,8 @@ extension LoginCoordinator: ParentCoordinator {
         case let child as AuthenticationCoordinator where child.authError != nil:
             introViewController?.enableIntroButton()
         case let child as AuthenticationCoordinator where child.authError == nil:
-            if loginError as? TokenError == .expired && userStore.defaultsStore.value(forKey: .returningUser) != nil {
+            if loginError as? TokenError == .expired,
+               userStore.defaultsStore.value(forKey: .returningUser) != nil {
                 userStore.storeTokenInfo()
                 root.dismiss(animated: true)
                 finish()

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -54,7 +54,7 @@ final class LoginCoordinator: NSObject,
     }
     
     private func showLoginErrorIfNecessary() {
-        if let error = loginError as? TokenError, error == .expired {
+        if loginError as? TokenError == .expired {
             let signOutWarningScreen = ErrorPresenter
                 .createSignOutWarning(analyticsService: analyticsCenter.analyticsService) { [unowned self] in
                     authenticate { [unowned self] in
@@ -139,7 +139,7 @@ extension LoginCoordinator: ParentCoordinator {
         case let child as AuthenticationCoordinator where child.authError != nil:
             introViewController?.enableIntroButton()
         case let child as AuthenticationCoordinator where child.authError == nil:
-            if let error = loginError as? TokenError, error == .expired {
+            if loginError as? TokenError == .expired && userStore.defaultsStore.value(forKey: .returningUser) != nil {
                 userStore.storeTokenInfo()
                 root.dismiss(animated: true)
                 finish()

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -68,6 +68,7 @@ final class LoginCoordinatorTests: XCTestCase {
                                userStore: mockUserStore,
                                networkMonitor: mockNetworkMonitor,
                                loginError: TokenError.expired)
+        mockDefaultStore.set(true, forKey: .returningUser)
     }
     
     func errorLogin() {
@@ -205,6 +206,7 @@ extension LoginCoordinatorTests {
     }
     
     func test_didRegainFocus_fromAuthenticationCoordinator_expiredToken() throws {
+        // GIVEN I'm a reauth user with tokens received in the authentication flow
         reauthLogin()
         let tokenResponse = try MockTokenResponse().getJSONData()
         TokenHolder.shared.tokenResponse = tokenResponse
@@ -217,7 +219,7 @@ extension LoginCoordinatorTests {
                                                         reauth: false)
         // GIVEN the LoginCoordinator regained focus from the AuthenticationCoordinator
         sut.didRegainFocus(fromChild: authCoordinator)
-        // THEN the LoginCoordinator should still have IntroViewController as it's top view controller
+        // THEN the LoginCoordinator should stored those tokens in secure store
         XCTAssertEqual(try mockSecureStore.readItem(itemName: .accessToken), tokenResponse.accessToken)
         XCTAssertEqual(try mockSecureStore.readItem(itemName: .idToken), tokenResponse.idToken)
         XCTAssertEqual(try mockOpenSecureStore.readItem(itemName: .persistentSessionID), TokenHolder.shared.idTokenPayload?.persistentId)


### PR DESCRIPTION
# DCMAW-9583: iOS | Clear credentials and preferences when a re-auth user does not have a persistent session ID

Missing implementation detail from #167 for a non-local auth user.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
