### PR TITLE
feat: implements GA4 on SignOutWarning screen

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -1067,9 +1067,9 @@
 				C86E223D2BE108140085453F /* DeveloperMenuViewControllerTests.swift */,
 				C82F950E2B9F0CCA00A90A6A /* UnlockScreenViewControllerTests.swift */,
 				D08B0B842BDFA40A00769CEA /* TabbedViewControllerTests.swift */,
+				41CCE1342C7764DE00FFBE64 /* UpdateAppViewModelTests.swift */,
 				C8514F6A2C09E4B0008E1433 /* Home */,
 				C8514F692C09E4A5008E1433 /* Profile */,
-				41CCE1342C7764DE00FFBE64 /* UpdateAppViewModelTests.swift */,
 			);
 			path = Screens;
 			sourceTree = "<group>";

--- a/Sources/Analytics/Errors/ErrorAnalytics.swift
+++ b/Sources/Analytics/Errors/ErrorAnalytics.swift
@@ -5,10 +5,12 @@ enum ErrorAnalyticsScreen: String, ScreenType {
     case generic = "genericErrorScreen"
     case unableToLogin = "unableToLoginErrorScreen"
     case networkConnection = "networkConnectionErrorScreen"
+    case signOutWarning = "signOutWarningScreen"
 }
 
 enum ErrorAnalyticsScreenID: String {
     case generic = "f275a786-7366-4ef5-b24b-9e514d324403"
     case networkConnection = "80606f36-f6aa-4f49-aaa8-ff7d3cdeb16f"
     case unableToLogin = "6c15e073-d1a5-4781-b416-aaad6e80b078"
+    case signOutWarning = "cfc50baa-4b56-4170-9707-cd05b60b6658"
 }

--- a/Sources/Errors/SignOutWarningViewModel.swift
+++ b/Sources/Errors/SignOutWarningViewModel.swift
@@ -2,19 +2,21 @@ import GDSAnalytics
 import GDSCommon
 import Logging
 
