### PR TITLE
feat: calling app info endpoint

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -48,6 +48,9 @@
 		41FF35AA2B21F06C00419DB3 /* ErrorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41FF35A92B21F06C00419DB3 /* ErrorPresenter.swift */; };
 		41FF35AC2B21F1AA00419DB3 /* GenericErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41FF35AB2B21F1AA00419DB3 /* GenericErrorViewModel.swift */; };
 		41FF35AF2B222CAC00419DB3 /* AuthenticationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B3207A2B063CA100FECDF0 /* AuthenticationCoordinatorTests.swift */; };
+		ABB941F82C6C069A0007052B /* AppInformationServicing.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB941F72C6C069A0007052B /* AppInformationServicing.swift */; };
+		ABB941FA2C6C07980007052B /* AppInfoResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB941F92C6C07980007052B /* AppInfoResponse.swift */; };
+		ABB941FC2C6C088C0007052B /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB941FB2C6C088C0007052B /* Service.swift */; };
 		C8098B972AEFF1AB001517A0 /* LoginSessionConfiguration+OneLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8098B962AEFF1AB001517A0 /* LoginSessionConfiguration+OneLogin.swift */; };
 		C8098B992AEFF287001517A0 /* AnalyticsService+GDS.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8098B982AEFF287001517A0 /* AnalyticsService+GDS.swift */; };
 		C80B871A2B029E230087C6D5 /* LoginUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80B87192B029E230087C6D5 /* LoginUITests.swift */; };
@@ -261,6 +264,9 @@
 		41E1A9142BE128610034B6C7 /* MockURLOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLOpener.swift; sourceTree = "<group>"; };
 		41FF35A92B21F06C00419DB3 /* ErrorPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorPresenter.swift; sourceTree = "<group>"; };
 		41FF35AB2B21F1AA00419DB3 /* GenericErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericErrorViewModel.swift; sourceTree = "<group>"; };
+		ABB941F72C6C069A0007052B /* AppInformationServicing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInformationServicing.swift; sourceTree = "<group>"; };
+		ABB941F92C6C07980007052B /* AppInfoResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfoResponse.swift; sourceTree = "<group>"; };
+		ABB941FB2C6C088C0007052B /* Service.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Service.swift; sourceTree = "<group>"; };
 		C803C21D2B8F8D73008DE774 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		C803C21F2B8F8D9C008DE774 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		C8098B962AEFF1AB001517A0 /* LoginSessionConfiguration+OneLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoginSessionConfiguration+OneLogin.swift"; sourceTree = "<group>"; };
@@ -500,6 +506,7 @@
 		3BBF28E42A9F7D3200491BB1 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				ABB941FD2C6CAD840007052B /* Service */,
 				C8178E3C2AEB2C8600059875 /* Analytics */,
 				3BBF28EC2A9F7D3200491BB1 /* Application */,
 				41FF35A82B21F05600419DB3 /* Errors */,
@@ -595,6 +602,16 @@
 				C8D6781F2C519B7E000AA26C /* DataDeletedWarningViewModel.swift */,
 			);
 			path = Errors;
