### PR TITLE
feat: adds update app screen

### DIFF
--- a/OneLogin-Info.plist
+++ b/OneLogin-Info.plist
@@ -29,6 +29,8 @@
 	<string>$(STS_BASE_URL)</string>
 	<key>STS Client ID</key>
 	<string>$(STS_CLIENT_ID)</string>
+	<key>App Store URL</key>
+	<string>apps.apple.com</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		C873B1DA2AF82403002C39E8 /* OneLoginUnit.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = C873B1D72AF82403002C39E8 /* OneLoginUnit.xctestplan */; };
 		C873B1E42AF82700002C39E8 /* StagingAppEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C873B1E12AF826D3002C39E8 /* StagingAppEnvironmentTests.swift */; };
 		C873B1E52AF82706002C39E8 /* BuildAppEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C873B1DF2AF826D3002C39E8 /* BuildAppEnvironmentTests.swift */; };
+		C8788F412C787F7D00472EC2 /* AppEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8788F402C787F7D00472EC2 /* AppEnvironmentTests.swift */; };
 		C87913C12B275F4900545B33 /* ErrorPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C87913C02B275F4900545B33 /* ErrorPresenterTests.swift */; };
 		C87913C42B27B7A300545B33 /* ErrorAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C87913C32B27B7A300545B33 /* ErrorAnalytics.swift */; };
 		C880DDE22AEAB6C100020796 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C880DDE12AEAB6C100020796 /* AppEnvironment.swift */; };
@@ -324,6 +325,7 @@
 		C873B1D72AF82403002C39E8 /* OneLoginUnit.xctestplan */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = OneLoginUnit.xctestplan; sourceTree = "<group>"; };
 		C873B1DF2AF826D3002C39E8 /* BuildAppEnvironmentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuildAppEnvironmentTests.swift; sourceTree = "<group>"; };
 		C873B1E12AF826D3002C39E8 /* StagingAppEnvironmentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StagingAppEnvironmentTests.swift; sourceTree = "<group>"; };
+		C8788F402C787F7D00472EC2 /* AppEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironmentTests.swift; sourceTree = "<group>"; };
 		C87913C02B275F4900545B33 /* ErrorPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorPresenterTests.swift; sourceTree = "<group>"; };
 		C87913C32B27B7A300545B33 /* ErrorAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorAnalytics.swift; sourceTree = "<group>"; };
 		C880DDE12AEAB6C100020796 /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
@@ -727,6 +729,7 @@
 				C8E6A3EE2BBC1181005015AF /* WindowManagerTests.swift */,
 				219602012A976305008F3427 /* MainCoordinatorTests.swift */,
 				C8C666592BCFDBDE00CF249B /* TokenHolderTests.swift */,
+				C8788F402C787F7D00472EC2 /* AppEnvironmentTests.swift */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -1698,6 +1701,7 @@
 				C87913C12B275F4900545B33 /* ErrorPresenterTests.swift in Sources */,
 				C8BADD272B87AEEA00385FE7 /* MockSecureStoreService.swift in Sources */,
 				41D469752B9758A5008705CD /* UnlockScreenViewModelTests.swift in Sources */,
+				C8788F412C787F7D00472EC2 /* AppEnvironmentTests.swift in Sources */,
 				C81ECB212B71769F00AFC3A6 /* EnrolmentCoordinatorTests.swift in Sources */,
 				C8486FE72C60E66400DE514C /* DummyLocalAuthServiceTests.swift in Sources */,
 			);

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		41C8E42F2B72920F0063B8A3 /* FaceIDEnrollmentViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41C8E42D2B7291F80063B8A3 /* FaceIDEnrollmentViewModelTests.swift */; };
 		41C8E4312B73A0160063B8A3 /* BiometricEnrollmentAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41C8E4302B73A0160063B8A3 /* BiometricEnrollmentAnalytics.swift */; };
 		41C8E4332B73AA600063B8A3 /* TouchIDEnrollmentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41C8E4322B73AA600063B8A3 /* TouchIDEnrollmentViewModel.swift */; };