-class SignOutWarningViewModel: GDSErrorViewModelV2, BaseViewModel {
+struct SignOutWarningViewModel: GDSErrorViewModelV2, BaseViewModel {
     let title: GDSLocalisedString = "app_signOutWarningTitle"
     let body: GDSLocalisedString = "app_signOutWarningBody"
     let primaryButtonViewModel: ButtonViewModel
     let secondaryButtonViewModel: ButtonViewModel? = nil
-    var analyticsService: AnalyticsService
+    let analyticsService: AnalyticsService
 
     let rightBarButtonTitle: GDSLocalisedString? = nil
     let backButtonIsHidden: Bool = true
     
     init(analyticsService: AnalyticsService,
          action: @escaping () -> Void) {
-        self.analyticsService = analyticsService
+        var tempAnalyticsService = analyticsService
+        tempAnalyticsService.setAdditionalParameters(appTaxonomy: .reauth)
+        self.analyticsService = tempAnalyticsService
         let event = LinkEvent(textKey: "app_extendedSignInButton",
                               linkDomain: AppEnvironment.oneLoginBaseURL,
                               external: .false)
@@ -26,7 +28,6 @@ class SignOutWarningViewModel: GDSErrorViewModelV2, BaseViewModel {
     }
     
     func didAppear() {
-        analyticsService.setAdditionalParameters(appTaxonomy: .reauth)
         let screen = ScreenView(id: ErrorAnalyticsScreen.signOutWarning.rawValue,
                                 screen: ErrorAnalyticsScreen.signOutWarning,
                                 titleKey: title.stringKey)

--- a/Sources/Errors/SignOutWarningViewModel.swift
+++ b/Sources/Errors/SignOutWarningViewModel.swift
@@ -29,7 +29,7 @@ class SignOutWarningViewModel: GDSErrorViewModelV2, BaseViewModel {
         analyticsService.setAdditionalParameters(appTaxonomy: .reauth)
         let screen = ScreenView(id: ErrorAnalyticsScreen.signOutWarning.rawValue,
                                 screen: ErrorAnalyticsScreen.signOutWarning,
-                                titleKey: "app_signOutWarningTitle")
+                                titleKey: title.stringKey)
         analyticsService.trackScreen(screen)
     }
     

--- a/Sources/Errors/SignOutWarningViewModel.swift
+++ b/Sources/Errors/SignOutWarningViewModel.swift
@@ -15,13 +15,22 @@ struct SignOutWarningViewModel: GDSErrorViewModelV2, BaseViewModel {
     init(analyticsService: AnalyticsService,
          action: @escaping () -> Void) {
         self.analyticsService = analyticsService
+        let event = LinkEvent(textKey: "app_extendedSignInButton",
+                              linkDomain: AppEnvironment.oneLoginBaseURL,
+                              external: .false)
         self.primaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "app_extendedSignInButton",
-                                                               analyticsService: analyticsService) {
+                                                               analyticsService: analyticsService,
+                                                               analyticsEvent: event) {
             action()
         }
     }
     
-    func didAppear() { /* BaseViewModel compliance */ }
+    func didAppear() {
+        let screen = ScreenView(id: ErrorAnalyticsScreen.signOutWarning.rawValue,
+                                screen: ErrorAnalyticsScreen.signOutWarning,
+                                titleKey: "app_signOutWarningTitle")
+        analyticsService.trackScreen(screen)
+    }
     
     func didDismiss() { /* BaseViewModel compliance */ }
 }

--- a/Sources/Errors/SignOutWarningViewModel.swift
+++ b/Sources/Errors/SignOutWarningViewModel.swift
@@ -2,13 +2,13 @@ import GDSAnalytics
 import GDSCommon
 import Logging
 
-struct SignOutWarningViewModel: GDSErrorViewModelV2, BaseViewModel {
+class SignOutWarningViewModel: GDSErrorViewModelV2, BaseViewModel {
     let title: GDSLocalisedString = "app_signOutWarningTitle"
     let body: GDSLocalisedString = "app_signOutWarningBody"
     let primaryButtonViewModel: ButtonViewModel
     let secondaryButtonViewModel: ButtonViewModel? = nil
-    let analyticsService: AnalyticsService
-    
+    var analyticsService: AnalyticsService
+
     let rightBarButtonTitle: GDSLocalisedString? = nil
     let backButtonIsHidden: Bool = true
     
@@ -26,6 +26,7 @@ struct SignOutWarningViewModel: GDSErrorViewModelV2, BaseViewModel {
     }
     
     func didAppear() {
+        analyticsService.setAdditionalParameters(appTaxonomy: .reauth)
         let screen = ScreenView(id: ErrorAnalyticsScreen.signOutWarning.rawValue,
                                 screen: ErrorAnalyticsScreen.signOutWarning,
                                 titleKey: "app_signOutWarningTitle")

--- a/Sources/Extensions/CustomTypes/AnalyticsService+GDS.swift
+++ b/Sources/Extensions/CustomTypes/AnalyticsService+GDS.swift
@@ -8,6 +8,7 @@ enum AppTaxonomy: String {
     case home
     case wallet
     case profile
+    case reauth = "re auth"
 }
 
 extension AnalyticsService {
@@ -23,9 +24,18 @@ extension AnalyticsService {
     }
     
     mutating func setAdditionalParameters(appTaxonomy: AppTaxonomy) {
+        var taxonomyLevel3: String {
+            if appTaxonomy == .reauth {
+                "re auth"
+            } else if appTaxonomy == .profile {
+                "my profile"
+            } else {
+                "undefined"
+            }
+        }
         additionalParameters = additionalParameters.merging([
-            "taxonomy_level2": appTaxonomy.rawValue,
-            "taxonomy_level3": appTaxonomy == .profile ? "my profile" : "undefined"
+            "taxonomy_level2": appTaxonomy == .reauth ? AppTaxonomy.login.rawValue : appTaxonomy.rawValue,
+            "taxonomy_level3": taxonomyLevel3
         ]) { $1 }
     }
 }

--- a/Sources/Extensions/CustomTypes/AnalyticsService+GDS.swift
+++ b/Sources/Extensions/CustomTypes/AnalyticsService+GDS.swift
@@ -26,9 +26,9 @@ extension AnalyticsService {
     mutating func setAdditionalParameters(appTaxonomy: AppTaxonomy) {
         var taxonomyLevel3: String {
             if appTaxonomy == .reauth {
-                "re auth"
+                appTaxonomy.rawValue
             } else if appTaxonomy == .profile {
-                "my profile"
+                "my \(appTaxonomy.rawValue)"
             } else {
                 "undefined"
             }

--- a/Sources/Screens/SignOutConfirmation/SignOutPageViewModel.swift
+++ b/Sources/Screens/SignOutConfirmation/SignOutPageViewModel.swift
@@ -28,7 +28,7 @@ struct SignOutPageViewModel: GDSInstructionsViewModel, BaseViewModel {
     func didAppear() {
         let screen = ScreenView(id: ProfileAnalyticsScreenID.signOutScreen.rawValue,
                                 screen: ProfileAnalyticsScreen.signOutScreen,
-                                titleKey: "app_signOutConfirmationTitle")
+                                titleKey: title.stringKey)
         analyticsService.trackScreen(screen)
     }
     

--- a/Sources/Screens/Tabs/HomeTabViewModel.swift
+++ b/Sources/Screens/Tabs/HomeTabViewModel.swift
@@ -2,10 +2,10 @@ import GDSAnalytics
 import GDSCommon
 import Logging
 
-class HomeTabViewModel: TabbedViewModel {
+struct HomeTabViewModel: TabbedViewModel {
     let navigationTitle: GDSLocalisedString = "app_homeTitle"
     let sectionModels: [TabbedViewSectionModel]
-    var analyticsService: AnalyticsService
+    let analyticsService: AnalyticsService
 
     let rightBarButtonTitle: GDSLocalisedString? = nil
     let backButtonIsHidden: Bool = true
@@ -14,16 +14,17 @@ class HomeTabViewModel: TabbedViewModel {
     
     init(analyticsService: AnalyticsService,
          sectionModels: [TabbedViewSectionModel] = [TabbedViewSectionModel]()) {
-        self.analyticsService = analyticsService
+        var tempAnalyticsService = analyticsService
+        tempAnalyticsService.setAdditionalParameters(appTaxonomy: .home)
+        self.analyticsService = tempAnalyticsService
         self.sectionModels = sectionModels
     }
     
     func didAppear() {
         if isLoggedIn {
-            analyticsService.setAdditionalParameters(appTaxonomy: .home)
             let screen = ScreenView(id: HomeAnalyticsScreenID.homeScreen.rawValue,
                                     screen: HomeAnalyticsScreen.homeScreen,
-                                    titleKey: "app_homeTitle")
+                                    titleKey: navigationTitle.stringKey)
             analyticsService.trackScreen(screen)
         }
     }

--- a/Sources/Screens/Tabs/ProfileTabViewModel.swift
+++ b/Sources/Screens/Tabs/ProfileTabViewModel.swift
@@ -2,10 +2,10 @@ import GDSAnalytics
 import GDSCommon
 import Logging
 
-class ProfileTabViewModel: TabbedViewModel {
+struct ProfileTabViewModel: TabbedViewModel {
     let navigationTitle: GDSLocalisedString = "app_profileTitle"
     let sectionModels: [TabbedViewSectionModel]
-    var analyticsService: AnalyticsService
+    let analyticsService: AnalyticsService
     
     let rightBarButtonTitle: GDSLocalisedString? = nil
     let backButtonIsHidden: Bool = true
@@ -14,16 +14,17 @@ class ProfileTabViewModel: TabbedViewModel {
     
     init(analyticsService: AnalyticsService,
          sectionModels: [TabbedViewSectionModel] = [TabbedViewSectionModel]()) {
-        self.analyticsService = analyticsService
+        var tempAnalyticsService = analyticsService
+        tempAnalyticsService.setAdditionalParameters(appTaxonomy: .profile)
+        self.analyticsService = tempAnalyticsService
         self.sectionModels = sectionModels
     }
     
     func didAppear() {
         if isLoggedIn {
-            analyticsService.setAdditionalParameters(appTaxonomy: .profile)
             let screen = ScreenView(id: ProfileAnalyticsScreenID.profileScreen.rawValue,
                                     screen: ProfileAnalyticsScreen.profileScreen,
-                                    titleKey: "app_profileTitle")
+                                    titleKey: navigationTitle.stringKey)
             analyticsService.trackScreen(screen)
         }
     }

--- a/Tests/UnitTests/Application/MainCoordinatorTests.swift
+++ b/Tests/UnitTests/Application/MainCoordinatorTests.swift
@@ -270,7 +270,7 @@ extension MainCoordinatorTests {
         XCTAssertEqual(mockAnalyticsService.eventsLogged, [iconEvent.name.name])
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["type"], iconEvent.type.rawValue)
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["text"], iconEvent.text)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String, "login")
+        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String, AppTaxonomy.login.rawValue)
         XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level3"] as? String, "undefined")
     }
     
@@ -290,9 +290,8 @@ extension MainCoordinatorTests {
         // THEN the wallet view controller's tab bar event is sent
         let iconEvent = IconEvent(textKey: "wallet")
         XCTAssertEqual(mockAnalyticsService.eventsLogged, [iconEvent.name.name])
-        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["type"], iconEvent.type.rawValue)
-        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["text"], iconEvent.text)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String, "login")
+        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged, iconEvent.parameters)
+        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String, AppTaxonomy.login.rawValue)
         XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level3"] as? String, "undefined")
     }
     
@@ -314,9 +313,8 @@ extension MainCoordinatorTests {
         // THEN the profile view controller's tab bar event is sent
         let iconEvent = IconEvent(textKey: "profile")
         XCTAssertEqual(mockAnalyticsService.eventsLogged, [iconEvent.name.name])
-        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["type"], iconEvent.type.rawValue)
-        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["text"], iconEvent.text)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String, "login")
+        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged, iconEvent.parameters)
+        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String, AppTaxonomy.login.rawValue)
         XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level3"] as? String, "undefined")
     }
     