+			sourceTree = "<group>";
+		};
+		ABB941FD2C6CAD840007052B /* Service */ = {
+			isa = PBXGroup;
+			children = (
+				ABB941F72C6C069A0007052B /* AppInformationServicing.swift */,
+				ABB941F92C6C07980007052B /* AppInfoResponse.swift */,
+				ABB941FB2C6C088C0007052B /* Service.swift */,
+			);
+			path = Service;
 			sourceTree = "<group>";
 		};
 		C803C2152B8F8865008DE774 /* BuildConfig */ = {
@@ -1511,6 +1528,7 @@
 				41C8E4332B73AA600063B8A3 /* TouchIDEnrollmentViewModel.swift in Sources */,
 				D08B0B732BDA8DD100769CEA /* TabbedViewController.swift in Sources */,
 				C8BADD222B8652F200385FE7 /* TokenHolder.swift in Sources */,
+				ABB941F82C6C069A0007052B /* AppInformationServicing.swift in Sources */,
 				C8E6A3E82BBC0536005015AF /* WindowManagement.swift in Sources */,
 				C81ECB1B2B71709500AFC3A6 /* EnrolmentCoordinator.swift in Sources */,
 				D0BE24472BEBD2E400759529 /* MockJWKSResponse.swift in Sources */,
@@ -1535,6 +1553,7 @@
 				C8098B972AEFF1AB001517A0 /* LoginSessionConfiguration+OneLogin.swift in Sources */,
 				C8C343972B909A2F00E92FB9 /* String+OneLogin.swift in Sources */,
 				D03B04CF2BECDB5C00418C0B /* KeyVerifier.swift in Sources */,
+				ABB941FC2C6C088C0007052B /* Service.swift in Sources */,
 				C8098B992AEFF287001517A0 /* AnalyticsService+GDS.swift in Sources */,
 				D0275CBF2BFF876800AF9A50 /* TokenVerifier.swift in Sources */,
 				C8B320792B062F9100FECDF0 /* AuthenticationCoordinator.swift in Sources */,
@@ -1579,6 +1598,7 @@
 				C85E21182ACEECD800AF8B4E /* AnalyticsButtonViewModel.swift in Sources */,
 				C851FFA22BADA4B200A7B73D /* SceneLifecycle.swift in Sources */,
 				D08B0B812BDC0D7100769CEA /* TabbedTableViewCell.swift in Sources */,
+				ABB941FA2C6C07980007052B /* AppInfoResponse.swift in Sources */,
 				C86B706B2B8E43DC00F4C9BF /* AnalyticsPreferenceViewModel.swift in Sources */,
 				41279DD52BFDD9CA00E16537 /* SignOutPageViewModel.swift in Sources */,
 				C8ECA12A2BB5957500722218 /* WalletCoordinator.swift in Sources */,

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -51,6 +51,8 @@
 		ABB941F82C6C069A0007052B /* AppInformationServicing.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB941F72C6C069A0007052B /* AppInformationServicing.swift */; };
 		ABB941FA2C6C07980007052B /* AppInfoResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB941F92C6C07980007052B /* AppInfoResponse.swift */; };
 		ABB941FC2C6C088C0007052B /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB941FB2C6C088C0007052B /* Service.swift */; };
+		ABB942032C6CCBE60007052B /* AppInfoServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB942012C6CCBE60007052B /* AppInfoServiceTests.swift */; };
+		ABF6FBC82C6D6EBE0068D564 /* ServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB941FF2C6CCAB30007052B /* ServiceTests.swift */; };
 		C8098B972AEFF1AB001517A0 /* LoginSessionConfiguration+OneLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8098B962AEFF1AB001517A0 /* LoginSessionConfiguration+OneLogin.swift */; };
 		C8098B992AEFF287001517A0 /* AnalyticsService+GDS.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8098B982AEFF287001517A0 /* AnalyticsService+GDS.swift */; };
 		C80B871A2B029E230087C6D5 /* LoginUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80B87192B029E230087C6D5 /* LoginUITests.swift */; };
@@ -267,6 +269,8 @@
 		ABB941F72C6C069A0007052B /* AppInformationServicing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInformationServicing.swift; sourceTree = "<group>"; };
 		ABB941F92C6C07980007052B /* AppInfoResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfoResponse.swift; sourceTree = "<group>"; };
 		ABB941FB2C6C088C0007052B /* Service.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Service.swift; sourceTree = "<group>"; };
+		ABB941FF2C6CCAB30007052B /* ServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceTests.swift; sourceTree = "<group>"; };
+		ABB942012C6CCBE60007052B /* AppInfoServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfoServiceTests.swift; sourceTree = "<group>"; };
 		C803C21D2B8F8D73008DE774 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		C803C21F2B8F8D9C008DE774 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		C8098B962AEFF1AB001517A0 /* LoginSessionConfiguration+OneLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoginSessionConfiguration+OneLogin.swift"; sourceTree = "<group>"; };
@@ -610,6 +614,15 @@
 				ABB941F72C6C069A0007052B /* AppInformationServicing.swift */,
 				ABB941F92C6C07980007052B /* AppInfoResponse.swift */,
 				ABB941FB2C6C088C0007052B /* Service.swift */,
