### PR TITLE
fix: sign out warning screen

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -730,6 +730,7 @@
 		C8520C282AE2C1AD006790C1 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				C8486FE42C60D80A00DE514C /* DummyLocalAuthService.swift */,
 				1E717D752B72959A00CCAF3E /* LAContexting.swift */,
 				D01A72782BE37B86004333F8 /* ViewIdentifiable.swift */,
 				C865E6512C21DC24001FA62D /* UniversalLinkQualifier.swift */,
@@ -738,7 +739,6 @@
 				D0BE243F2BEBAEB600759529 /* JWT */,
 				C8BADD322B88CBB200385FE7 /* Network */,
 				C8BADD332B88CBBA00385FE7 /* Storage */,
-				C8486FE42C60D80A00DE514C /* DummyLocalAuthService.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		C83E18122C05DDDB00B451D6 /* LoginLoadingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83E18112C05DDDB00B451D6 /* LoginLoadingViewModelTests.swift */; };
 		C8454A8F2B99D1BC000F9ED0 /* LoginCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8454A8E2B99D1BC000F9ED0 /* LoginCoordinatorTests.swift */; };
 		C8486FE52C60D80A00DE514C /* DummyLocalAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8486FE42C60D80A00DE514C /* DummyLocalAuthService.swift */; };
+		C8486FE72C60E66400DE514C /* DummyLocalAuthServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8486FE62C60E66400DE514C /* DummyLocalAuthServiceTests.swift */; };
 		C8514F682C09E133008E1433 /* ProfileTabAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8514F672C09E133008E1433 /* ProfileTabAnalytics.swift */; };
 		C8514F6D2C09EC18008E1433 /* HomeTabAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8514F6C2C09EC18008E1433 /* HomeTabAnalytics.swift */; };
 		C851FFA22BADA4B200A7B73D /* SceneLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C851FFA12BADA4B200A7B73D /* SceneLifecycle.swift */; };
@@ -280,6 +281,7 @@
 		C83E18112C05DDDB00B451D6 /* LoginLoadingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginLoadingViewModelTests.swift; sourceTree = "<group>"; };
 		C8454A8E2B99D1BC000F9ED0 /* LoginCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginCoordinatorTests.swift; sourceTree = "<group>"; };
 		C8486FE42C60D80A00DE514C /* DummyLocalAuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyLocalAuthService.swift; sourceTree = "<group>"; };
+		C8486FE62C60E66400DE514C /* DummyLocalAuthServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyLocalAuthServiceTests.swift; sourceTree = "<group>"; };
 		C8514F672C09E133008E1433 /* ProfileTabAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTabAnalytics.swift; sourceTree = "<group>"; };
 		C8514F6C2C09EC18008E1433 /* HomeTabAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTabAnalytics.swift; sourceTree = "<group>"; };
 		C851FFA12BADA4B200A7B73D /* SceneLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneLifecycle.swift; sourceTree = "<group>"; };
@@ -758,6 +760,7 @@
 		C85966462AEC31AE006DF61D /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				C8486FE62C60E66400DE514C /* DummyLocalAuthServiceTests.swift */,
 				C87913C02B275F4900545B33 /* ErrorPresenterTests.swift */,
 				C85966472AEC31AE006DF61D /* OnboardingViewControllerFactoryTests.swift */,
 				D0BE24442BEBCB5000759529 /* JWTVerifierTests.swift */,
@@ -1640,6 +1643,7 @@
 				C8BADD272B87AEEA00385FE7 /* MockSecureStoreService.swift in Sources */,
 				41D469752B9758A5008705CD /* UnlockScreenViewModelTests.swift in Sources */,
 				C81ECB212B71769F00AFC3A6 /* EnrolmentCoordinatorTests.swift in Sources */,
+				C8486FE72C60E66400DE514C /* DummyLocalAuthServiceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		C82F950F2B9F0CCA00A90A6A /* UnlockScreenViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82F950E2B9F0CCA00A90A6A /* UnlockScreenViewControllerTests.swift */; };
 		C83E18122C05DDDB00B451D6 /* LoginLoadingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83E18112C05DDDB00B451D6 /* LoginLoadingViewModelTests.swift */; };
 		C8454A8F2B99D1BC000F9ED0 /* LoginCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8454A8E2B99D1BC000F9ED0 /* LoginCoordinatorTests.swift */; };
+		C8486FE52C60D80A00DE514C /* DummyLocalAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8486FE42C60D80A00DE514C /* DummyLocalAuthService.swift */; };
 		C8514F682C09E133008E1433 /* ProfileTabAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8514F672C09E133008E1433 /* ProfileTabAnalytics.swift */; };
 		C8514F6D2C09EC18008E1433 /* HomeTabAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8514F6C2C09EC18008E1433 /* HomeTabAnalytics.swift */; };
 		C851FFA22BADA4B200A7B73D /* SceneLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C851FFA12BADA4B200A7B73D /* SceneLifecycle.swift */; };