--- a/Tests/UnitTests/Application/SceneLifecycleTests.swift
+++ b/Tests/UnitTests/Application/SceneLifecycleTests.swift
@@ -59,8 +59,6 @@ extension SceneLifecycleTests {
                                 screen: IntroAnalyticsScreen.splashScreen,
                                 titleKey: "one login splash screen")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"], screen.parameters["screen_id"])
-
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
     }
 }

--- a/Tests/UnitTests/Errors/GenericErrorViewModelTests.swift
+++ b/Tests/UnitTests/Errors/GenericErrorViewModelTests.swift
@@ -62,10 +62,6 @@ extension GenericErrorViewModelTests {
                                      titleKey: "app_somethingWentWrongErrorTitle",
                                      reason: sut.errorDescription)
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"],
-                       screen.parameters["screen_id"])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["reason"],
-                       screen.parameters["reason"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
     }
 }

--- a/Tests/UnitTests/Errors/NetworkConnectionErrorViewModelTests.swift
+++ b/Tests/UnitTests/Errors/NetworkConnectionErrorViewModelTests.swift
@@ -54,8 +54,6 @@ extension NetworkConnectionErrorViewModelTests {
                                      titleKey: "app_networkErrorTitle",
                                      reason: "network connection error")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"], screen.parameters["screen_id"])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["reason"], screen.parameters["reason"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
     }
 }