+			);
+			path = Service;
+			sourceTree = "<group>";
+		};
+		ABB941FE2C6CCA9E0007052B /* Service */ = {
+			isa = PBXGroup;
+			children = (
+				ABB942012C6CCBE60007052B /* AppInfoServiceTests.swift */,
+				ABB941FF2C6CCAB30007052B /* ServiceTests.swift */,
 			);
 			path = Service;
 			sourceTree = "<group>";
@@ -1113,6 +1126,7 @@
 		C8E6C7632AF821D2008C19C9 /* UnitTests */ = {
 			isa = PBXGroup;
 			children = (
+				ABB941FE2C6CCA9E0007052B /* Service */,
 				C81ECB1E2B71767500AFC3A6 /* Application */,
 				41A0BD0E2B275155009AE51F /* Errors */,
 				C85DF8502AEC1C6E0064F68E /* Extensions */,
@@ -1630,6 +1644,7 @@
 				41C8E42F2B72920F0063B8A3 /* FaceIDEnrollmentViewModelTests.swift in Sources */,
 				C865E6542C21DDA5001FA62D /* UniversalLinkQualifierTests.swift in Sources */,
 				C8454A8F2B99D1BC000F9ED0 /* LoginCoordinatorTests.swift in Sources */,
+				ABB942032C6CCBE60007052B /* AppInfoServiceTests.swift in Sources */,
 				C82F950F2B9F0CCA00A90A6A /* UnlockScreenViewControllerTests.swift in Sources */,
 				21FA1C502AE18C8B0052136E /* OneLoginIntroViewModelTests.swift in Sources */,
 				C8C343A02B92227C00E92FB9 /* MockAnalyticsPreferenceStore.swift in Sources */,
@@ -1651,6 +1666,7 @@
 				C88E40E92C371431008A3C20 /* SignOutWarningViewModelTests.swift in Sources */,
 				D0275CC12C00951600AF9A50 /* MockTokenVerifier.swift in Sources */,
 				41C5E3322B45B07D00212A12 /* NetworkConnectionErrorViewModelTests.swift in Sources */,
+				ABF6FBC82C6D6EBE0068D564 /* ServiceTests.swift in Sources */,
 				411D1FD32B73CA74002393D1 /* TouchIDEnrollmentViewModelTests.swift in Sources */,
 				C8B5EFC52B0E53EE004EA4D4 /* XCTestCase+TestExtensions.swift in Sources */,
 				D087BCF22C19E4BB00825F60 /* SignOutErrorViewModelTests.swift in Sources */,

--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -1,7 +1,7 @@
 import Coordination
-import Logging
 import GDSAnalytics
 import LocalAuthentication
+import Logging
 import SecureStore
 import UIKit
 
@@ -110,7 +110,7 @@ final class MainCoordinator: NSObject,
         }
     }
     
-    private func checkAvailabilityAndAppVersion() {
+    private func checkAppVersion() {
         Task {
             do {
                 let appInfo = try await updateService.fetchAppInfo()

--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -105,6 +105,8 @@ final class MainCoordinator: NSObject,
             return
         }
     }
+    
+    // TODO: DCMAW-9866 - Add logic for checking app version & presenting UI
 }
 
 extension MainCoordinator {

--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -13,6 +13,7 @@ final class MainCoordinator: NSObject,
     private var analyticsCenter: AnalyticsCentral
     private let userStore: UserStorable
     private let tokenVerifier: TokenVerifier
+    private let updateService: AppInformationServicing
     
     private weak var loginCoordinator: LoginCoordinator?
     private weak var homeCoordinator: HomeCoordinator?
@@ -23,12 +24,14 @@ final class MainCoordinator: NSObject,
          root: UITabBarController,
          analyticsCenter: AnalyticsCentral,
          userStore: UserStorable,
-         tokenVerifier: TokenVerifier = JWTVerifier()) {
+         tokenVerifier: TokenVerifier = JWTVerifier(),
+         updateService: AppInformationServicing = AppInformationService()) {
         self.windowManager = windowManager
         self.root = root
         self.analyticsCenter = analyticsCenter
         self.userStore = userStore
         self.tokenVerifier = tokenVerifier
+        self.updateService = updateService
     }
     
     func start() {
@@ -106,7 +109,21 @@ final class MainCoordinator: NSObject,
         }
     }
     
-    // TODO: DCMAW-9866 - Add logic for checking app version & presenting UI
+    private func checkAvailabilityAndAppVersion() {
+        Task {
+            do {
+                let appInfo = try await updateService.fetchAppInfo()
+                
+                guard updateService.currentVersion >= appInfo.minimumVersion else {
+                    // TODO: DCMAW-9866 - Present 'app update required' screen
+                    
+                    return
+                }
+            } catch {
+                // TODO: Add error handling
+            }
+        }
+    }
 }
 
 extension MainCoordinator {

--- a/Sources/Application/MainCoordinator.swift
+++ b/Sources/Application/MainCoordinator.swift
@@ -1,4 +1,5 @@
 import Coordination
+import Logging
 import GDSAnalytics
 import LocalAuthentication
 import SecureStore
@@ -116,11 +117,16 @@ final class MainCoordinator: NSObject,
                 
                 guard updateService.currentVersion >= appInfo.minimumVersion else {
                     // TODO: DCMAW-9866 - Present 'app update required' screen
-                    
                     return
                 }
+                
             } catch {
-                // TODO: Add error handling
+                let error = ErrorPresenter
+                    .createSignOutError(errorDescription: error.localizedDescription,
+                                        analyticsService: analyticsCenter.analyticsService) {
+                        exit(0)
+                    }
+                root.present(error, animated: true)
             }
         }
     }