+		41CCE1332C7764C000FFBE64 /* UpdateAppViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41CCE1322C7764C000FFBE64 /* UpdateAppViewModel.swift */; };
+		41CCE1362C77657600FFBE64 /* UpdateAppViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41CCE1342C7764DE00FFBE64 /* UpdateAppViewModelTests.swift */; };
 		41D469752B9758A5008705CD /* UnlockScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D469742B9758A5008705CD /* UnlockScreenViewModelTests.swift */; };
 		41D9DC452B55851A00FC7DDD /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D9DC442B55851A00FC7DDD /* NetworkMonitor.swift */; };
 		41E1A9132BE1278F0034B6C7 /* MockNetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41E1A9122BE1278F0034B6C7 /* MockNetworkMonitor.swift */; };
@@ -261,6 +263,8 @@
 		41C8E42D2B7291F80063B8A3 /* FaceIDEnrollmentViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaceIDEnrollmentViewModelTests.swift; sourceTree = "<group>"; };
 		41C8E4302B73A0160063B8A3 /* BiometricEnrollmentAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricEnrollmentAnalytics.swift; sourceTree = "<group>"; };
 		41C8E4322B73AA600063B8A3 /* TouchIDEnrollmentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchIDEnrollmentViewModel.swift; sourceTree = "<group>"; };
+		41CCE1322C7764C000FFBE64 /* UpdateAppViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateAppViewModel.swift; sourceTree = "<group>"; };
+		41CCE1342C7764DE00FFBE64 /* UpdateAppViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateAppViewModelTests.swift; sourceTree = "<group>"; };
 		41D469742B9758A5008705CD /* UnlockScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnlockScreenViewModelTests.swift; sourceTree = "<group>"; };
 		41D9DC442B55851A00FC7DDD /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
 		41E1A9122BE1278F0034B6C7 /* MockNetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkMonitor.swift; sourceTree = "<group>"; };
@@ -566,6 +570,7 @@
 		4195E6C62B0CC6C50065E2BB /* Screens */ = {
 			isa = PBXGroup;
 			children = (
+				41CCE1312C7764A600FFBE64 /* UpdateAppVersion */,
 				41279DD32BFDD9A700E16537 /* SignOutConfirmation */,
 				D08B0B5D2BD95C4900769CEA /* Tabs */,
 				D08B0B522BD7F7D600769CEA /* DeveloperMenu */,
@@ -585,6 +590,14 @@
 				C8D678212C540297000AA26C /* DataDeletedWarningViewModelTests.swift */,
 			);
 			path = Errors;
+			sourceTree = "<group>";
+		};
+		41CCE1312C7764A600FFBE64 /* UpdateAppVersion */ = {
+			isa = PBXGroup;
+			children = (
+				41CCE1322C7764C000FFBE64 /* UpdateAppViewModel.swift */,
+			);
+			path = UpdateAppVersion;
 			sourceTree = "<group>";
 		};
 		41E1A90F2BE126910034B6C7 /* Networking */ = {
@@ -965,6 +978,7 @@
 				D08B0B842BDFA40A00769CEA /* TabbedViewControllerTests.swift */,
 				C8514F6A2C09E4B0008E1433 /* Home */,
 				C8514F692C09E4A5008E1433 /* Profile */,
+				41CCE1342C7764DE00FFBE64 /* UpdateAppViewModelTests.swift */,
 			);
 			path = Screens;
 			sourceTree = "<group>";
@@ -1581,6 +1595,7 @@
 				D08B0B8F2BE1231A00769CEA /* TabbedViewSectionFactory.swift in Sources */,
 				D08B0B762BDA95F600769CEA /* TabbedViewModel.swift in Sources */,
 				C8ECA1322BB73E2E00722218 /* WindowManager.swift in Sources */,