--- a/Tests/UnitTests/Errors/SignOutWarningViewModelTests.swift
+++ b/Tests/UnitTests/Errors/SignOutWarningViewModelTests.swift
@@ -1,3 +1,4 @@
+import GDSAnalytics
 import GDSCommon
 @testable import OneLogin
 import XCTest
@@ -43,7 +44,29 @@ extension SignOutWarningViewModelTests {
     
     func test_buttonAction() throws {
         XCTAssertFalse(didCallButtonAction)
+        XCTAssertEqual(mockAnalyticsService.eventsLogged.count, 0)
         sut.primaryButtonViewModel.action()
         XCTAssertTrue(didCallButtonAction)
+        XCTAssertEqual(mockAnalyticsService.eventsLogged.count, 1)
+        let event = LinkEvent(textKey: "app_extendedSignInButton",
+                              linkDomain: AppEnvironment.oneLoginBaseURL,
+                              external: .false)
+        XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
+        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["text"], event.parameters["text"])
+        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["type"], event.parameters["type"])
+        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["link_domain"], event.parameters["link_domain"])
+        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["external"], event.parameters["external"])
+    }
+
+    func test_didAppear() {
+        XCTAssertEqual(mockAnalyticsService.screensVisited.count, 0)
+        sut.didAppear()
+        XCTAssertEqual(mockAnalyticsService.screensVisited.count, 1)
+        let screen = ScreenView(id: ErrorAnalyticsScreen.signOutWarning.rawValue,
+                                screen: ErrorAnalyticsScreen.signOutWarning,
+                                titleKey: "app_signOutWarningTitle")
+        XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"], screen.parameters["screen_id"])
     }
 }