--- a/Sources/Login/OnboardingCoordinator.swift
+++ b/Sources/Login/OnboardingCoordinator.swift
@@ -18,6 +18,8 @@ final class OnboardingCoordinator: NSObject,
     }
     
     func start() {
+        // TODO: DCMAW-9866 - Call func for checking app version
+        
         let analyticsPreferenceScreen = OnboardingViewControllerFactory
             .createAnalyticsPeferenceScreen { [unowned self] in
                 analyticsPreferenceStore.hasAcceptedAnalytics = true

--- a/Sources/Service/AppInfoResponse.swift
+++ b/Sources/Service/AppInfoResponse.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Networking
+
+public struct App: Decodable {
+    public let minimumVersion: Version
+    public let allowAppUsage: Bool
+    public let releaseFlags: [String: Bool]
+    
+    public init(minimumVersion: Version, allowAppUsage: Bool, releaseFlags: [String: Bool]) {
+        self.minimumVersion = minimumVersion
+        self.allowAppUsage = allowAppUsage
+        self.releaseFlags = releaseFlags
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case minimumVersion
+        case allowAppUsage = "available"
+        case releaseFlags
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.minimumVersion = try container.decode(Version.self, forKey: .minimumVersion)
+        self.allowAppUsage = try container.decodeIfPresent(Bool.self, forKey: .allowAppUsage) ?? true
+        self.releaseFlags = try container.decodeIfPresent([String: Bool].self, forKey: .releaseFlags) ?? [:]
+    }
+}
+
+struct Apps: Decodable {
+    let iOS: App
+}
+
+struct AppInfoResponse: Decodable {
+    let appList: Apps
+    
+    enum CodingKeys: String, CodingKey {
+        case appList = "apps"
+    }
+}

--- a/Sources/Service/AppInformationServicing.swift
+++ b/Sources/Service/AppInformationServicing.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Networking
+import UIKit
+
+public protocol AppInformationServicing {
+    func fetchAppInfo() async throws -> App
+    var currentVersion: Version { get }
+}
+
+/// Update Service ensures  the app being run isn't below the minimum supported version
+///
+/// It polls the `appInfo` endpoint on the backend every 15 minutes, and returns results to `isBelowMinimumSupportedVersion` when this is the case.
+///
+public final class AppInformationService: AppInformationServicing {
+    private let client: NetworkClient
+    
+    /// Initialise a new `UpdateService`
+    ///
+    /// No parameters are required.
+    public convenience init() {
+        self.init(client: .init())
+    }
+    
+    init(client: NetworkClient) {
+        self.client = client
+    }
+    
+    public var currentVersion: Version {
+        guard let versionString = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else { return .one }
+        return Version(string: versionString) ?? .one
+    }
+    
+    public func fetchAppInfo() async throws -> App {
+        let updateURL = Service.baseURL.appendingPathComponent("appInfo")
+        var request = URLRequest(url: updateURL)
+        request.httpMethod = "GET"
+        
+        let data = try await client.makeRequest(request)
+        let appInfo = try parseResult(data).appList.iOS
+        
+        return appInfo
+    }
+    
+    private func parseResult(_ dataArray: Data) throws -> AppInfoResponse {
+        try JSONDecoder().decode(AppInfoResponse.self, from: dataArray)
+    }
+}

--- a/Sources/Service/AppInformationServicing.swift
+++ b/Sources/Service/AppInformationServicing.swift
@@ -7,10 +7,6 @@ public protocol AppInformationServicing {
     var currentVersion: Version { get }
 }
 
-/// Update Service ensures  the app being run isn't below the minimum supported version
-///
-/// It polls the `appInfo` endpoint on the backend every 15 minutes, and returns results to `isBelowMinimumSupportedVersion` when this is the case.
-///
 public final class AppInformationService: AppInformationServicing {
     private let client: NetworkClient
     

--- a/Sources/Service/AppInformationServicing.swift
+++ b/Sources/Service/AppInformationServicing.swift
@@ -14,7 +14,7 @@ public protocol AppInformationServicing {
 public final class AppInformationService: AppInformationServicing {
     private let client: NetworkClient
     
-    /// Initialise a new `UpdateService`
+    /// Initialise a new `AppInformationService`
     ///
     /// No parameters are required.
     public convenience init() {

--- a/Sources/Service/Service.swift
+++ b/Sources/Service/Service.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct Service {
+    private(set) static var baseURL: URL!
+    
+    public static func initialize(baseURL: URL) {
+        self.baseURL = baseURL
+    }
+}

--- a/Sources/Utilities/Factories/OnboardingViewControllerFactory.swift
+++ b/Sources/Utilities/Factories/OnboardingViewControllerFactory.swift
@@ -62,4 +62,6 @@ final class OnboardingViewControllerFactory {
         }
         return UnlockScreenViewController(viewModel: viewModel)
     }
+    
+    // TODO: DCMAW-9865 - Create functions to present UI for loading screen & app update required screen
 }

--- a/Tests/UnitTests/Service/AppInfoServiceTests.swift
+++ b/Tests/UnitTests/Service/AppInfoServiceTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+import MockNetworking
+@testable import Networking
+@testable import OneLogin
+import XCTest
+
+final class AppInfoServiceTests: XCTestCase {
+    private var sut: AppInformationService!
+    private func createMock(minimumVersion: String = "1.0.0",
+                            available: Bool = true,
+                            releaseFlags: [Bool] = [true, false]) -> Data {
+        
+        """
+        {
+            "apps": {
+                "android": {
+                    "minimumVersion": "\(minimumVersion)"
+                },
+                "iOS": {
+                    "available": \(available),
+                    "minimumVersion": "\(minimumVersion)",
+                    "releaseFlags": {
+                        \(flagFactory(releaseFlags))
+                    }
+                }
+            }
+        }
+        """.data(using: .utf8)!
+    }
+    
+    private func flagFactory(_ flags: [Bool]) -> String {
+        flags
+            .enumerated()
+            .map {
+                "\"Feature\($0+1)\": \($1)"
+            }
+            .joined(separator: ",\n")
+    }
+    
+    override class func setUp() {
+        let url = URL(string: "https://example.com/dev")!
+        Service.initialize(baseURL: url)
+    }
+    
+    override func setUp() {
+        super.setUp()
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        let client = NetworkClient(configuration: configuration)
+        
+        sut = .init(client: client)
+    }
+    
+    
+    override func tearDown() {
+        super.tearDown()
+        sut = nil
+        MockURLProtocol.clear()
+    }
+}
+
+extension AppInfoServiceTests {
+    func test_fetchAppVersion_makesNetworkCall() async throws {
+        MockURLProtocol.handler = {
+            (self.createMock(), HTTPURLResponse(statusCode: 200))
+        }
+        
+        let version = try await sut.fetchAppInfo().minimumVersion
+        
+        XCTAssertEqual(MockURLProtocol.requests.count, 1)
+        XCTAssertNotNil(version)
+        
+        let request = try XCTUnwrap(MockURLProtocol.requests.first)
+        XCTAssertEqual(request.httpMethod, "GET")
+        XCTAssertEqual(request.url?.scheme, "https")
+        XCTAssertEqual(request.url?.host, "example.com")
+        XCTAssertEqual(request.url?.path, "/dev/appInfo")
+        
+        XCTAssertEqual(version, Version(1, 0, 0))
+    }
+    
+    func test_isSupportedVersion_makesNetworkCall() throws {
+        MockURLProtocol.handler = {
+            (self.createMock(), HTTPURLResponse(statusCode: 200))
+        }
+        
+        Task { try await sut.fetchAppInfo() }
+        
+        let exp = expectation(for: .init { _, _ in
+            !MockURLProtocol.requests.isEmpty
+        }, evaluatedWith: nil)
+        wait(for: [exp], timeout: 2)
+        
+        let request = try XCTUnwrap(MockURLProtocol.requests.first)
+        XCTAssertEqual(request.httpMethod, "GET")
+        XCTAssertEqual(request.url?.scheme, "https")
+        XCTAssertEqual(request.url?.host, "example.com")
+        XCTAssertEqual(request.url?.path, "/dev/appInfo")
+    }
+    
+    func test_appInfoIsDecoded_usageIsTrue() async throws {
+        MockURLProtocol.handler = {
+            (self.createMock(), HTTPURLResponse(statusCode: 200))
+        }
+        
+        let appInfo = try await sut.fetchAppInfo()
+        XCTAssertTrue(appInfo.allowAppUsage)
+    }
+    
+    func test_appInfoIsDecoded_usageIsFalse() async throws {
+        MockURLProtocol.handler = {
+            (self.createMock(available: false), HTTPURLResponse(statusCode: 200))
+        }
+        
+        let appInfo = try await sut.fetchAppInfo()
+        XCTAssertFalse(appInfo.allowAppUsage)
+    }
+    
+    func test_appInfoIsDecoded_releaseFlags() async throws {
+        MockURLProtocol.handler = {
+            (self.createMock(), HTTPURLResponse(statusCode: 200))
+        }
+        
+        let appInfo = try await sut.fetchAppInfo()
+        XCTAssertEqual(appInfo.releaseFlags, ["Feature1": true,
+                                              "Feature2": false])
+    }
+}

--- a/Tests/UnitTests/Service/ServiceTests.swift
+++ b/Tests/UnitTests/Service/ServiceTests.swift
@@ -1,0 +1,11 @@
+import Network
+@testable import OneLogin
+import XCTest
+
+ final class ServiceTests: XCTestCase {
+    func testInitialize() throws {
+        let url = URL(string: "https://example.com")!
+        Service.initialize(baseURL: url)
+        XCTAssertEqual(Service.baseURL, url)
+    }
+ }


### PR DESCRIPTION
# DCMAW-9864: Call app info endpoint, and ensure we get version back

Calling `/appInfo` to get the minimum app version when the app is opened & putting TODO’s in the code where we will show the new minimum version UI

# Checklist

## Before raising your pull request:
- [ ] Commit messages that conform to conventional commit messages
- [ ] Ran the app locally ensuring it builds 
- [ ] Ran the tests locally ensuring they pass on Build
- [ ] Pull request has a clear title with a short description about the feature or update
~- [ ] Created a `draft` pull request if it is not yet ready for review~

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?~
    ~- [ ] Checked dynamic type sizes are applied~
    ~- [ ] Checked VoiceOver can navigate your new code~
    ~- [ ] Checked a user can navigate only using a keyboard around your new code~ 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