+				41CCE1332C7764C000FFBE64 /* UpdateAppViewModel.swift in Sources */,
 				D08B0B652BDA478000769CEA /* SignInView.swift in Sources */,
 				41C5E32F2B45A36E00212A12 /* NetworkConnectionErrorViewModel.swift in Sources */,
 				C8486FE52C60D80A00DE514C /* DummyLocalAuthService.swift in Sources */,
@@ -1640,6 +1655,7 @@
 				41E1A9132BE1278F0034B6C7 /* MockNetworkMonitor.swift in Sources */,
 				413C58762BF261D300171C06 /* HomeTabViewModelTests.swift in Sources */,
 				41A0BD112B2758E6009AE51F /* GenericErrorViewModelTests.swift in Sources */,
+				41CCE1362C77657600FFBE64 /* UpdateAppViewModelTests.swift in Sources */,
 				410464F62B29D078000E7CB2 /* UnableToLoginErrorViewModelTests.swift in Sources */,
 				C851FFA42BADAAB600A7B73D /* SceneLifecycleTests.swift in Sources */,
 				C83E18122C05DDDB00B451D6 /* LoginLoadingViewModelTests.swift in Sources */,

--- a/Sources/Application/Environment/AppEnvironment.swift
+++ b/Sources/Application/Environment/AppEnvironment.swift
@@ -9,6 +9,7 @@ public final class AppEnvironment {
         case oneLoginClientID = "One Login Client ID"
         case stsClientID = "STS Client ID"
         case externalBaseURL = "External Base URL"
+        case appStoreURL = "App Store URL"
     }
     
     private static var appDictionary: [String: Any] {
@@ -143,6 +144,24 @@ extension AppEnvironment {
     
     static var isLocaleWelsh: Bool {
         UserDefaults.standard.stringArray(forKey: "AppleLanguages")?.first?.prefix(2) == "cy"
+    }
+}
+
+// MARK: - App Store URL
+extension AppEnvironment {
+    static var appStoreURL: URL {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = AppEnvironment.string(for: .appStoreURL)
+        return components.url!
+    }
+
+    static var appStore: URL {
+        appStoreURL
+            .appendingPathComponent("gb")
+            .appendingPathExtension("app")
+            .appendingPathExtension("uk.gov.digital-identity")
+        // TODO: DCMAW-9819: Update to App ID
     }
 }
 

--- a/Sources/Resources/cy-GB.lproj/Localizable.strings
+++ b/Sources/Resources/cy-GB.lproj/Localizable.strings
@@ -160,3 +160,10 @@
 
 // MARK: Data DeletionWarning screen
 "app_dataDeletionWarningBody" = "Rydym wedi dileu'r wybodaeth yn eich ap GOV.UK One Login oherwydd ni allwn gadarnhau eich manylion mewngofnodi.\n\nRydym wedi gwneud hyn i leihau'r risg y bydd rhywun arall yn gweld eich gwybodaeth.\n\nEr mwyn parhau i ddefnyddio'r ap, bydd angen i chi fewngofnodi. Yna gofynnir i chi osod eich dewisiadau dadansoddi a mewngofnodi eto.";
+
+// MARK: Update App screen
+"app_updateAppTitle" = "Mae angen i chi ddiweddaru eich ap";
+
+"app_updateAppBody" = "Rydych yn defnyddio hen fersiwn o'r ap GOV.UK One Login.\n\nDiweddarwch eich ap i barhau.";
+
+"app_updateAppButton" = "Diweddaru Ap GOV.UK One Login";

--- a/Sources/Resources/en.lproj/Localizable.strings
+++ b/Sources/Resources/en.lproj/Localizable.strings
@@ -160,3 +160,10 @@
 
 // MARK: Data DeletionWarning screen
 "app_dataDeletionWarningBody" = "We’ve deleted the information in your GOV.UK One Login app because we cannot confirm your sign in details.\n\nWe did this to reduce the risk that someone else will see your information.\n\nTo keep using the app, you’ll need to sign in. You’ll then be asked to set your analytics and sign in preferences again.";
+
+// MARK: Update App screen
+"app_updateAppTitle" = "You need to update your app";
+
+"app_updateAppBody" = "You’re using an old version of the GOV.UK One Login app.\n\nUpdate your app to continue.";
+
+"app_updateAppButton" = "Update GOV.UK One Login app";

--- a/Sources/Screens/UpdateAppVersion/UpdateAppViewModel.swift
+++ b/Sources/Screens/UpdateAppVersion/UpdateAppViewModel.swift
@@ -1,0 +1,36 @@
+import GDSAnalytics
+import GDSCommon
+import Logging
+import UIKit
+
+struct UpdateAppViewModel: GDSInformationViewModel, BaseViewModel {
+    let title: GDSLocalisedString = "app_updateAppTitle"
+    let body: GDSLocalisedString? = "app_updateAppBody"
+    let footnote: GDSLocalisedString? = nil
+    let image: String = "exclamationmark.arrow.circlepath"
+    let imageWeight: UIFont.Weight? = .regular
+    let imageColour: UIColor? = nil
+    let imageHeightConstraint: CGFloat? = 100
+    let primaryButtonViewModel: ButtonViewModel
+    let secondaryButtonViewModel: ButtonViewModel? = nil
+    let analyticsService: AnalyticsService
+
+    let rightBarButtonTitle: GDSLocalisedString? = nil
+    let backButtonIsHidden: Bool = true
+
+    init(urlOpener: URLOpener = UIApplication.shared, analyticsService: AnalyticsService, action: @escaping () -> Void) {
+        self.analyticsService = analyticsService
+        // TODO DCMAW-9612: add event for clicking the link (LinkEvent most likely).
+        // update titleKey and action in `primaryButtonViewModel`
+        self.primaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "app_updateAppButton",
+                                                               analyticsService: analyticsService) {
+            urlOpener.open(url: AppEnvironment.appStoreURL)
+        }
+    }
+
+    func didAppear() {
+        // TODO DCMAW-9612: create screen, send event
+    }
+
+    func didDismiss() { /* Conforming to BaseViewModel */ }
+}