--- a/Tests/UnitTests/Errors/SignOutWarningViewModelTests.swift
+++ b/Tests/UnitTests/Errors/SignOutWarningViewModelTests.swift
@@ -52,10 +52,7 @@ extension SignOutWarningViewModelTests {
                               linkDomain: AppEnvironment.oneLoginBaseURL,
                               external: .false)
         XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
-        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["text"], event.parameters["text"])
-        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["type"], event.parameters["type"])
-        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["link_domain"], event.parameters["link_domain"])
-        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["external"], event.parameters["external"])
+        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged, event.parameters)
     }
 
     func test_didAppear() {
@@ -64,7 +61,7 @@ extension SignOutWarningViewModelTests {
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 1)
         let screen = ScreenView(id: ErrorAnalyticsScreen.signOutWarning.rawValue,
                                 screen: ErrorAnalyticsScreen.signOutWarning,
-                                titleKey: "app_signOutWarningTitle")
+                                titleKey: sut.title.stringKey)
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"], screen.parameters["screen_id"])

--- a/Tests/UnitTests/Errors/SignOutWarningViewModelTests.swift
+++ b/Tests/UnitTests/Errors/SignOutWarningViewModelTests.swift
@@ -63,7 +63,6 @@ extension SignOutWarningViewModelTests {
                                 screen: ErrorAnalyticsScreen.signOutWarning,
                                 titleKey: sut.title.stringKey)
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"], screen.parameters["screen_id"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
     }
 }

--- a/Tests/UnitTests/Errors/SignOutWarningViewModelTests.swift
+++ b/Tests/UnitTests/Errors/SignOutWarningViewModelTests.swift
@@ -53,6 +53,8 @@ extension SignOutWarningViewModelTests {
                               external: .false)
         XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged, event.parameters)
+        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String, AppTaxonomy.login.rawValue)
+        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level3"] as? String, AppTaxonomy.reauth.rawValue)
     }
 
     func test_didAppear() {
@@ -64,5 +66,7 @@ extension SignOutWarningViewModelTests {
                                 titleKey: sut.title.stringKey)
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
+        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String, AppTaxonomy.login.rawValue)
+        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level3"] as? String, AppTaxonomy.reauth.rawValue)
     }
 }

--- a/Tests/UnitTests/Errors/UnableToLoginErrorViewModelTests.swift
+++ b/Tests/UnitTests/Errors/UnableToLoginErrorViewModelTests.swift
@@ -55,8 +55,6 @@ extension UnableToLoginErrorViewModelTests {
                                      titleKey: "app_signInErrorTitle",
                                      reason: "error description")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"], screen.parameters["screen_id"])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["reason"], screen.parameters["reason"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
     }
 }

--- a/Tests/UnitTests/Login/ViewModels/FaceIDEnrollmentViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/FaceIDEnrollmentViewModelTests.swift
@@ -70,7 +70,6 @@ extension FaceIDEnrollmentViewModelTests {
                                 screen: BiometricEnrollmentAnalyticsScreen.faceIDEnrollment,
                                 titleKey: "app_enableFaceIDTitle")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"], screen.parameters["screen_id"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
     }
 }

