### PR TITLE
feat: server error

### DIFF
--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -235,5 +235,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,4 @@
 {
-  "originHash" : "3683584c1cd7a545289ff5c7273b638c309ca3340d1b9e4a6cbde21a88011273",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "3683584c1cd7a545289ff5c7273b638c309ca3340d1b9e4a6cbde21a88011273",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -122,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-authentication.git",
       "state" : {
-        "revision" : "ecf0a5614ac205c53702a691971fdfd40dcc9caf",
-        "version" : "1.3.0"
+        "revision" : "a28f10bd17e70719b50b11c5c1143f236663c758",
+        "version" : "1.4.0"
       }
     },
     {
@@ -235,5 +236,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Sources/Login/AuthenticationCoordinator.swift
+++ b/Sources/Login/AuthenticationCoordinator.swift
@@ -57,7 +57,8 @@ final class AuthenticationCoordinator: NSObject,
                 finish()
             } catch let error as LoginError where error == .non200,
                     let error as LoginError where error == .invalidRequest,
-                    let error as LoginError where error == .clientError {
+                    let error as LoginError where error == .clientError,
+                    let error as LoginError where error == .serverError {
                 showUnableToLoginErrorScreen(error)
             } catch let error as JWTVerifierError {
                 showUnableToLoginErrorScreen(error)

--- a/Tests/UnitTests/Login/AuthenticationCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/AuthenticationCoordinatorTests.swift
@@ -142,6 +142,21 @@ extension AuthenticationCoordinatorTests {
         sut.authError = LoginError.clientError
     }
     
+    func test_loginError_serverError() throws {
+        mockLoginSession.errorFromPerformLoginFlow = LoginError.serverError
+        sut.start()
+        // GIVEN the AuthenticationCoordinator has logged in via start()
+        // WHEN the AuthenticationCoordinator calls performLoginFlow on the session
+        // and there is a server error
+        waitForTruth(self.navigationController.viewControllers.count == 1, timeout: 20)
+        // THEN the 'unable to login' error screen is shown
+        XCTAssertTrue(sut.root.topViewController is GDSErrorViewController)
+        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorViewController)
+        XCTAssertTrue(vc.viewModel is UnableToLoginErrorViewModel)
+        // THEN the loginError should be a serverError error
+        sut.authError = LoginError.serverError
+    }
+    
     func test_loginError_generic() throws {
         mockLoginSession.errorFromPerformLoginFlow = LoginError.generic(description: "")
         sut.start()


### PR DESCRIPTION
# DCMAW-9216: User sees 'Unable to login' error when a server_error occurs

When login related errors are passed from Auth to STS, STS delivers a  server_error response to the app. In this scenario, we should ensure that the user is shown an appropriate error page. This PR ensures that the required 'Unable to login' error page is shown instead of the generic error page.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
~- [ ] Created a `draft` pull request if it is not yet ready for review~

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?~
    ~- [ ] Checked dynamic type sizes are applied~
    ~- [ ] Checked VoiceOver can navigate your new code~
    ~- [ ] Checked a user can navigate only using a keyboard around your new code~ 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
