### PR TITLE
ci: fix deployment pipeline

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -125,6 +125,14 @@ platform :ios do
 
       version = get_version_number(xcodeproj: project_name)
 
+      #
+      # App Store Connect considers 1.0.0 and 1.0 the same
+      # but will only return results for 1.0 as this was uploaded first
+      #
+      if version == "1.0.0" then
+        version = "1.0"
+      end
+
       build_number = latest_testflight_build_number(
         app_identifier: app_identifier,
         version: version


### PR DESCRIPTION
# ci: fix deployment pipeline

The deployment pipelines for the One Login app have been failing because of a version number conflict.

Initial uploads of the app were against 1.0, but this has been updated to 1.0.0 as part of our work to enforce a minimum app version: [DCMAW-9522](https://govukverify.atlassian.net/browse/DCMAW-9522).

1.0 and 1.0.0 are considered equivalent by the App Store Connect UI.

When requesting a list of previous builds for 1.0.0, no results are returned.
When requesting a list of previous builds for 1.0, results matching both 1.0 and 1.0.0 are returned.

This change ensures that the build number is correctly incremented for 1.0.0 builds as part of the deployment pipeline.
The build number will therefore now no longer conflict with builds that have been uploaded previously.

[DCMAW-9522]: https://govukverify.atlassian.net/browse/DCMAW-9522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