--- a/Tests/UnitTests/Login/ViewModels/LoginLoadingViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/LoginLoadingViewModelTests.swift
@@ -33,7 +33,6 @@ extension LoginLoadingViewModelTests {
                                 screen: IntroAnalyticsScreen.loginLoadingScreen,
                                 titleKey: "app_loadingBody")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"], screen.parameters["screen_id"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
     }
 }

--- a/Tests/UnitTests/Login/ViewModels/OneLoginIntroViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/OneLoginIntroViewModelTests.swift
@@ -58,7 +58,6 @@ extension OneLoginIntroViewModelTests {
                                 screen: IntroAnalyticsScreen.welcomeScreen,
                                 titleKey: "app_signInTitle")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"], screen.parameters["screen_id"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
     }
 }

--- a/Tests/UnitTests/Login/ViewModels/PasscodeInformationViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/PasscodeInformationViewModelTests.swift
@@ -57,7 +57,6 @@ extension PasscodeInformationViewModelTests {
                                 screen: InformationAnalyticsScreen.passcode,
                                 titleKey: "app_noPasscodeSetupTitle")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"], screen.parameters["screen_id"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
     }
 }

--- a/Tests/UnitTests/Login/ViewModels/TouchIDEnrollmentViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/TouchIDEnrollmentViewModelTests.swift
@@ -70,7 +70,6 @@ extension TouchIDEnrollmentViewModelTests {
                                 screen: BiometricEnrollmentAnalyticsScreen.touchIDEnrollment,
                                 titleKey: "app_enableTouchIDTitle")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"], screen.parameters["screen_id"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
     }
 }

--- a/Tests/UnitTests/Login/ViewModels/UnlockScreenViewModelTests.swift
+++ b/Tests/UnitTests/Login/ViewModels/UnlockScreenViewModelTests.swift
@@ -37,8 +37,7 @@ extension UnlockScreenViewModelTests {
         XCTAssertEqual(mockAnalyticsService.eventsLogged.count, 1)
         let event = ButtonEvent(textKey: "app_unlockButton")
         XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
-        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["text"], event.parameters["text"])
-        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["type"], event.parameters["type"])
+        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged, event.parameters)
     }
 
     func test_didAppear() throws {
@@ -48,7 +47,6 @@ extension UnlockScreenViewModelTests {
         let screen = ScreenView(screen: BiometricEnrollmentAnalyticsScreen.unlockScreen,
                                 titleKey: "unlock screen")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"], screen.parameters["screen_id"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
     }
 }

--- a/Tests/UnitTests/Mocks/Sessions+Services/Analytics/MockAnalyticsService.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Analytics/MockAnalyticsService.swift
@@ -23,23 +23,19 @@ final class MockAnalyticsService: AnalyticsService {
             XCTFail("Non-string parameters were logged")
             return
         }
+        
         screenParamsLogged = parameters
     }
     
     func trackScreen(_ screen: LoggableScreenV2, parameters: [String: Any]) {
         screensVisited.append(screen.name)
         
-        guard var parameters = parameters as? [String: String] else {
+        guard let parameters = parameters as? [String: String] else {
             XCTFail("Non-string parameters were logged")
             return
         }
 
-        parameters["AnalyticsParameterScreenClass"] = screen.type.name
-        parameters["AnalyticsParameterScreenName"] = screen.name
-        
-        screenParamsLogged["title"] = parameters["title"]
-        screenParamsLogged["screen_id"] = parameters["screen_id"]
-        screenParamsLogged["reason"] = parameters["reason"]
+        screenParamsLogged = parameters
     }
     
     
@@ -50,6 +46,7 @@ final class MockAnalyticsService: AnalyticsService {
             XCTFail("Non-string parameters were logged")
             return
         }
+        
         eventsParamsLogged = parameters
     }
     

--- a/Tests/UnitTests/Mocks/Sessions+Services/Analytics/MockAnalyticsService.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Analytics/MockAnalyticsService.swift
@@ -39,6 +39,7 @@ final class MockAnalyticsService: AnalyticsService {
         
         screenParamsLogged["title"] = parameters["title"]
         screenParamsLogged["screen_id"] = parameters["screen_id"]
+        screenParamsLogged["reason"] = parameters["reason"]
     }
     
     