@@ -278,6 +279,7 @@
 		C82F950E2B9F0CCA00A90A6A /* UnlockScreenViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnlockScreenViewControllerTests.swift; sourceTree = "<group>"; };
 		C83E18112C05DDDB00B451D6 /* LoginLoadingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginLoadingViewModelTests.swift; sourceTree = "<group>"; };
 		C8454A8E2B99D1BC000F9ED0 /* LoginCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginCoordinatorTests.swift; sourceTree = "<group>"; };
+		C8486FE42C60D80A00DE514C /* DummyLocalAuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyLocalAuthService.swift; sourceTree = "<group>"; };
 		C8514F672C09E133008E1433 /* ProfileTabAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTabAnalytics.swift; sourceTree = "<group>"; };
 		C8514F6C2C09EC18008E1433 /* HomeTabAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTabAnalytics.swift; sourceTree = "<group>"; };
 		C851FFA12BADA4B200A7B73D /* SceneLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneLifecycle.swift; sourceTree = "<group>"; };
@@ -736,6 +738,7 @@
 				D0BE243F2BEBAEB600759529 /* JWT */,
 				C8BADD322B88CBB200385FE7 /* Network */,
 				C8BADD332B88CBBA00385FE7 /* Storage */,
+				C8486FE42C60D80A00DE514C /* DummyLocalAuthService.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -1541,6 +1544,7 @@
 				C8ECA1322BB73E2E00722218 /* WindowManager.swift in Sources */,
 				D08B0B652BDA478000769CEA /* SignInView.swift in Sources */,
 				41C5E32F2B45A36E00212A12 /* NetworkConnectionErrorViewModel.swift in Sources */,
+				C8486FE52C60D80A00DE514C /* DummyLocalAuthService.swift in Sources */,
 				D0825A952C12F5B800E940F7 /* SignOutErrorViewModel.swift in Sources */,
 				D08B0B7D2BDBF86100769CEA /* TabbedViewSectionHeader.swift in Sources */,
 				D08B0B872BDFE2DA00769CEA /* TabbedViewSectionFooter.swift in Sources */,