--- a/Tests/ConfigTests/BuildConfig/BuildAppEnvironmentTests.swift
+++ b/Tests/ConfigTests/BuildConfig/BuildAppEnvironmentTests.swift
@@ -17,7 +17,7 @@ final class BuildAppEnvironmentTests: XCTestCase {
         XCTAssertEqual(sut.stsHelloWorld, URL(string: "https://hello-world.token.build.account.gov.uk/hello-world"))
         XCTAssertEqual(sut.stsHelloWorldError, URL(string: "https://hello-world.token.build.account.gov.uk/hello-world/error"))
         XCTAssertEqual(sut.appStoreURL, URL(string: "https://apps.apple.com"))
-                XCTAssertEqual(sut.appStore, URL(string: "https://apps.apple.com/gb.app.uk.gov.digital-identity"))
+        XCTAssertEqual(sut.appStore, URL(string: "https://apps.apple.com/gb.app.uk.gov.digital-identity"))
         XCTAssertTrue(sut.callingSTSEnabled)
         XCTAssertFalse(sut.isLocaleWelsh)
     }

--- a/Tests/ConfigTests/BuildConfig/BuildAppEnvironmentTests.swift
+++ b/Tests/ConfigTests/BuildConfig/BuildAppEnvironmentTests.swift
@@ -16,6 +16,8 @@ final class BuildAppEnvironmentTests: XCTestCase {
         XCTAssertEqual(sut.oneLoginBaseURL, "mobile.build.account.gov.uk")
         XCTAssertEqual(sut.stsHelloWorld, URL(string: "https://hello-world.token.build.account.gov.uk/hello-world"))
         XCTAssertEqual(sut.stsHelloWorldError, URL(string: "https://hello-world.token.build.account.gov.uk/hello-world/error"))
+        XCTAssertEqual(sut.appStoreURL, URL(string: "https://apps.apple.com"))
+                XCTAssertEqual(sut.appStore, URL(string: "https://apps.apple.com/gb.app.uk.gov.digital-identity"))
         XCTAssertTrue(sut.callingSTSEnabled)
         XCTAssertFalse(sut.isLocaleWelsh)
     }