--- a/Tests/UnitTests/Mocks/Sessions+Services/Analytics/MockAnalyticsService.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Analytics/MockAnalyticsService.swift
@@ -37,7 +37,8 @@ final class MockAnalyticsService: AnalyticsService {
         parameters["AnalyticsParameterScreenClass"] = screen.type.name
         parameters["AnalyticsParameterScreenName"] = screen.name
         
-        screenParamsLogged = parameters
+        screenParamsLogged["title"] = parameters["title"]
+        screenParamsLogged["screen_id"] = parameters["screen_id"]
     }
     
     

--- a/Tests/UnitTests/Screens/Home/HomeTabViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Home/HomeTabViewModelTests.swift
@@ -38,7 +38,7 @@ extension HomeTabViewModelTests {
                                 titleKey: "app_homeTitle")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String, "home")
+        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String, AppTaxonomy.home.rawValue)
         XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level3"] as? String, "undefined")
     }
 }

--- a/Tests/UnitTests/Screens/Home/HomeTabViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Home/HomeTabViewModelTests.swift
@@ -37,8 +37,7 @@ extension HomeTabViewModelTests {
                                 screen: HomeAnalyticsScreen.homeScreen,
                                 titleKey: "app_homeTitle")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"], screen.parameters["screen_id"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
         XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String, "home")
         XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level3"] as? String, "undefined")
     }

--- a/Tests/UnitTests/Screens/Profile/ProfileTabViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Profile/ProfileTabViewModelTests.swift
@@ -38,7 +38,7 @@ extension ProfileTabViewModelTests {
                                 titleKey: "app_profileTitle")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String, "profile")
+        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String, AppTaxonomy.profile.rawValue)
         XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level3"] as? String, "my profile")
     }
 }

--- a/Tests/UnitTests/Screens/Profile/ProfileTabViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Profile/ProfileTabViewModelTests.swift
@@ -37,8 +37,7 @@ extension ProfileTabViewModelTests {
                                 screen: ProfileAnalyticsScreen.profileScreen,
                                 titleKey: "app_profileTitle")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"], screen.parameters["screen_id"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
         XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String, "profile")
         XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level3"] as? String, "my profile")
     }

--- a/Tests/UnitTests/Screens/Profile/SignOutPageViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Profile/SignOutPageViewModelTests.swift
@@ -75,8 +75,7 @@ extension SignOutPageViewModelTests {
                                 screen: ProfileAnalyticsScreen.signOutScreen,
                                 titleKey: "app_signOutConfirmationTitle")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["title"], screen.parameters["title"])
-        XCTAssertEqual(mockAnalyticsService.screenParamsLogged["screen_id"], screen.parameters["screen_id"])
+        XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
     }
     
     func test_didDismiss() throws {
@@ -85,8 +84,7 @@ extension SignOutPageViewModelTests {
         XCTAssertEqual(mockAnalyticsService.eventsLogged.count, 1)
         let event = ButtonEvent(textKey: "back")
         XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
-        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["text"], event.parameters["text"])
-        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["type"], event.parameters["type"])
+        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged, event.parameters)
     }
     
     func test_buttonAction() throws {
@@ -97,8 +95,7 @@ extension SignOutPageViewModelTests {
         XCTAssertEqual(mockAnalyticsService.eventsLogged.count, 1)
         let event = ButtonEvent(textKey: "app_signOutAndDeleteAppDataButton")
         XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
-        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["text"], event.parameters["text"])
-        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["type"], event.parameters["type"])
+        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged, event.parameters)
     }
 }
 


### PR DESCRIPTION
# DCMAW-9634: Implement GA4 schema on the 'You have been signed out' page

This implements the GA4 schema for the SignOutWarning screen. 

_Note_: the proposed solution in this PR has meant the `SignOutWarningViewModel` has changed from a struct to a class due to having to rework how the taxonomy is set, as the this schema requires an update to set it for 'reauth'. 