@@ -2638,8 +2642,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/govuk-one-login/mobile-ios-common.git";
 			requirement = {
-				branch = "feature/dcmaw-9589-error-page-icon";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
 			};
 		};
 		C8A13CA22AFBD07E00FCBD36 /* XCRemoteSwiftPackageReference "mobile-ios-authentication" */ = {
@@ -2679,7 +2683,7 @@
 			repositoryURL = "https://github.com/govuk-one-login/mobile-wallet-ios.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				minimumVersion = 3.0.0;
 			};
 		};
 		D0BE243C2BEB7E5E00759529 /* XCRemoteSwiftPackageReference "jwt-kit" */ = {

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -2638,8 +2638,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/govuk-one-login/mobile-ios-common.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				branch = "feature/dcmaw-9589-error-page-icon";
+				kind = branch;
 			};
 		};
 		C8A13CA22AFBD07E00FCBD36 /* XCRemoteSwiftPackageReference "mobile-ios-authentication" */ = {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-common.git",
       "state" : {
-        "revision" : "f2fdfba817a33f20f2dbeb0e5b5672071238a0aa",
-        "version" : "1.12.0"
+        "branch" : "feature/dcmaw-9589-error-page-icon",
+        "revision" : "2cb1619c5805d88e9cdcef7f312e32a019f82a77"
       }
     },
     {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-common.git",
       "state" : {
-        "branch" : "feature/dcmaw-9589-error-page-icon",
-        "revision" : "9ad256e23641c8e57db9347c5d91950336a8b0c0"
+        "revision" : "e21d187d2b1a41204b1a4488c8caae08fbd4c62e",
+        "version" : "2.2.0"
       }
     },
     {
@@ -176,8 +176,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-wallet-ios.git",
       "state" : {
-        "revision" : "5bab1dfd6602439acca11f753e4d8c0423c2e3cb",
-        "version" : "1.0.0"
+        "revision" : "210dd80c2b882144fe0888225a8d3b919c1f330f",
+        "version" : "3.4.3"
       }
     },
     {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -132,7 +132,7 @@
       "location" : "https://github.com/govuk-one-login/mobile-ios-common.git",
       "state" : {
         "branch" : "feature/dcmaw-9589-error-page-icon",
-        "revision" : "2cb1619c5805d88e9cdcef7f312e32a019f82a77"
+        "revision" : "9ad256e23641c8e57db9347c5d91950336a8b0c0"
       }
     },
     {

--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -194,7 +194,6 @@ extension MainCoordinator: ParentCoordinator {
                 try walletCoordinator?.deleteWalletData()
                 userStore.resetPersistentSession()
                 analyticsCenter.analyticsPreferenceStore.hasAcceptedAnalytics = nil
-                userStore.defaultsStore.removeObject(forKey: .accessTokenExpiry)
                 fullLogin()
                 homeCoordinator?.baseVc?.isLoggedIn(false)
                 root.selectedIndex = 0

--- a/Sources/Application/WindowManagement.swift
+++ b/Sources/Application/WindowManagement.swift
@@ -1,6 +1,7 @@
 import Logging
 import UIKit
 
+@MainActor
 protocol WindowManagement {
     var windowScene: UIWindowScene { get }
     var appWindow: UIWindow { get }

--- a/Sources/Application/WindowManager.swift
+++ b/Sources/Application/WindowManager.swift
@@ -1,6 +1,7 @@
 import Logging
 import UIKit
 
+@MainActor
 final class WindowManager: WindowManagement {
     let windowScene: UIWindowScene
     let appWindow: UIWindow

--- a/Sources/Errors/DataDeletedWarningViewModel.swift
+++ b/Sources/Errors/DataDeletedWarningViewModel.swift
@@ -2,7 +2,7 @@ import GDSAnalytics
 import GDSCommon
 import Logging
 
-struct DataDeletedWarningViewModel: GDSErrorViewModel, BaseViewModel {
+struct DataDeletedWarningViewModel: GDSErrorViewModelV2, GDSErrorViewModelWithImage, BaseViewModel {
     let image: String = "exclamationmark.circle"
     let title: GDSLocalisedString = "app_somethingWentWrongErrorTitle"
     let body: GDSLocalisedString = "app_dataDeletionWarningBody"
@@ -16,7 +16,7 @@ struct DataDeletedWarningViewModel: GDSErrorViewModel, BaseViewModel {
     init(analyticsService: AnalyticsService,
          action: @escaping () -> Void) {
         self.analyticsService = analyticsService
-        self.primaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "app_dataDeletionSignInButton",
+        self.primaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "app_extendedSignInButton",
                                                                analyticsService: analyticsService) {
             action()
         }

--- a/Sources/Errors/GenericErrorViewModel.swift
+++ b/Sources/Errors/GenericErrorViewModel.swift
@@ -2,7 +2,7 @@ import GDSAnalytics
 import GDSCommon
 import Logging
 
-struct GenericErrorViewModel: GDSErrorViewModel, BaseViewModel {
+struct GenericErrorViewModel: GDSErrorViewModelV2, GDSErrorViewModelWithImage, BaseViewModel {
     let image: String = "exclamationmark.circle"
     let title: GDSLocalisedString = "app_somethingWentWrongErrorTitle"
     let body: GDSLocalisedString = "app_somethingWentWrongErrorBody"

--- a/Sources/Errors/NetworkConnectionErrorViewModel.swift
+++ b/Sources/Errors/NetworkConnectionErrorViewModel.swift
@@ -2,7 +2,7 @@ import GDSAnalytics
 import GDSCommon
 import Logging
 
-struct NetworkConnectionErrorViewModel: GDSErrorViewModel, BaseViewModel {
+struct NetworkConnectionErrorViewModel: GDSErrorViewModelV2, GDSErrorViewModelWithImage, BaseViewModel {
     let image: String = "exclamationmark.circle"
     let title: GDSLocalisedString = "app_networkErrorTitle"
     let body: GDSLocalisedString = "app_networkErrorBody"

--- a/Sources/Errors/SignOutErrorViewModel.swift
+++ b/Sources/Errors/SignOutErrorViewModel.swift
@@ -2,7 +2,7 @@ import GDSAnalytics
 import GDSCommon
 import Logging
 
-struct SignOutErrorViewModel: GDSErrorViewModel, BaseViewModel {
+struct SignOutErrorViewModel: GDSErrorViewModelV2, GDSErrorViewModelWithImage, BaseViewModel {
     let image: String = "exclamationmark.circle"
     let title: GDSLocalisedString = "app_signOutErrorTitle"
     let body: GDSLocalisedString = "app_signOutErrorBody"

--- a/Sources/Errors/SignOutWarningViewModel.swift
+++ b/Sources/Errors/SignOutWarningViewModel.swift
@@ -2,8 +2,7 @@ import GDSAnalytics
 import GDSCommon
 import Logging
 
-struct SignOutWarningViewModel: GDSErrorViewModel, BaseViewModel {
-    let image: String = "exclamationmark.circle"
+struct SignOutWarningViewModel: GDSErrorViewModelV2, BaseViewModel {
     let title: GDSLocalisedString = "app_signOutWarningTitle"
     let body: GDSLocalisedString = "app_signOutWarningBody"
     let primaryButtonViewModel: ButtonViewModel
@@ -16,7 +15,7 @@ struct SignOutWarningViewModel: GDSErrorViewModel, BaseViewModel {
     init(analyticsService: AnalyticsService,
          action: @escaping () -> Void) {
         self.analyticsService = analyticsService
-        self.primaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "app_signInButton",
+        self.primaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "app_extendedSignInButton",
                                                                analyticsService: analyticsService) {
             action()
         }

--- a/Sources/Errors/UnableToLoginErrorViewModel.swift
+++ b/Sources/Errors/UnableToLoginErrorViewModel.swift
@@ -2,7 +2,7 @@ import GDSAnalytics
 import GDSCommon
 import Logging
 
-struct UnableToLoginErrorViewModel: GDSErrorViewModel, BaseViewModel {
+struct UnableToLoginErrorViewModel: GDSErrorViewModelV2, GDSErrorViewModelWithImage, BaseViewModel {
     let image: String = "exclamationmark.circle"
     let title: GDSLocalisedString = "app_signInErrorTitle"
     let body: GDSLocalisedString = "app_signInErrorBody"

--- a/Sources/Resources/cy-GB.lproj/Localizable.strings
+++ b/Sources/Resources/cy-GB.lproj/Localizable.strings
@@ -35,6 +35,8 @@
 
 "app_signInButton" = "Mewngofnodi";
 
+"app_extendedSignInButton" = "Mewngofnodi gyda GOV.UK One Login";
+
 
 // MARK: Analytics peference screen
 "app_acceptAnalyticsPreferences_title" = "Helpu i wella'r ap drwy rannu dadansoddi";
@@ -151,12 +153,10 @@
 
 
 // Mark: Sign Out Warning screen
-"app_signOutWarningTitle" = "You’ve been signed-out";
+"app_signOutWarningTitle" = "Rydych wedi cael eich allgofnodi";
 
-"app_signOutWarningBody" = "You will need to reauthenticate";
+"app_signOutWarningBody" = "Mae hyn er mwyn cadw'r wybodaeth yn eich ap GOV.UK One Login yn ddiogel.\n\nMae angen i chi fewngofnodi eto i barhau.";
 
 
 // MARK: Data DeletionWarning screen
 "app_dataDeletionWarningBody" = "Rydym wedi dileu'r wybodaeth yn eich ap GOV.UK One Login oherwydd ni allwn gadarnhau eich manylion mewngofnodi.\n\nRydym wedi gwneud hyn i leihau'r risg y bydd rhywun arall yn gweld eich gwybodaeth.\n\nEr mwyn parhau i ddefnyddio'r ap, bydd angen i chi fewngofnodi. Yna gofynnir i chi osod eich dewisiadau dadansoddi a mewngofnodi eto.";
-
-"app_dataDeletionSignInButton" = "Mewngofnodi gyda GOV.UK One Login";

--- a/Sources/Resources/en.lproj/Localizable.strings
+++ b/Sources/Resources/en.lproj/Localizable.strings
@@ -35,6 +35,8 @@
 
 "app_signInButton" = "Sign in";
 
+"app_extendedSignInButton" = "Sign in with GOV.UK One Login";
+
 
 // MARK: Analytics peference screen
 "app_acceptAnalyticsPreferences_title" = "Help improve the app by sharing analytics";
@@ -151,12 +153,10 @@
 
 
 // Mark: Sign Out Warning screen
-"app_signOutWarningTitle" = "You’ve been signed-out";
+"app_signOutWarningTitle" = "You’ve been signed out";
 
-"app_signOutWarningBody" = "You will need to reauthenticate";
+"app_signOutWarningBody" = "This is to keep the information in your GOV.UK One Login app secure.\n\nYou need to sign in again to continue.";
 
 
 // MARK: Data DeletionWarning screen
 "app_dataDeletionWarningBody" = "We’ve deleted the information in your GOV.UK One Login app because we cannot confirm your sign in details.\n\nWe did this to reduce the risk that someone else will see your information.\n\nTo keep using the app, you’ll need to sign in. You’ll then be asked to set your analytics and sign in preferences again.";
-
-"app_dataDeletionSignInButton" = "Sign in with GOV.UK One Login";

--- a/Sources/Tabs/WalletCoordinator.swift
+++ b/Sources/Tabs/WalletCoordinator.swift
@@ -1,5 +1,6 @@
 import Coordination
 import GDSCommon
+import LocalAuthentication
 import Logging
 import Networking
 import SecureStore
@@ -34,7 +35,8 @@ final class WalletCoordinator: NSObject,
                         with: root,
                         networkClient: networkClient,
                         analyticsService: analyticsCenter.analyticsService,
-                        persistentSecureStore: userStore.openStore)
+                        persistentSecureStore: userStore.openStore,
+                        localAuthService: DummyLocalAuthService(context: LAContext()))
         NotificationCenter.default
             .addObserver(self,
                          selector: #selector(clearWallet),

--- a/Sources/Utilities/DummyLocalAuthService.swift
+++ b/Sources/Utilities/DummyLocalAuthService.swift
@@ -1,0 +1,24 @@
+import Authentication
+import LocalAuthentication
+import UIKit
+
+//
+// NOTE: This type is only being used to build the Wallet implementation, this will be replaced with an actual local auth service
+//
+
+struct DummyLocalAuthService: LocalAuthService {
+    let context: LAContexting
+    
+    func evaluateLocalAuth(navigationController: UINavigationController,
+                           completion: @escaping (AuthType) -> Void) {
+        if (context.canEvaluatePolicy(LAPolicy.deviceOwnerAuthentication, error: nil) && context.biometryType == .touchID) {
+            completion(.touch)
+        } else if (context.canEvaluatePolicy(LAPolicy.deviceOwnerAuthentication, error: nil) && context.biometryType == .faceID) {
+            completion(.face)
+        } else if !context.canEvaluatePolicy(LAPolicy.deviceOwnerAuthentication, error: nil) {
+            completion(.none)
+        } else{
+            completion(.passcode)
+        }
+    }
+}

--- a/Sources/Utilities/DummyLocalAuthService.swift
+++ b/Sources/Utilities/DummyLocalAuthService.swift
@@ -11,13 +11,13 @@ struct DummyLocalAuthService: LocalAuthService {
     
     func evaluateLocalAuth(navigationController: UINavigationController,
                            completion: @escaping (AuthType) -> Void) {
-        if (context.canEvaluatePolicy(LAPolicy.deviceOwnerAuthentication, error: nil) && context.biometryType == .touchID) {
+        if context.canEvaluatePolicy(LAPolicy.deviceOwnerAuthentication, error: nil) && context.biometryType == .touchID {
             completion(.touch)
-        } else if (context.canEvaluatePolicy(LAPolicy.deviceOwnerAuthentication, error: nil) && context.biometryType == .faceID) {
+        } else if context.canEvaluatePolicy(LAPolicy.deviceOwnerAuthentication, error: nil) && context.biometryType == .faceID {
             completion(.face)
         } else if !context.canEvaluatePolicy(LAPolicy.deviceOwnerAuthentication, error: nil) {
             completion(.none)
-        } else{
+        } else {
             completion(.passcode)
         }
     }

--- a/Sources/Utilities/Factories/ErrorPresenter.swift
+++ b/Sources/Utilities/Factories/ErrorPresenter.swift
@@ -1,6 +1,7 @@
 import GDSCommon
 import Logging
 
+@MainActor
 final class ErrorPresenter {
     static func createGenericError(errorDescription: String,
                                    analyticsService: AnalyticsService,

--- a/Sources/Utilities/Factories/OnboardingViewControllerFactory.swift
+++ b/Sources/Utilities/Factories/OnboardingViewControllerFactory.swift
@@ -2,6 +2,7 @@ import Authentication
 import GDSCommon
 import Logging
 
+@MainActor
 final class OnboardingViewControllerFactory {
     static func createIntroViewController(analyticsService: AnalyticsService,
                                           action: @escaping () -> Void) -> IntroViewController {

--- a/Sources/Utilities/Storage/UserStorable.swift
+++ b/Sources/Utilities/Storage/UserStorable.swift
@@ -46,6 +46,7 @@ extension UserStorable {
     func resetPersistentSession() {
         openStore.deleteItem(itemName: .persistentSessionID)
         defaultsStore.removeObject(forKey: .returningUser)
+        defaultsStore.removeObject(forKey: .accessTokenExpiry)
     }
     
     func saveItem(_ item: String?, itemName: String, storage: Storage) throws {

--- a/Tests/UnitTests/Errors/DataDeletedWarningViewModelTests.swift
+++ b/Tests/UnitTests/Errors/DataDeletedWarningViewModelTests.swift
@@ -2,6 +2,7 @@ import GDSCommon
 @testable import OneLogin
 import XCTest
 
+@MainActor
 final class DataDeletedWarningViewModelTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
     var sut: DataDeletedWarningViewModel!

--- a/Tests/UnitTests/Errors/DataDeletedWarningViewModelTests.swift
+++ b/Tests/UnitTests/Errors/DataDeletedWarningViewModelTests.swift
@@ -37,7 +37,7 @@ extension DataDeletedWarningViewModelTests {
     
     func test_buttonConfiuration() throws {
         XCTAssertTrue(sut.primaryButtonViewModel is AnalyticsButtonViewModel)
-        XCTAssertEqual(sut.primaryButtonViewModel.title, GDSLocalisedString(stringLiteral: "app_dataDeletionSignInButton"))
+        XCTAssertEqual(sut.primaryButtonViewModel.title, GDSLocalisedString(stringLiteral: "app_extendedSignInButton"))
         let button = try XCTUnwrap(sut.primaryButtonViewModel as? AnalyticsButtonViewModel)
         XCTAssertEqual(button.backgroundColor, .gdsGreen)
     }

--- a/Tests/UnitTests/Errors/GenericErrorViewModelTests.swift
+++ b/Tests/UnitTests/Errors/GenericErrorViewModelTests.swift
@@ -2,6 +2,7 @@ import GDSAnalytics
 @testable import OneLogin
 import XCTest
 
+@MainActor
 final class GenericErrorViewModelTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
     var sut: GenericErrorViewModel!

--- a/Tests/UnitTests/Errors/NetworkConnectionErrorViewModelTests.swift
+++ b/Tests/UnitTests/Errors/NetworkConnectionErrorViewModelTests.swift
@@ -2,6 +2,7 @@ import GDSAnalytics
 @testable import OneLogin
 import XCTest
 
+@MainActor
 final class NetworkConnectionErrorViewModelTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
     var sut: NetworkConnectionErrorViewModel!

--- a/Tests/UnitTests/Errors/SignOutErrorViewModelTests.swift
+++ b/Tests/UnitTests/Errors/SignOutErrorViewModelTests.swift
@@ -2,8 +2,7 @@ import GDSCommon
 @testable import OneLogin
 import XCTest
 
-import Foundation
-
+@MainActor
 final class SignOutErrorViewModelTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
     var sut: SignOutErrorViewModel!

--- a/Tests/UnitTests/Errors/SignOutWarningViewModelTests.swift
+++ b/Tests/UnitTests/Errors/SignOutWarningViewModelTests.swift
@@ -2,6 +2,7 @@ import GDSCommon
 @testable import OneLogin
 import XCTest
 
+@MainActor
 final class SignOutWarningViewModelTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
     var sut: SignOutWarningViewModel!
@@ -26,7 +27,6 @@ final class SignOutWarningViewModelTests: XCTestCase {
 
 extension SignOutWarningViewModelTests {
     func test_pageConfiguration() throws {
-        XCTAssertEqual(sut.image, "exclamationmark.circle")
         XCTAssertEqual(sut.title.stringKey, "app_signOutWarningTitle")
         XCTAssertEqual(sut.body, "app_signOutWarningBody")
         XCTAssertNil(sut.secondaryButtonViewModel)

--- a/Tests/UnitTests/Errors/SignOutWarningViewModelTests.swift
+++ b/Tests/UnitTests/Errors/SignOutWarningViewModelTests.swift
@@ -36,7 +36,7 @@ extension SignOutWarningViewModelTests {
     
     func test_buttonConfiuration() throws {
         XCTAssertTrue(sut.primaryButtonViewModel is AnalyticsButtonViewModel)
-        XCTAssertEqual(sut.primaryButtonViewModel.title, GDSLocalisedString(stringLiteral: "app_signInButton"))
+        XCTAssertEqual(sut.primaryButtonViewModel.title, GDSLocalisedString(stringLiteral: "app_extendedSignInButton"))
         let button = try XCTUnwrap(sut.primaryButtonViewModel as? AnalyticsButtonViewModel)
         XCTAssertEqual(button.backgroundColor, .gdsGreen)
     }

--- a/Tests/UnitTests/Errors/UnableToLoginErrorViewModelTests.swift
+++ b/Tests/UnitTests/Errors/UnableToLoginErrorViewModelTests.swift
@@ -2,6 +2,7 @@ import GDSAnalytics
 @testable import OneLogin
 import XCTest
 
+@MainActor
 final class UnableToLoginErrorViewModelTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
     var sut: UnableToLoginErrorViewModel!

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -108,7 +108,7 @@ extension LoginCoordinatorTests {
         // THEN the presented view controller should be the GDSErrorViewController
         let warningScreen = try XCTUnwrap(sut.root.presentedViewController as? GDSErrorViewController)
         // THEN the presented view model should be the SignOutWarningViewModel
-        XCTAssertTrue(warningScreen.viewModel is SignOutWarningViewModel)
+        XCTAssertTrue(warningScreen.viewModelV2 is SignOutWarningViewModel)
     }
     
     func test_start_error() throws {

--- a/Tests/UnitTests/Login/ViewModels/FaceIDEnrollmentViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/FaceIDEnrollmentViewModelTests.swift
@@ -2,6 +2,7 @@ import GDSAnalytics
 @testable import OneLogin
 import XCTest
 
+@MainActor
 final class FaceIDEnrollmentViewModelTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
     var sut: FaceIDEnrollmentViewModel!

--- a/Tests/UnitTests/Login/ViewModels/LoginLoadingViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/LoginLoadingViewModelTests.swift
@@ -2,6 +2,7 @@ import GDSAnalytics
 @testable import OneLogin
 import XCTest
 
+@MainActor
 final class LoginLoadingViewModelTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
     var sut: LoginLoadingViewModel!

--- a/Tests/UnitTests/Login/ViewModels/OneLoginIntroViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/OneLoginIntroViewModelTests.swift
@@ -2,6 +2,7 @@ import GDSAnalytics
 @testable import OneLogin
 import XCTest
 
+@MainActor
 final class OneLoginIntroViewModelTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
     var sut: OneLoginIntroViewModel!

--- a/Tests/UnitTests/Login/ViewModels/PasscodeInformationViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/PasscodeInformationViewModelTests.swift
@@ -2,6 +2,7 @@ import GDSAnalytics
 @testable import OneLogin
 import XCTest
 
+@MainActor
 final class PasscodeInformationViewModelTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
     var sut: PasscodeInformationViewModel!

--- a/Tests/UnitTests/Login/ViewModels/TouchIDEnrollmentViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/TouchIDEnrollmentViewModelTests.swift
@@ -2,6 +2,7 @@ import GDSAnalytics
 @testable import OneLogin
 import XCTest
 
+@MainActor
 final class TouchIDEnrollmentViewModelTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
     var sut: TouchIDEnrollmentViewModel!

--- a/Tests/UnitTests/Login/ViewModels/UnlockScreenViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/UnlockScreenViewModelTests.swift
@@ -2,6 +2,7 @@ import GDSAnalytics
 @testable import OneLogin
 import XCTest
 
+@MainActor
 final class UnlockScreenViewModelTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
     var sut: UnlockScreenViewModel!

--- a/Tests/UnitTests/Resources/LocalizedEnglishStringTests.swift
+++ b/Tests/UnitTests/Resources/LocalizedEnglishStringTests.swift
@@ -40,6 +40,8 @@ final class LocalizedEnglishStringTests: XCTestCase {
                        "Sign in with the email address you use for your GOV.UK One Login.")
         XCTAssertEqual("app_signInButton".getEnglishString(),
                        "Sign in")
+        XCTAssertEqual("app_extendedSignInButton".getEnglishString(),
+                       "Sign in with GOV.UK One Login")
     }
     
     func test_analyticsScreen_keys() throws {
@@ -170,16 +172,14 @@ final class LocalizedEnglishStringTests: XCTestCase {
     
     func test_signOutWarningPageKeys() {
         XCTAssertEqual("app_signOutWarningTitle".getEnglishString(),
-                       "You’ve been signed-out")
+                       "You’ve been signed out")
         XCTAssertEqual("app_signOutWarningBody".getEnglishString(),
-                       "You will need to reauthenticate")
+                       "This is to keep the information in your GOV.UK One Login app secure.\n\nYou need to sign in again to continue.")
     }
     
     func test_dataDeletedWarningPageKeys() {
         XCTAssertEqual("app_dataDeletionWarningBody".getEnglishString(),
                        "We’ve deleted the information in your GOV.UK One Login app because we cannot confirm your sign in details.\n\nWe did this to reduce the risk that someone else will see your information.\n\nTo keep using the app, you’ll need to sign in. You’ll then be asked to set your analytics and sign in preferences again.")
-        XCTAssertEqual("app_dataDeletionSignInButton".getEnglishString(),
-                       "Sign in with GOV.UK One Login")
     }
 }
 

--- a/Tests/UnitTests/Resources/LocalizedWelshStringTests.swift
+++ b/Tests/UnitTests/Resources/LocalizedWelshStringTests.swift
@@ -40,6 +40,8 @@ final class LocalizedWelshStringTests: XCTestCase {
                        "Mewngofnodwch gyda'r cyfeiriad e-bost rydych yn ei ddefnyddio ar gyfer eich GOV.UK One Login.")
         XCTAssertEqual("app_signInButton".getWelshString(),
                        "Mewngofnodi")
+        XCTAssertEqual("app_extendedSignInButton".getWelshString(),
+                       "Mewngofnodi gyda GOV.UK One Login")
     }
     
     func test_analyticsScreen_keys() throws {
@@ -170,16 +172,14 @@ final class LocalizedWelshStringTests: XCTestCase {
     
     func test_signOutWarningPageKeys() {
         XCTAssertEqual("app_signOutWarningTitle".getWelshString(),
-                       "You’ve been signed-out")
+                       "Rydych wedi cael eich allgofnodi")
         XCTAssertEqual("app_signOutWarningBody".getWelshString(),
-                       "You will need to reauthenticate")
+                       "Mae hyn er mwyn cadw'r wybodaeth yn eich ap GOV.UK One Login yn ddiogel.\n\nMae angen i chi fewngofnodi eto i barhau.")
     }
     
     func test_dataDeletedWarningPageKeys() {
         XCTAssertEqual("app_dataDeletionWarningBody".getWelshString(),
                        "Rydym wedi dileu'r wybodaeth yn eich ap GOV.UK One Login oherwydd ni allwn gadarnhau eich manylion mewngofnodi.\n\nRydym wedi gwneud hyn i leihau'r risg y bydd rhywun arall yn gweld eich gwybodaeth.\n\nEr mwyn parhau i ddefnyddio'r ap, bydd angen i chi fewngofnodi. Yna gofynnir i chi osod eich dewisiadau dadansoddi a mewngofnodi eto.")
-        XCTAssertEqual("app_dataDeletionSignInButton".getWelshString(),
-                       "Mewngofnodi gyda GOV.UK One Login")
     }
 }
 

--- a/Tests/UnitTests/Screens/Home/HomeTabViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Home/HomeTabViewModelTests.swift
@@ -2,6 +2,7 @@ import GDSAnalytics
 @testable import OneLogin
 import XCTest
 
+@MainActor
 final class HomeTabViewModelTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
     var sut: HomeTabViewModel!

--- a/Tests/UnitTests/Screens/Profile/ProfileTabViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Profile/ProfileTabViewModelTests.swift
@@ -2,6 +2,7 @@ import GDSAnalytics
 @testable import OneLogin
 import XCTest
 
+@MainActor
 final class ProfileTabViewModelTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
     var sut: ProfileTabViewModel!

--- a/Tests/UnitTests/Screens/Profile/SignOutPageViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Profile/SignOutPageViewModelTests.swift
@@ -3,7 +3,7 @@ import GDSCommon
 @testable import OneLogin
 import XCTest
 
-
+@MainActor
 final class SignOutPageViewModelTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
     var sut: SignOutPageViewModel!

--- a/Tests/UnitTests/Screens/TabbedViewControllerTests.swift
+++ b/Tests/UnitTests/Screens/TabbedViewControllerTests.swift
@@ -3,6 +3,7 @@ import GDSCommon
 @testable import OneLogin
 import XCTest
 
+@MainActor
 final class TabbedViewControllerTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
     var viewModel: TabbedViewModel!

--- a/Tests/UnitTests/Screens/UnlockScreenViewControllerTests.swift
+++ b/Tests/UnitTests/Screens/UnlockScreenViewControllerTests.swift
@@ -1,6 +1,7 @@
 @testable import OneLogin
 import XCTest
 
+@MainActor
 final class UnlockScreenViewControllerTests: XCTestCase {
     var viewModel: UnlockScreenViewModel!
     var sut: UnlockScreenViewController!

--- a/Tests/UnitTests/Utilities/DummyLocalAuthServiceTests.swift
+++ b/Tests/UnitTests/Utilities/DummyLocalAuthServiceTests.swift
@@ -1,0 +1,54 @@
+@testable import OneLogin
+import XCTest
+
+final class DummyLocalAuthServiceTests: XCTestCase {
+    var mockLAContext: MockLAContext!
+    var sut: DummyLocalAuthService!
+    
+    override func setUp() {
+        super.setUp()
+        
+        mockLAContext = MockLAContext()
+        sut = DummyLocalAuthService(context: mockLAContext)
+    }
+    
+    override func tearDown() {
+        mockLAContext = nil
+        sut = nil
+        
+        super.tearDown()
+    }
+}
+
+extension DummyLocalAuthServiceTests {
+    func test_faceID() {
+        mockLAContext.biometryType = .faceID
+        mockLAContext.returnedFromCanEvaluatePolicyForAuthentication = true
+        sut.evaluateLocalAuth(navigationController: UINavigationController()) { authType in
+            XCTAssertEqual(authType, .face)
+        }
+    }
+    
+    func test_touchID() {
+        mockLAContext.biometryType = .touchID
+        mockLAContext.returnedFromCanEvaluatePolicyForAuthentication = true
+        sut.evaluateLocalAuth(navigationController: UINavigationController()) { authType in
+            XCTAssertEqual(authType, .touch)
+        }
+    }
+    
+    func test_none() {
+        mockLAContext.returnedFromCanEvaluatePolicyForAuthentication = false
+        sut.evaluateLocalAuth(navigationController: UINavigationController()) { authType in
+            XCTAssertEqual(authType, .none)
+        }
+    }
+    
+    func test_passcode() {
+        mockLAContext.biometryType = .none
+        mockLAContext.returnedFromCanEvaluatePolicyForAuthentication = true
+        sut.evaluateLocalAuth(navigationController: UINavigationController()) { authType in
+            XCTAssertEqual(authType, .passcode)
+        }
+    }
+}

--- a/Tests/UnitTests/Utilities/ErrorPresenterTests.swift
+++ b/Tests/UnitTests/Utilities/ErrorPresenterTests.swift
@@ -1,6 +1,7 @@
 @testable import OneLogin
 import XCTest
 
+@MainActor
 final class ErrorPresenterTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
     var sut: ErrorPresenter.Type!

--- a/Tests/UnitTests/Utilities/OnboardingViewControllerFactoryTests.swift
+++ b/Tests/UnitTests/Utilities/OnboardingViewControllerFactoryTests.swift
@@ -2,6 +2,7 @@ import GDSCommon
 @testable import OneLogin
 import XCTest
 
+@MainActor
 final class OnboardingViewControllerFactoryTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
     var sut: OnboardingViewControllerFactory.Type!


### PR DESCRIPTION
# DCMAW-9589: iOS | Update designs for 'You've been signed out' re-auth page

This PR fixes the 'You've been signed out' sign out warning screen copy and design.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