--- a/Tests/ConfigTests/StagingConfig/StagingAppEnvironmentTests.swift
+++ b/Tests/ConfigTests/StagingConfig/StagingAppEnvironmentTests.swift
@@ -16,6 +16,7 @@ final class StagingAppEnvironmentTests: XCTestCase {
         XCTAssertEqual(sut.oneLoginBaseURL, "mobile.staging.account.gov.uk")
         XCTAssertEqual(sut.stsHelloWorld, URL(string: "https://hello-world.token.staging.account.gov.uk/hello-world"))
         XCTAssertEqual(sut.stsHelloWorldError, URL(string: "https://hello-world.token.staging.account.gov.uk/hello-world/error"))
+        XCTAssertEqual(sut.jwskURL, URL(string: "https://token.staging.account.gov.uk/.well-known/jwks.json"))
         XCTAssertEqual(sut.appStoreURL, URL(string: "https://apps.apple.com"))
         XCTAssertEqual(sut.appStore, URL(string: "https://apps.apple.com/gb.app.uk.gov.digital-identity"))
         XCTAssertTrue(sut.callingSTSEnabled)

--- a/Tests/ConfigTests/StagingConfig/StagingAppEnvironmentTests.swift
+++ b/Tests/ConfigTests/StagingConfig/StagingAppEnvironmentTests.swift
@@ -16,6 +16,8 @@ final class StagingAppEnvironmentTests: XCTestCase {
         XCTAssertEqual(sut.oneLoginBaseURL, "mobile.staging.account.gov.uk")
         XCTAssertEqual(sut.stsHelloWorld, URL(string: "https://hello-world.token.staging.account.gov.uk/hello-world"))
         XCTAssertEqual(sut.stsHelloWorldError, URL(string: "https://hello-world.token.staging.account.gov.uk/hello-world/error"))
+        XCTAssertEqual(sut.appStoreURL, URL(string: "https://apps.apple.com"))
+                XCTAssertEqual(sut.appStore, URL(string: "https://apps.apple.com/gb.app.uk.gov.digital-identity"))
         XCTAssertTrue(sut.callingSTSEnabled)
         XCTAssertFalse(sut.isLocaleWelsh)
     }

--- a/Tests/ConfigTests/StagingConfig/StagingAppEnvironmentTests.swift
+++ b/Tests/ConfigTests/StagingConfig/StagingAppEnvironmentTests.swift
@@ -17,7 +17,7 @@ final class StagingAppEnvironmentTests: XCTestCase {
         XCTAssertEqual(sut.stsHelloWorld, URL(string: "https://hello-world.token.staging.account.gov.uk/hello-world"))
         XCTAssertEqual(sut.stsHelloWorldError, URL(string: "https://hello-world.token.staging.account.gov.uk/hello-world/error"))
         XCTAssertEqual(sut.appStoreURL, URL(string: "https://apps.apple.com"))
-                XCTAssertEqual(sut.appStore, URL(string: "https://apps.apple.com/gb.app.uk.gov.digital-identity"))
+        XCTAssertEqual(sut.appStore, URL(string: "https://apps.apple.com/gb.app.uk.gov.digital-identity"))
         XCTAssertTrue(sut.callingSTSEnabled)
         XCTAssertFalse(sut.isLocaleWelsh)
     }

--- a/Tests/UnitTests/Application/AppEnvironmentTests.swift
+++ b/Tests/UnitTests/Application/AppEnvironmentTests.swift
@@ -2,21 +2,22 @@
 import XCTest
 
 final class BuildAppEnvironmentTests: XCTestCase {
-    func test_defaultEnvironment_retrieveFromPlist() throws {
+    func test_appEnvironmentValues() throws {
         let sut = AppEnvironment.self
         XCTAssertEqual(sut.oneLoginAuthorize, URL(string: "https://auth-stub.mobile.build.account.gov.uk/authorize"))
-        XCTAssertEqual(sut.stsAuthorize, URL(string: "https://token.build.account.gov.uk/authorize"))
         XCTAssertEqual(sut.oneLoginToken, URL(string: "https://mobile.build.account.gov.uk/token"))
-        XCTAssertEqual(sut.stsToken, URL(string: "https://token.build.account.gov.uk/token"))
         XCTAssertEqual(sut.privacyPolicyURL, URL(string: "https://signin.account.gov.uk/privacy-notice?lng=en"))
         XCTAssertEqual(sut.manageAccountURL, URL(string: "https://signin.account.gov.uk/sign-in-or-create?lng=en"))
         XCTAssertEqual(sut.oneLoginClientID, "TEST_CLIENT_ID")
-        XCTAssertEqual(sut.stsClientID, "bYrcuRVvnylvEgYSSbBjwXzHrwJ")
         XCTAssertEqual(sut.oneLoginRedirect, "https://mobile.build.account.gov.uk/redirect")
         XCTAssertEqual(sut.oneLoginBaseURL, "mobile.build.account.gov.uk")
+        XCTAssertEqual(sut.stsAuthorize, URL(string: "https://token.build.account.gov.uk/authorize"))
+        XCTAssertEqual(sut.stsToken, URL(string: "https://token.build.account.gov.uk/token"))
         XCTAssertEqual(sut.stsHelloWorld, URL(string: "https://hello-world.token.build.account.gov.uk/hello-world"))
         XCTAssertEqual(sut.stsHelloWorldError, URL(string: "https://hello-world.token.build.account.gov.uk/hello-world/error"))
         XCTAssertEqual(sut.jwskURL, URL(string: "https://token.build.account.gov.uk/.well-known/jwks.json"))
+        XCTAssertEqual(sut.stsClientID, "bYrcuRVvnylvEgYSSbBjwXzHrwJ")
+        XCTAssertEqual(sut.isLocaleWelsh, false)
         XCTAssertEqual(sut.appStoreURL, URL(string: "https://apps.apple.com"))
         XCTAssertEqual(sut.appStore, URL(string: "https://apps.apple.com/gb.app.uk.gov.digital-identity"))
         XCTAssertTrue(sut.callingSTSEnabled)

--- a/Tests/UnitTests/Resources/LocalizedEnglishStringTests.swift
+++ b/Tests/UnitTests/Resources/LocalizedEnglishStringTests.swift
@@ -181,6 +181,12 @@ final class LocalizedEnglishStringTests: XCTestCase {
         XCTAssertEqual("app_dataDeletionWarningBody".getEnglishString(),
                        "We’ve deleted the information in your GOV.UK One Login app because we cannot confirm your sign in details.\n\nWe did this to reduce the risk that someone else will see your information.\n\nTo keep using the app, you’ll need to sign in. You’ll then be asked to set your analytics and sign in preferences again.")
     }
+
+    func test_updateAppPageKeys() {
+        XCTAssertEqual("app_updateAppTitle".getEnglishString(), "You need to update your app")
+        XCTAssertEqual("app_updateAppBody".getEnglishString(), "You’re using an old version of the GOV.UK One Login app.\n\nUpdate your app to continue.")
+        XCTAssertEqual("app_updateAppButton".getEnglishString(), "Update GOV.UK One Login app")
+    }
 }
 
 // swiftlint:enable line_length

--- a/Tests/UnitTests/Resources/LocalizedWelshStringTests.swift
+++ b/Tests/UnitTests/Resources/LocalizedWelshStringTests.swift
@@ -181,6 +181,12 @@ final class LocalizedWelshStringTests: XCTestCase {
         XCTAssertEqual("app_dataDeletionWarningBody".getWelshString(),
                        "Rydym wedi dileu'r wybodaeth yn eich ap GOV.UK One Login oherwydd ni allwn gadarnhau eich manylion mewngofnodi.\n\nRydym wedi gwneud hyn i leihau'r risg y bydd rhywun arall yn gweld eich gwybodaeth.\n\nEr mwyn parhau i ddefnyddio'r ap, bydd angen i chi fewngofnodi. Yna gofynnir i chi osod eich dewisiadau dadansoddi a mewngofnodi eto.")
     }
+
+    func test_updateAppPageKeys() {
+        XCTAssertEqual("app_updateAppTitle".getWelshString(), "Mae angen i chi ddiweddaru eich ap")
+        XCTAssertEqual("app_updateAppBody".getWelshString(), "Rydych yn defnyddio hen fersiwn o'r ap GOV.UK One Login.\n\nDiweddarwch eich ap i barhau.")
+        XCTAssertEqual("app_updateAppButton".getWelshString(), "Diweddaru Ap GOV.UK One Login")
+    }
 }
 
 // swiftlint:enable line_length

--- a/Tests/UnitTests/Screens/UpdateAppViewModelTests.swift
+++ b/Tests/UnitTests/Screens/UpdateAppViewModelTests.swift
@@ -1,0 +1,44 @@
+import GDSAnalytics
+@testable import OneLogin
+import XCTest
+
+@MainActor
+final class UpdateAppViewModelTests: XCTestCase {
+    var mockAnalyticsService: MockAnalyticsService!
+    var urlOpener: MockURLOpener!
+    var sut: UpdateAppViewModel!
+
+    override func setUp() {
+        super.setUp()
+
+        mockAnalyticsService = MockAnalyticsService()
+        urlOpener = .init()
+        sut = UpdateAppViewModel(urlOpener: urlOpener,
+                                 analyticsService: mockAnalyticsService) { }
+    }
+
+    override func tearDown() {
+        mockAnalyticsService = nil
+        urlOpener = nil
+        sut = nil
+
+        super.tearDown()
+    }
+}
+
+extension UpdateAppViewModelTests {
+    func test_label_contents() throws {
+        XCTAssertEqual(sut.title.stringKey, "app_updateAppTitle")
+        XCTAssertEqual(sut.body?.stringKey, "app_updateAppBody")
+        XCTAssertEqual(sut.primaryButtonViewModel.title, "app_updateAppButton")
+        XCTAssertEqual(sut.imageWeight, .regular)
+        XCTAssertEqual(sut.image, "exclamationmark.arrow.circlepath")
+    }
+
+    func test_didCallButtonAction() throws {
+        XCTAssertNil(sut.primaryButtonViewModel.icon)
+        XCTAssertFalse(urlOpener.didOpenURL)
+        sut.primaryButtonViewModel.action()
+        XCTAssertTrue(urlOpener.didOpenURL)
+    }
+}


### PR DESCRIPTION
# DCMAW-9865: Create UI part, along with link to app store on button, and test it in isolation\

This PR adds the UI telling the user to update their app version, with the button opening the app store (which needs to be updated in future with the relevant ID for the store listing in DCMAW-9819). In the simulator the link seems to open Safari on the AppStore webpage, on a device, it opens the AppStore's home screen.

Note: This needs manual QA. Adding something like the below to `OnboardingViewControllerFactory` FaceID or TouchID methods (as these are already the same return type as the new screen) is an easy way to manually check

```
       let vm = UpdateAppViewModel(analyticsService: analyticsService) {
            primaryButtonAction()
        }
```

![simulator_screenshot_13468F3E-5A23-4E15-9CAC-0EE4E7FBBE1D](https://github.com/user-attachments/assets/0f155d88-9521-4f2e-b578-59178a70ebd4)

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