**Log for analytics:**
_Screen:_
```
11.1.0 - [FirebaseAnalytics][I-ACS023072] Event logged. Event name, event params: navigation, {
    external = false;
    ga_debug (_dbg) = 1;
    ga_event_origin (_o) = app;
    ga_realtime (_r) = 1;
    ga_screen (_sn) = you’ve been signed out;
    ga_screen_class (_sc) = signOutWarningScreen;
    ga_screen_id (_si) = 1423121875559033750;
    language = en;
    link_domain = mobile.build.account.gov.uk;
    organisation = <OT1056>;
    primary_publishing_organisation = government digital service - digital identity;
    saved_doc_type = undefined;
    taxonomy_level1 = one login mobile application;
    taxonomy_level2 = login;
    taxonomy_level3 = re auth;
    text = sign in with gov.uk one login;
    type = generic link;
}
```

_ButtonEvent:_
```
11.1.0 - [FirebaseAnalytics][I-ACS023105] Event is not subject to real-time event count daily limit. Marking an event as real-time. Event name, parameters: navigation, {
    external = false;
    ga_debug (_dbg) = 1;
    ga_event_origin (_o) = app;
    ga_realtime (_r) = 1;
    ga_screen (_sn) = you’ve been signed out;
    ga_screen_class (_sc) = signOutWarningScreen;
    ga_screen_id (_si) = 1423121875559033750;
    language = en;
    link_domain = mobile.build.account.gov.uk;
    organisation = <OT1056>;
    primary_publishing_organisation = government digital service - digital identity;
    saved_doc_type = undefined;
    taxonomy_level1 = one login mobile application;
    taxonomy_level2 = login;
    taxonomy_level3 = re auth;
    text = sign in with gov.uk one login;
    type = generic link;
}
```
The screenID is given the value here: `case signOutWarning = "cfc50baa-4b56-4170-9707-cd05b60b6658"` in the `ErrorAnalyticsScreenID` enum in the `ErrorAnalytics` file

**Analytics disabled:**
```
11.1.0 - [FirebaseAnalytics][I-ACS023049] Analytics is disabled. Event not logged
11.1.0 - [FirebaseAnalytics][I-ACS023049] Analytics is disabled. Event not logged
```

**Welsh:**
_Screen:_
```
11.1.0 - [FirebaseAnalytics][I-ACS023105] Event is not subject to real-time event count daily limit. Marking an event as real-time. Event name, parameters: screen_view (_vs), {
    _mst = 1;
    ga_debug (_dbg) = 1;
    ga_event_origin (_o) = app;
    ga_previous_class (_pc) = introWelcomeScreen;
    ga_previous_id (_pi) = -3966439220278464730;
    ga_previous_screen (_pn) = gov.uk one login;
    ga_realtime (_r) = 1;
    ga_screen (_sn) = you’ve been signed out;
    ga_screen_class (_sc) = signOutWarningScreen;
    ga_screen_id (_si) = -3966439220278464729;
    language = cy;
    organisation = <OT1056>;
    primary_publishing_organisation = government digital service - digital identity;
    saved_doc_type = undefined;
    screen_id = signoutwarningscreen;
    taxonomy_level1 = one login mobile application;
    taxonomy_level2 = login;
    taxonomy_level3 = re auth;
    title = you’ve been signed out;
}
```

_Button:_
```
11.1.0 - [FirebaseAnalytics][I-ACS023105] Event is not subject to real-time event count daily limit. Marking an event as real-time. Event name, parameters: navigation, {
    external = false;
    ga_debug (_dbg) = 1;
    ga_event_origin (_o) = app;
    ga_realtime (_r) = 1;
    ga_screen (_sn) = you’ve been signed out;
    ga_screen_class (_sc) = signOutWarningScreen;
    ga_screen_id (_si) = -3966439220278464729;
    language = cy;
    link_domain = mobile.build.account.gov.uk;
    organisation = <OT1056>;
    primary_publishing_organisation = government digital service - digital identity;
    saved_doc_type = undefined;
    taxonomy_level1 = one login mobile application;
    taxonomy_level2 = login;
    taxonomy_level3 = re auth;
    text = sign in with gov.uk one login;
    type = generic link;
}
```

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
