### PR TITLE
feat: Create SignOutPage when wallet not accessed

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -43,18 +43,10 @@ jobs:
           GIT_CONFIG_NOSYSTEM: "true"
           GIT_CONFIG_GLOBAL: '${{ github.workspace }}/scripts-configs/override-git-config'
         run: |
-          pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-          brew install sonar-scanner
-
           bundle install
 
-          bundle exec fastlane test scheme:"OneLogin" \
-            sonar_token:${{secrets.SONAR_TOKEN}} \
-            workspace:${{github.workspace}} \
-            source_branch:${{github.head_ref}} \
-            target_branch:${{github.base_ref}} \
-            pr_number:$pull_number \
-            testplan:OneLoginUnit
+          bundle exec fastlane testWithoutCoverageForUITests scheme:"OneLoginBuild" \
+            testplan:OneLoginUI
 
       # Check the Quality Gate status.
       - name: SonarQube Quality Gate check

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -43,10 +43,18 @@ jobs:
           GIT_CONFIG_NOSYSTEM: "true"
           GIT_CONFIG_GLOBAL: '${{ github.workspace }}/scripts-configs/override-git-config'
         run: |
+          pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+          brew install sonar-scanner
+
           bundle install
 
-          bundle exec fastlane testWithoutCoverageForUITests scheme:"OneLoginBuild" \
-            testplan:OneLoginUI
+          bundle exec fastlane test scheme:"OneLogin" \
+            sonar_token:${{secrets.SONAR_TOKEN}} \
+            workspace:${{github.workspace}} \
+            source_branch:${{github.head_ref}} \
+            target_branch:${{github.base_ref}} \
+            pr_number:$pull_number \
+            testplan:OneLoginUnit
 
       # Check the Quality Gate status.
       - name: SonarQube Quality Gate check

--- a/MobilePlatformServices/Package.resolved
+++ b/MobilePlatformServices/Package.resolved
@@ -176,8 +176,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-wallet-ios",
       "state" : {
-        "revision" : "c0d632c22fbc51788916cfb18619b1acb00a4b16",
-        "version" : "4.0.0"
+        "revision" : "86e952046f226bccc198572ec598e40f13117d11",
+        "version" : "5.0.0"
       }
     },
     {

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -27,7 +27,7 @@
 		410464F62B29D078000E7CB2 /* UnableToLoginErrorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410464F52B29D078000E7CB2 /* UnableToLoginErrorViewModelTests.swift */; };
 		411D1FD32B73CA74002393D1 /* TouchIDEnrollmentViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 411D1FD22B73CA74002393D1 /* TouchIDEnrollmentViewModelTests.swift */; };
 		41279DD52BFDD9CA00E16537 /* WalletSignOutPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41279DD42BFDD9CA00E16537 /* WalletSignOutPageViewModel.swift */; };
-		41279DD72BFF46DB00E16537 /* SignOutPageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41279DD62BFF46DB00E16537 /* SignOutPageViewModelTests.swift */; };
+		41279DD72BFF46DB00E16537 /* WalletSignOutPageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41279DD62BFF46DB00E16537 /* WalletSignOutPageViewModelTests.swift */; };
 		413C58762BF261D300171C06 /* HomeTabViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413C58752BF261D300171C06 /* HomeTabViewModelTests.swift */; };
 		413C58782BF266A200171C06 /* ProfileTabViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413C58772BF266A200171C06 /* ProfileTabViewModelTests.swift */; };
 		414D98032B8DEC7100E267EF /* UnlockScreenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 414D98022B8DEC7100E267EF /* UnlockScreenViewController.swift */; };
@@ -205,6 +205,7 @@
 		D0BE24472BEBD2E400759529 /* MockJWKSResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BE24462BEBD2E400759529 /* MockJWKSResponse.swift */; };
 		D0BE24492BEBD43300759529 /* MockNetworking in Frameworks */ = {isa = PBXBuildFile; productRef = D0BE24482BEBD43300759529 /* MockNetworking */; };
 		F1B6807E2CA4424400A64971 /* SignOutPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B6807D2CA4424400A64971 /* SignOutPageViewModel.swift */; };
+		F1B680822CA452CD00A64971 /* SignOutPageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B680812CA452CD00A64971 /* SignOutPageViewModelTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -266,7 +267,7 @@
 		410464F52B29D078000E7CB2 /* UnableToLoginErrorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnableToLoginErrorViewModelTests.swift; sourceTree = "<group>"; };
 		411D1FD22B73CA74002393D1 /* TouchIDEnrollmentViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchIDEnrollmentViewModelTests.swift; sourceTree = "<group>"; };
 		41279DD42BFDD9CA00E16537 /* WalletSignOutPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSignOutPageViewModel.swift; sourceTree = "<group>"; };
-		41279DD62BFF46DB00E16537 /* SignOutPageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignOutPageViewModelTests.swift; sourceTree = "<group>"; };
+		41279DD62BFF46DB00E16537 /* WalletSignOutPageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSignOutPageViewModelTests.swift; sourceTree = "<group>"; };
 		412B95A02B0529B800C390B2 /* OneLoginStaging.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = OneLoginStaging.entitlements; sourceTree = "<group>"; };
 		413C58752BF261D300171C06 /* HomeTabViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTabViewModelTests.swift; sourceTree = "<group>"; };
 		413C58772BF266A200171C06 /* ProfileTabViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTabViewModelTests.swift; sourceTree = "<group>"; };
@@ -444,6 +445,7 @@
 		D0BE24442BEBCB5000759529 /* JWTVerifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWTVerifierTests.swift; sourceTree = "<group>"; };
 		D0BE24462BEBD2E400759529 /* MockJWKSResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockJWKSResponse.swift; sourceTree = "<group>"; };
 		F1B6807D2CA4424400A64971 /* SignOutPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignOutPageViewModel.swift; sourceTree = "<group>"; };
+		F1B680812CA452CD00A64971 /* SignOutPageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignOutPageViewModelTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -885,8 +887,9 @@
 		C8514F692C09E4A5008E1433 /* Profile */ = {
 			isa = PBXGroup;
 			children = (
+				F1B680812CA452CD00A64971 /* SignOutPageViewModelTests.swift */,
 				413C58772BF266A200171C06 /* ProfileTabViewModelTests.swift */,
-				41279DD62BFF46DB00E16537 /* SignOutPageViewModelTests.swift */,
+				41279DD62BFF46DB00E16537 /* WalletSignOutPageViewModelTests.swift */,
 			);
 			path = Profile;
 			sourceTree = "<group>";
@@ -1853,6 +1856,7 @@
 				21FA1C502AE18C8B0052136E /* OneLoginIntroViewModelTests.swift in Sources */,
 				C8C343A02B92227C00E92FB9 /* MockAnalyticsPreferenceStore.swift in Sources */,
 				C8AA3B352BF4CF500093A220 /* WalletCoordinatorTests.swift in Sources */,
+				F1B680822CA452CD00A64971 /* SignOutPageViewModelTests.swift in Sources */,
 				C86E223E2BE108140085453F /* DeveloperMenuViewControllerTests.swift in Sources */,
 				7CA719682C846E7600973585 /* URLRequest+AuthorizationTests.swift in Sources */,
 				C8B825C42B98D3E600336146 /* MockSessionManager.swift in Sources */,
@@ -1886,7 +1890,7 @@
 				1E38C0E12B7CE249002B49A0 /* String+TestExtensions.swift in Sources */,
 				41C0F5B92C8F45DA0055C571 /* MockSecureTokenStore.swift in Sources */,
 				D08B0B5C2BD8046200769CEA /* HomeCoordinatorTests.swift in Sources */,
-				41279DD72BFF46DB00E16537 /* SignOutPageViewModelTests.swift in Sources */,
+				41279DD72BFF46DB00E16537 /* WalletSignOutPageViewModelTests.swift in Sources */,
 				219602022A976305008F3427 /* TabManagerCoordinatorTests.swift in Sources */,
 				C8BADD272B87AEEA00385FE7 /* MockSecureStoreService.swift in Sources */,
 				41D469752B9758A5008705CD /* UnlockScreenViewModelTests.swift in Sources */,

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -26,7 +26,7 @@
 		3BBF28F42A9F7D3200491BB1 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BBF28EE2A9F7D3200491BB1 /* SceneDelegate.swift */; };
 		410464F62B29D078000E7CB2 /* UnableToLoginErrorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410464F52B29D078000E7CB2 /* UnableToLoginErrorViewModelTests.swift */; };
 		411D1FD32B73CA74002393D1 /* TouchIDEnrollmentViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 411D1FD22B73CA74002393D1 /* TouchIDEnrollmentViewModelTests.swift */; };
-		41279DD52BFDD9CA00E16537 /* SignOutPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41279DD42BFDD9CA00E16537 /* SignOutPageViewModel.swift */; };
+		41279DD52BFDD9CA00E16537 /* WalletSignOutPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41279DD42BFDD9CA00E16537 /* WalletSignOutPageViewModel.swift */; };
 		41279DD72BFF46DB00E16537 /* SignOutPageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41279DD62BFF46DB00E16537 /* SignOutPageViewModelTests.swift */; };
 		413C58762BF261D300171C06 /* HomeTabViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413C58752BF261D300171C06 /* HomeTabViewModelTests.swift */; };
 		413C58782BF266A200171C06 /* ProfileTabViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413C58772BF266A200171C06 /* ProfileTabViewModelTests.swift */; };
@@ -204,6 +204,7 @@
 		D0BE24452BEBCB5000759529 /* JWTVerifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BE24442BEBCB5000759529 /* JWTVerifierTests.swift */; };
 		D0BE24472BEBD2E400759529 /* MockJWKSResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BE24462BEBD2E400759529 /* MockJWKSResponse.swift */; };
 		D0BE24492BEBD43300759529 /* MockNetworking in Frameworks */ = {isa = PBXBuildFile; productRef = D0BE24482BEBD43300759529 /* MockNetworking */; };
+		F1B6807E2CA4424400A64971 /* SignOutPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B6807D2CA4424400A64971 /* SignOutPageViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -264,7 +265,7 @@
 		3BBF28F52A9F7D4900491BB1 /* OneLogin-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "OneLogin-Info.plist"; sourceTree = "<group>"; };
 		410464F52B29D078000E7CB2 /* UnableToLoginErrorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnableToLoginErrorViewModelTests.swift; sourceTree = "<group>"; };
 		411D1FD22B73CA74002393D1 /* TouchIDEnrollmentViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchIDEnrollmentViewModelTests.swift; sourceTree = "<group>"; };
-		41279DD42BFDD9CA00E16537 /* SignOutPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignOutPageViewModel.swift; sourceTree = "<group>"; };
+		41279DD42BFDD9CA00E16537 /* WalletSignOutPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSignOutPageViewModel.swift; sourceTree = "<group>"; };
 		41279DD62BFF46DB00E16537 /* SignOutPageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignOutPageViewModelTests.swift; sourceTree = "<group>"; };
 		412B95A02B0529B800C390B2 /* OneLoginStaging.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = OneLoginStaging.entitlements; sourceTree = "<group>"; };
 		413C58752BF261D300171C06 /* HomeTabViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTabViewModelTests.swift; sourceTree = "<group>"; };
@@ -442,6 +443,7 @@
 		D0BE24422BEBB06700759529 /* JWKInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWKInfo.swift; sourceTree = "<group>"; };
 		D0BE24442BEBCB5000759529 /* JWTVerifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWTVerifierTests.swift; sourceTree = "<group>"; };
 		D0BE24462BEBD2E400759529 /* MockJWKSResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockJWKSResponse.swift; sourceTree = "<group>"; };
+		F1B6807D2CA4424400A64971 /* SignOutPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignOutPageViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -588,7 +590,8 @@
 		41279DD32BFDD9A700E16537 /* SignOutConfirmation */ = {
 			isa = PBXGroup;
 			children = (
-				41279DD42BFDD9CA00E16537 /* SignOutPageViewModel.swift */,
+				F1B6807D2CA4424400A64971 /* SignOutPageViewModel.swift */,
+				41279DD42BFDD9CA00E16537 /* WalletSignOutPageViewModel.swift */,
 			);
 			path = SignOutConfirmation;
 			sourceTree = "<group>";
@@ -1735,6 +1738,7 @@
 				7C7A76412C945B1500EE85CB /* Notification+Session.swift in Sources */,
 				C81ECB1B2B71709500AFC3A6 /* EnrolmentCoordinator.swift in Sources */,
 				D0BE24472BEBD2E400759529 /* MockJWKSResponse.swift in Sources */,
+				F1B6807E2CA4424400A64971 /* SignOutPageViewModel.swift in Sources */,
 				C87913C42B27B7A300545B33 /* ErrorAnalytics.swift in Sources */,
 				C8514F6D2C09EC18008E1433 /* HomeTabAnalytics.swift in Sources */,
 				D08B0B8A2BDFEBA600769CEA /* TabbedViewSectionModel.swift in Sources */,
@@ -1813,7 +1817,7 @@
 				C851FFA22BADA4B200A7B73D /* SceneLifecycle.swift in Sources */,
 				D08B0B812BDC0D7100769CEA /* TabbedTableViewCell.swift in Sources */,
 				C86B706B2B8E43DC00F4C9BF /* AnalyticsPreferenceViewModel.swift in Sources */,
-				41279DD52BFDD9CA00E16537 /* SignOutPageViewModel.swift in Sources */,
+				41279DD52BFDD9CA00E16537 /* WalletSignOutPageViewModel.swift in Sources */,
 				C8ECA12A2BB5957500722218 /* WalletCoordinator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk.git",
       "state" : {
-        "revision" : "9118aca998dbe2ceac45d64b21a91c6376928df7",
-        "version" : "11.1.0"
+        "revision" : "1fc52ab0e172e7c5a961f975a76c2611f4f22852",
+        "version" : "11.2.0"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/leveldb.git",
       "state" : {
-        "revision" : "9d108e9112aa1d65ce508facf804674546116d9c",
-        "version" : "1.22.3"
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
       }
     },
     {
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-common.git",
       "state" : {
-        "revision" : "e21d187d2b1a41204b1a4488c8caae08fbd4c62e",
-        "version" : "2.2.0"
+        "revision" : "2020d39df5cfc2788eaf04e49a83585ddaabec38",
+        "version" : "2.4.0"
       }
     },
     {
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-coordination.git",
       "state" : {
-        "revision" : "207e8aaa1ed98ffe5cd32a7f03df754c8446fec8",
-        "version" : "1.2.0"
+        "revision" : "d4ac8868dcb52e0bb6beb121f6ec9adde52e4cfc",
+        "version" : "1.2.1"
       }
     },
     {
@@ -167,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-secure-store",
       "state" : {
-        "revision" : "9d437ef2e55c8aedd41e654b5f6a52e126421625",
-        "version" : "1.0.0"
+        "revision" : "7ae407442d56c46f17b23e6d0c873a33aadfcb86",
+        "version" : "1.0.1"
       }
     },
     {
@@ -203,8 +203,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/realm/realm-core.git",
       "state" : {
-        "revision" : "c2552e1d36867cb42b28130e894a81fc17081062",
-        "version" : "14.12.0"
+        "revision" : "e474a8d2270a8b12ac63ac9504e4757e39814b99",
+        "version" : "14.13.0"
       }
     },
     {
@@ -212,8 +212,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/realm/realm-swift",
       "state" : {
-        "revision" : "9815e6c29d43cb5314add5dff8705c5476ab556c",
-        "version" : "10.53.0"
+        "revision" : "863498d37a9f0e72caa65963da9641d8cdfc8228",
+        "version" : "10.54.0"
       }
     },
     {
@@ -221,8 +221,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "f0525da24dc3c6cbb2b6b338b65042bc91cbc4bb",
-        "version" : "3.3.0"
+        "revision" : "81bee98e706aee68d39ed5996db069ef2b313d62",
+        "version" : "3.7.1"
       }
     },
     {
@@ -230,8 +230,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "65e8f29b2d63c4e38e736b25c27b83e012159be8",
-        "version" : "1.25.2"
+        "revision" : "edb6ed4919f7756157fe02f2552b7e3850a538e5",
+        "version" : "1.28.1"
       }
     }
   ],

--- a/Sources/Analytics/Tabs/Profile/ProfileTabAnalytics.swift
+++ b/Sources/Analytics/Tabs/Profile/ProfileTabAnalytics.swift
@@ -3,10 +3,12 @@ import Logging
 
 enum ProfileAnalyticsScreen: String, ScreenType {
     case profileScreen
-    case signOutScreen
+    case signOutScreenWithWallet
+    case signOutScreenNoWallet
 }
 
 enum ProfileAnalyticsScreenID: String {
     case profileScreen = "d6bae235-e427-4e51-8e17-17d2b976a201"
-    case signOutScreen = "17ab1f34-3d1b-4465-9ce6-fe648c2ff06c"
+    case signOutScreenWithWallet = "17ab1f34-3d1b-4465-9ce6-fe648c2ff06c"
+    case signOutScreenNoWallet = "3e50cd12-4ee8-4787-add8-6a2ac7d4a840"
 }

--- a/Sources/Application/SceneDelegate.swift
+++ b/Sources/Application/SceneDelegate.swift
@@ -14,14 +14,14 @@ final class SceneDelegate: UIResponder,
 
     private var rootCoordinator: QualifyingCoordinator?
 
-    private let walletAvailibilityService = WalletAvailabilityService()
+    private let walletAvailabilityService = WalletAvailabilityService()
     private lazy var networkClient = NetworkClient()
     private lazy var sessionManager = {
         let manager = PersistentSessionManager()
         networkClient.authorizationProvider = manager.tokenProvider
 
         manager.registerSessionBoundData(WalletSessionData())
-        manager.registerSessionBoundData(walletAvailibilityService)
+        manager.registerSessionBoundData(walletAvailabilityService)
         manager.registerSessionBoundData(analyticsCenter)
 
         return manager
@@ -53,7 +53,7 @@ final class SceneDelegate: UIResponder,
             appQualifyingService: appQualifyingService,
             sessionManager: sessionManager,
             networkClient: networkClient,
-            walletAvailibilityService: walletAvailibilityService
+            walletAvailabilityService: walletAvailabilityService
         )
         rootCoordinator?.start()
         

--- a/Sources/Application/SceneDelegate.swift
+++ b/Sources/Application/SceneDelegate.swift
@@ -14,12 +14,14 @@ final class SceneDelegate: UIResponder,
 
     private var rootCoordinator: QualifyingCoordinator?
 
+    private let walletAvailibilityService = WalletAvailabilityService()
     private lazy var networkClient = NetworkClient()
     private lazy var sessionManager = {
         let manager = PersistentSessionManager()
         networkClient.authorizationProvider = manager.tokenProvider
 
         manager.registerSessionBoundData(WalletSessionData())
+        manager.registerSessionBoundData(walletAvailibilityService)
         manager.registerSessionBoundData(analyticsCenter)
 
         return manager
@@ -50,10 +52,11 @@ final class SceneDelegate: UIResponder,
             analyticsCenter: analyticsCenter,
             appQualifyingService: appQualifyingService,
             sessionManager: sessionManager,
-            networkClient: networkClient
+            networkClient: networkClient,
+            walletAvailibilityService: walletAvailibilityService
         )
         rootCoordinator?.start()
-
+        
         setUpBasicUI()
     }
     

--- a/Sources/Qualification/QualifyingCoordinator.swift
+++ b/Sources/Qualification/QualifyingCoordinator.swift
@@ -22,6 +22,7 @@ final class QualifyingCoordinator: NSObject,
     private let appQualifyingService: QualifyingService
     private let sessionManager: SessionManager
     private let networkClient: NetworkClient
+    private let walletAvailibilityService: WalletFeatureAvailabilityService
 
     private var loginCoordinator: LoginCoordinator? {
         childCoordinators.firstInstanceOf(LoginCoordinator.self)
@@ -44,12 +45,14 @@ final class QualifyingCoordinator: NSObject,
          analyticsCenter: AnalyticsCentral,
          appQualifyingService: QualifyingService,
          sessionManager: SessionManager,
-         networkClient: NetworkClient) {
+         networkClient: NetworkClient,
+         walletAvailibilityService: WalletFeatureAvailabilityService) {
         self.window = window
         self.appQualifyingService = appQualifyingService
         self.analyticsCenter = analyticsCenter
         self.sessionManager = sessionManager
         self.networkClient = networkClient
+        self.walletAvailibilityService = walletAvailibilityService
         super.init()
         self.appQualifyingService.delegate = self
     }
@@ -123,7 +126,8 @@ final class QualifyingCoordinator: NSObject,
                 root: UITabBarController(),
                 analyticsCenter: analyticsCenter,
                 networkClient: networkClient,
-                sessionManager: sessionManager)
+                sessionManager: sessionManager,
+                walletAvailabilityService: walletAvailibilityService)
             displayChildCoordinator(tabManagerCoordinator)
         }
     }

--- a/Sources/Qualification/QualifyingCoordinator.swift
+++ b/Sources/Qualification/QualifyingCoordinator.swift
@@ -22,7 +22,7 @@ final class QualifyingCoordinator: NSObject,
     private let appQualifyingService: QualifyingService
     private let sessionManager: SessionManager
     private let networkClient: NetworkClient
-    private let walletAvailibilityService: WalletFeatureAvailabilityService
+    private let walletAvailabilityService: WalletFeatureAvailabilityService
 
     private var loginCoordinator: LoginCoordinator? {
         childCoordinators.firstInstanceOf(LoginCoordinator.self)
@@ -46,13 +46,13 @@ final class QualifyingCoordinator: NSObject,
          appQualifyingService: QualifyingService,
          sessionManager: SessionManager,
          networkClient: NetworkClient,
-         walletAvailibilityService: WalletFeatureAvailabilityService) {
+         walletAvailabilityService: WalletFeatureAvailabilityService) {
         self.window = window
         self.appQualifyingService = appQualifyingService
         self.analyticsCenter = analyticsCenter
         self.sessionManager = sessionManager
         self.networkClient = networkClient
-        self.walletAvailibilityService = walletAvailibilityService
+        self.walletAvailabilityService = walletAvailabilityService
         super.init()
         self.appQualifyingService.delegate = self
     }
@@ -127,7 +127,7 @@ final class QualifyingCoordinator: NSObject,
                 analyticsCenter: analyticsCenter,
                 networkClient: networkClient,
                 sessionManager: sessionManager,
-                walletAvailabilityService: walletAvailibilityService)
+                walletAvailabilityService: walletAvailabilityService)
             displayChildCoordinator(tabManagerCoordinator)
         }
     }

--- a/Sources/Resources/cy-GB.lproj/Localizable.strings
+++ b/Sources/Resources/cy-GB.lproj/Localizable.strings
@@ -145,6 +145,18 @@
 
 "app_signOutAndDeleteAppDataButton" = "Allgofnodwch a dileu data yr ap";
 
+// Mark: Sign Out Confirmation screen no Wallet displayed
+"app_signOutConfirmationTitleNoWallet" = "Ydych chi'n siŵr eich bod eisiau allgofnodi?";
+
+"app_signOutConfirmationBody1NoWallet" = "Bydd allgofnodi yn difodd eich dewisiadau am:";
+
+"app_signOutConfirmationBullet1iOSNoWallet" = "ddefnyddio Touch ID neu Face ID i ddatgloi'r ap";
+
+"app_signOutConfirmationBullet2NoWallet" = "rhannu dadansoddeg am sut rydych yn defnyddio'r ap";
+
+"app_signOutConfirmationBody2NoWallet" = "Gofynnir i chi osod y dewisiadau hyn eto y tro nesaf y byddwch yn mewngofnodi.";
+
+"app_signOutAndDeletePreferences" = "Allgofnodi a dileu dewisiadau";
 
 // Mark: Sign Out Error screen
 "app_signOutErrorTitle" = "Roedd problem wrth eich allgofnodi";

--- a/Sources/Resources/en.lproj/Localizable.strings
+++ b/Sources/Resources/en.lproj/Localizable.strings
@@ -145,6 +145,19 @@
 
 "app_signOutAndDeleteAppDataButton" = "Sign out and delete app data";
 
+// Mark: Sign Out Confirmation screen no Wallet displayed
+"app_signOutConfirmationTitleNoWallet" = "Are you sure you want to sign out?";
+
+"app_signOutConfirmationBody1NoWallet" = "Signing out will switch off your preferences for:";
+
+"app_signOutConfirmationBullet1iOSNoWallet" = "using Touch ID or Face ID to unlock the app";
+
+"app_signOutConfirmationBullet2NoWallet" = "sharing analytics about how you use the app";
+
+"app_signOutConfirmationBody2NoWallet" = "You’ll be asked to set these preferences again next time you sign in.";
+
+"app_signOutAndDeletePreferences" = "Sign out and delete preferences";
+
 
 // Mark: Sign Out Error screen
 "app_signOutErrorTitle" = "There was a problem signing you out";

--- a/Sources/Screens/SignOutConfirmation/SignOutPageViewModel.swift
+++ b/Sources/Screens/SignOutConfirmation/SignOutPageViewModel.swift
@@ -18,7 +18,7 @@ struct SignOutPageViewModel: GDSInstructionsViewModel, BaseViewModel {
          buttonAction: @escaping () -> Void) {
         self.analyticsService = analyticsService
         self.buttonViewModel = AnalyticsButtonViewModel(titleKey: "app_signOutAndDeletePreferences",
-                                                        backgroundColor: .gdsRed,
+                                                        backgroundColor: .gdsGreen,
                                                         analyticsService: analyticsService) {
             buttonAction()
         }

--- a/Sources/Screens/SignOutConfirmation/SignOutPageViewModel.swift
+++ b/Sources/Screens/SignOutConfirmation/SignOutPageViewModel.swift
@@ -4,7 +4,7 @@ import Logging
 import UIKit
 
 struct SignOutPageViewModel: GDSInstructionsViewModel, BaseViewModel {
-    let title: GDSLocalisedString = "app_signOutConfirmationTitle"
+    let title: GDSLocalisedString = "app_signOutConfirmationTitleNoWallet"
     let body: String = GDSLocalisedString(stringLiteral: "app_signOutConfirmationBody1").value
     var childView = UIView()
     let buttonViewModel: any ButtonViewModel
@@ -17,7 +17,7 @@ struct SignOutPageViewModel: GDSInstructionsViewModel, BaseViewModel {
     init(analyticsService: AnalyticsService,
          buttonAction: @escaping () -> Void) {
         self.analyticsService = analyticsService
-        self.buttonViewModel = AnalyticsButtonViewModel(titleKey: "app_signOutAndDeleteAppDataButton",
+        self.buttonViewModel = AnalyticsButtonViewModel(titleKey: "app_signOutAndDeletePreferences",
                                                         backgroundColor: .gdsRed,
                                                         analyticsService: analyticsService) {
             buttonAction()
@@ -26,8 +26,8 @@ struct SignOutPageViewModel: GDSInstructionsViewModel, BaseViewModel {
     }
     
     func didAppear() {
-        let screen = ScreenView(id: ProfileAnalyticsScreenID.signOutScreen.rawValue,
-                                screen: ProfileAnalyticsScreen.signOutScreen,
+        let screen = ScreenView(id: ProfileAnalyticsScreenID.signOutScreenNoWallet.rawValue,
+                                screen: ProfileAnalyticsScreen.signOutScreenNoWallet,
                                 titleKey: title.stringKey)
         analyticsService.trackScreen(screen)
     }
@@ -40,15 +40,14 @@ struct SignOutPageViewModel: GDSInstructionsViewModel, BaseViewModel {
     private func configureStackView() -> UIView {
         let bulletView: BulletView = BulletView(title: nil,
                                                 text: [
-                                                    GDSLocalisedString(stringLiteral: "app_signOutConfirmationBullet1").value,
-                                                    GDSLocalisedString(stringLiteral: "app_signOutConfirmationBullet2").value,
-                                                    GDSLocalisedString(stringLiteral: "app_signOutConfirmationBullet3").value
+                                                    GDSLocalisedString(stringLiteral: "app_signOutConfirmationBullet1iOSNoWallet").value,
+                                                    GDSLocalisedString(stringLiteral: "app_signOutConfirmationBullet2NoWallet").value
                                                 ])
-        bulletView.accessibilityIdentifier = "sign-out-bullet-list"
+        bulletView.accessibilityIdentifier = "sign-out-bullet-list-wallet"
         
         let body2Label = {
             let label = UILabel()
-            label.text = GDSLocalisedString(stringLiteral: "app_signOutConfirmationBody2").value
+            label.text = GDSLocalisedString(stringLiteral: "app_signOutConfirmationBody2NoWallet").value
             label.adjustsFontForContentSizeCategory = true
             label.numberOfLines = 0
             label.font = .bodyBold
@@ -56,17 +55,7 @@ struct SignOutPageViewModel: GDSInstructionsViewModel, BaseViewModel {
             return label
         }()
         
-        let body3Label = {
-            let label = UILabel()
-            label.text = GDSLocalisedString(stringLiteral: "app_signOutConfirmationBody3").value
-            label.adjustsFontForContentSizeCategory = true
-            label.numberOfLines = 0
-            label.font = .body
-            label.accessibilityIdentifier = "sign-out-body3-text"
-            return label
-        }()
-        
-        let stackView = UIStackView(arrangedSubviews: [bulletView, body2Label, body3Label])
+        let stackView = UIStackView(arrangedSubviews: [bulletView, body2Label])
         stackView.axis = .vertical
         stackView.alignment = .top
         stackView.spacing = 12

--- a/Sources/Screens/SignOutConfirmation/SignOutPageViewModel.swift
+++ b/Sources/Screens/SignOutConfirmation/SignOutPageViewModel.swift
@@ -5,7 +5,7 @@ import UIKit
 
 struct SignOutPageViewModel: GDSInstructionsViewModel, BaseViewModel {
     let title: GDSLocalisedString = "app_signOutConfirmationTitleNoWallet"
-    let body: String = GDSLocalisedString(stringLiteral: "app_signOutConfirmationBody1").value
+    let body: String = GDSLocalisedString(stringLiteral: "app_signOutConfirmationBody1NoWallet").value
     var childView = UIView()
     let buttonViewModel: any ButtonViewModel
     let secondaryButtonViewModel: (any ButtonViewModel)? = nil
@@ -43,7 +43,7 @@ struct SignOutPageViewModel: GDSInstructionsViewModel, BaseViewModel {
                                                     GDSLocalisedString(stringLiteral: "app_signOutConfirmationBullet1iOSNoWallet").value,
                                                     GDSLocalisedString(stringLiteral: "app_signOutConfirmationBullet2NoWallet").value
                                                 ])
-        bulletView.accessibilityIdentifier = "sign-out-bullet-list-wallet"
+        bulletView.accessibilityIdentifier = "sign-out-bullet-list-no-wallet"
         
         let body2Label = {
             let label = UILabel()
@@ -51,7 +51,7 @@ struct SignOutPageViewModel: GDSInstructionsViewModel, BaseViewModel {
             label.adjustsFontForContentSizeCategory = true
             label.numberOfLines = 0
             label.font = .bodyBold
-            label.accessibilityIdentifier = "sign-out-body2-text"
+            label.accessibilityIdentifier = "sign-out-body2-text-no-wallet"
             return label
         }()
         
@@ -59,7 +59,7 @@ struct SignOutPageViewModel: GDSInstructionsViewModel, BaseViewModel {
         stackView.axis = .vertical
         stackView.alignment = .top
         stackView.spacing = 12
-        stackView.accessibilityIdentifier = "sign-out-stack-view"
+        stackView.accessibilityIdentifier = "sign-out-stack-view-no-wallet"
         return stackView
     }
 }

--- a/Sources/Screens/SignOutConfirmation/WalletSignOutPageViewModel.swift
+++ b/Sources/Screens/SignOutConfirmation/WalletSignOutPageViewModel.swift
@@ -1,0 +1,76 @@
+import GDSAnalytics
+import GDSCommon
+import Logging
+import UIKit
+
+struct WalletSignOutPageViewModel: GDSInstructionsViewModel, BaseViewModel {
+    let title: GDSLocalisedString = "app_signOutConfirmationTitle"
+    let body: String = GDSLocalisedString(stringLiteral: "app_signOutConfirmationBody1").value
+    var childView = UIView()
+    let buttonViewModel: any ButtonViewModel
+    let secondaryButtonViewModel: (any ButtonViewModel)? = nil
+    let analyticsService: AnalyticsService
+    
+    let rightBarButtonTitle: GDSLocalisedString? = "app_cancelButton"
+    let backButtonIsHidden: Bool = true
+    
+    init(analyticsService: AnalyticsService,
+         buttonAction: @escaping () -> Void) {
+        self.analyticsService = analyticsService
+        self.buttonViewModel = AnalyticsButtonViewModel(titleKey: "app_signOutAndDeleteAppDataButton",
+                                                        backgroundColor: .gdsRed,
+                                                        analyticsService: analyticsService) {
+            buttonAction()
+        }
+        self.childView = configureStackView()
+    }
+    
+    func didAppear() {
+        let screen = ScreenView(id: ProfileAnalyticsScreenID.signOutScreen.rawValue,
+                                screen: ProfileAnalyticsScreen.signOutScreen,
+                                titleKey: title.stringKey)
+        analyticsService.trackScreen(screen)
+    }
+    
+    func didDismiss() {
+        let event = ButtonEvent(textKey: "back")
+        analyticsService.logEvent(event)
+    }
+    
+    private func configureStackView() -> UIView {
+        let bulletView: BulletView = BulletView(title: nil,
+                                                text: [
+                                                    GDSLocalisedString(stringLiteral: "app_signOutConfirmationBullet1").value,
+                                                    GDSLocalisedString(stringLiteral: "app_signOutConfirmationBullet2").value,
+                                                    GDSLocalisedString(stringLiteral: "app_signOutConfirmationBullet3").value
+                                                ])
+        bulletView.accessibilityIdentifier = "sign-out-bullet-list"
+        
+        let body2Label = {
+            let label = UILabel()
+            label.text = GDSLocalisedString(stringLiteral: "app_signOutConfirmationBody2").value
+            label.adjustsFontForContentSizeCategory = true
+            label.numberOfLines = 0
+            label.font = .bodyBold
+            label.accessibilityIdentifier = "sign-out-body2-text"
+            return label
+        }()
+        
+        let body3Label = {
+            let label = UILabel()
+            label.text = GDSLocalisedString(stringLiteral: "app_signOutConfirmationBody3").value
+            label.adjustsFontForContentSizeCategory = true
+            label.numberOfLines = 0
+            label.font = .body
+            label.accessibilityIdentifier = "sign-out-body3-text"
+            return label
+        }()
+        
+        let stackView = UIStackView(arrangedSubviews: [bulletView, body2Label, body3Label])
+        stackView.axis = .vertical
+        stackView.alignment = .top
+        stackView.spacing = 12
+        stackView.accessibilityIdentifier = "sign-out-stack-view"
+        return stackView
+    }
+}

--- a/Sources/Screens/SignOutConfirmation/WalletSignOutPageViewModel.swift
+++ b/Sources/Screens/SignOutConfirmation/WalletSignOutPageViewModel.swift
@@ -26,8 +26,8 @@ struct WalletSignOutPageViewModel: GDSInstructionsViewModel, BaseViewModel {
     }
     
     func didAppear() {
-        let screen = ScreenView(id: ProfileAnalyticsScreenID.signOutScreen.rawValue,
-                                screen: ProfileAnalyticsScreen.signOutScreen,
+        let screen = ScreenView(id: ProfileAnalyticsScreenID.signOutScreenWithWallet.rawValue,
+                                screen: ProfileAnalyticsScreen.signOutScreenWithWallet,
                                 titleKey: title.stringKey)
         analyticsService.trackScreen(screen)
     }

--- a/Sources/Screens/SignOutConfirmation/WalletSignOutPageViewModel.swift
+++ b/Sources/Screens/SignOutConfirmation/WalletSignOutPageViewModel.swift
@@ -44,7 +44,7 @@ struct WalletSignOutPageViewModel: GDSInstructionsViewModel, BaseViewModel {
                                                     GDSLocalisedString(stringLiteral: "app_signOutConfirmationBullet2").value,
                                                     GDSLocalisedString(stringLiteral: "app_signOutConfirmationBullet3").value
                                                 ])
-        bulletView.accessibilityIdentifier = "sign-out-bullet-list"
+        bulletView.accessibilityIdentifier = "sign-out-bullet-list-with-wallet"
         
         let body2Label = {
             let label = UILabel()
@@ -52,7 +52,7 @@ struct WalletSignOutPageViewModel: GDSInstructionsViewModel, BaseViewModel {
             label.adjustsFontForContentSizeCategory = true
             label.numberOfLines = 0
             label.font = .bodyBold
-            label.accessibilityIdentifier = "sign-out-body2-text"
+            label.accessibilityIdentifier = "sign-out-body2-text-with-wallet"
             return label
         }()
         
@@ -62,7 +62,7 @@ struct WalletSignOutPageViewModel: GDSInstructionsViewModel, BaseViewModel {
             label.adjustsFontForContentSizeCategory = true
             label.numberOfLines = 0
             label.font = .body
-            label.accessibilityIdentifier = "sign-out-body3-text"
+            label.accessibilityIdentifier = "sign-out-body3-text-with-wallet"
             return label
         }()
         
@@ -70,7 +70,7 @@ struct WalletSignOutPageViewModel: GDSInstructionsViewModel, BaseViewModel {
         stackView.axis = .vertical
         stackView.alignment = .top
         stackView.spacing = 12
-        stackView.accessibilityIdentifier = "sign-out-stack-view"
+        stackView.accessibilityIdentifier = "sign-out-stack-view-with-wallet"
         return stackView
     }
 }

--- a/Sources/Service/WalletAvailabilityService.swift
+++ b/Sources/Service/WalletAvailabilityService.swift
@@ -3,9 +3,10 @@ import Networking
 import UIKit
 
 protocol FeatureAvailabilityService {
-    var hasAccessedBefore: Bool { get }
+    var hasAccessedBefore: Bool { get set }
     var shouldShowFeature: Bool { get }
     func accessedFeature()
+    func resetFeatureState()
 }
 
 protocol UniversalLinkFeatureAvailabilityService {
@@ -16,7 +17,13 @@ typealias WalletFeatureAvailabilityService = FeatureAvailabilityService & Univer
 
 class WalletAvailabilityService: WalletFeatureAvailabilityService {
     var hasAccessedBefore: Bool {
-        UserDefaults.standard.bool(forKey: "hasAccessedWalletBefore")
+        get {
+            UserDefaults.standard.bool(forKey: "hasAccessedWalletBefore")
+        }
+        
+        set {
+            UserDefaults.standard.set(newValue, forKey: "hasAccessedWalletBefore")
+        }
     }
     
     var shouldShowFeature: Bool {
@@ -41,6 +48,10 @@ class WalletAvailabilityService: WalletFeatureAvailabilityService {
     }
     
     func accessedFeature() {
-        UserDefaults.standard.set(true, forKey: "hasAccessedWalletBefore")
+        hasAccessedBefore = true
+    }
+    
+    func resetFeatureState() {
+        hasAccessedBefore = false
     }
 }

--- a/Sources/Service/WalletAvailabilityService.swift
+++ b/Sources/Service/WalletAvailabilityService.swift
@@ -3,8 +3,9 @@ import Networking
 import UIKit
 
 protocol FeatureAvailabilityService {
+    var hasAccessedBefore: Bool { get }
     var shouldShowFeature: Bool { get }
-    func hasAccessedPreviously()
+    func accessedWalletFeature()
 }
 
 protocol UniversalLinkFeatureAvailabilityService {
@@ -14,10 +15,14 @@ protocol UniversalLinkFeatureAvailabilityService {
 typealias WalletFeatureAvailabilityService = FeatureAvailabilityService & UniversalLinkFeatureAvailabilityService
 
 class WalletAvailabilityService: WalletFeatureAvailabilityService {
+    var hasAccessedBefore: Bool {
+        UserDefaults.standard.bool(forKey: "hasAccessedWalletBefore")
+    }
+    
     var shouldShowFeature: Bool {
         guard AppEnvironment.walletVisibleToAll else {
             guard AppEnvironment.walletVisibleIfExists,
-                  UserDefaults.standard.bool(forKey: "hasAccessedWalletBefore") else {
+                  hasAccessedBefore else {
                 return false
             }
             return true
@@ -35,7 +40,7 @@ class WalletAvailabilityService: WalletFeatureAvailabilityService {
         return true
     }
     
-    func hasAccessedPreviously() {
+    func accessedWalletFeature() {
         UserDefaults.standard.set(true, forKey: "hasAccessedWalletBefore")
     }
 }

--- a/Sources/Service/WalletAvailabilityService.swift
+++ b/Sources/Service/WalletAvailabilityService.swift
@@ -2,20 +2,19 @@ import Foundation
 import Networking
 import UIKit
 
-protocol FeatureAvailabilityService {
+protocol FeatureAvailabilityService: AnyObject {
     var hasAccessedBefore: Bool { get set }
     var shouldShowFeature: Bool { get }
-    func accessedFeature()
-    func resetFeatureState()
 }
 
 protocol UniversalLinkFeatureAvailabilityService {
     var shouldShowFeatureOnUniversalLink: Bool { get }
 }
 
-typealias WalletFeatureAvailabilityService = FeatureAvailabilityService & UniversalLinkFeatureAvailabilityService
+typealias WalletFeatureAvailabilityService = FeatureAvailabilityService & UniversalLinkFeatureAvailabilityService & SessionBoundData
 
 class WalletAvailabilityService: WalletFeatureAvailabilityService {
+
     var hasAccessedBefore: Bool {
         get {
             UserDefaults.standard.bool(forKey: "hasAccessedWalletBefore")
@@ -47,11 +46,7 @@ class WalletAvailabilityService: WalletFeatureAvailabilityService {
         return true
     }
     
-    func accessedFeature() {
-        hasAccessedBefore = true
-    }
-    
-    func resetFeatureState() {
+    func delete() throws {
         hasAccessedBefore = false
     }
 }

--- a/Sources/Service/WalletAvailabilityService.swift
+++ b/Sources/Service/WalletAvailabilityService.swift
@@ -5,7 +5,7 @@ import UIKit
 protocol FeatureAvailabilityService {
     var hasAccessedBefore: Bool { get }
     var shouldShowFeature: Bool { get }
-    func accessedWalletFeature()
+    func accessedFeature()
 }
 
 protocol UniversalLinkFeatureAvailabilityService {
@@ -40,7 +40,7 @@ class WalletAvailabilityService: WalletFeatureAvailabilityService {
         return true
     }
     
-    func accessedWalletFeature() {
+    func accessedFeature() {
         UserDefaults.standard.set(true, forKey: "hasAccessedWalletBefore")
     }
 }

--- a/Sources/Service/WalletAvailabilityService.swift
+++ b/Sources/Service/WalletAvailabilityService.swift
@@ -13,7 +13,7 @@ protocol UniversalLinkFeatureAvailabilityService {
 
 typealias WalletFeatureAvailabilityService = FeatureAvailabilityService & UniversalLinkFeatureAvailabilityService & SessionBoundData
 
-class WalletAvailabilityService: WalletFeatureAvailabilityService {
+final class WalletAvailabilityService: WalletFeatureAvailabilityService {
 
     var hasAccessedBefore: Bool {
         get {

--- a/Sources/Tabs/ProfileCoordinator.swift
+++ b/Sources/Tabs/ProfileCoordinator.swift
@@ -53,7 +53,7 @@ final class ProfileCoordinator: NSObject,
         walletAvailable: Bool,
         navController: UINavigationController
     ) -> GDSInstructionsViewModel {
-        return if (walletAvailable) {
+        return if walletAvailable {
             WalletSignOutPageViewModel(analyticsService: analyticsService) { [unowned self] in
                 navController.dismiss(animated: true) { [unowned self] in
                     finish()

--- a/Sources/Tabs/ProfileCoordinator.swift
+++ b/Sources/Tabs/ProfileCoordinator.swift
@@ -42,7 +42,7 @@ final class ProfileCoordinator: NSObject,
     
     func openSignOutPage() {
         let navController = UINavigationController()
-        let walletAvailable = UserDefaults.standard.bool(forKey: "hasAccessedWalletBefore")
+        let walletAvailable = walletAvailablityService.hasAccessedBefore
         let viewModel = showSignOutConfirmationScreen(walletAvailable: walletAvailable, navController: navController)
         let signOutViewController = GDSInstructionsViewController(viewModel: viewModel)
         navController.setViewControllers([signOutViewController], animated: false)

--- a/Sources/Tabs/ProfileCoordinator.swift
+++ b/Sources/Tabs/ProfileCoordinator.swift
@@ -15,13 +15,16 @@ final class ProfileCoordinator: NSObject,
     private let userProvider: UserProvider
     private let analyticsService: AnalyticsService
     private let urlOpener: URLOpener
+    private let walletAvailablityService: WalletFeatureAvailabilityService
     
     init(userProvider: UserProvider,
          analyticsService: AnalyticsService,
-         urlOpener: URLOpener) {
+         urlOpener: URLOpener,
+         walletAvailabilityService: WalletFeatureAvailabilityService) {
         self.userProvider = userProvider
         self.analyticsService = analyticsService
         self.urlOpener = urlOpener
+        self.walletAvailablityService = walletAvailabilityService
     }
     
     func start() {
@@ -39,13 +42,29 @@ final class ProfileCoordinator: NSObject,
     
     func openSignOutPage() {
         let navController = UINavigationController()
-        let viewModel = SignOutPageViewModel(analyticsService: analyticsService) { [unowned self] in
-            navController.dismiss(animated: true) { [unowned self] in
-                finish()
-            }
-        }
+        let walletAvailable = UserDefaults.standard.bool(forKey: "hasAccessedWalletBefore")
+        let viewModel = showSignOutConfirmationScreen(walletAvailable: walletAvailable, navController: navController)
         let signOutViewController = GDSInstructionsViewController(viewModel: viewModel)
         navController.setViewControllers([signOutViewController], animated: false)
         root.present(navController, animated: true)
+    }
+    
+    private func showSignOutConfirmationScreen(
+        walletAvailable: Bool,
+        navController: UINavigationController
+    ) -> GDSInstructionsViewModel {
+        return if (walletAvailable) {
+            WalletSignOutPageViewModel(analyticsService: analyticsService) { [unowned self] in
+                navController.dismiss(animated: true) { [unowned self] in
+                    finish()
+                }
+            }
+        } else {
+            SignOutPageViewModel(analyticsService: analyticsService) { [unowned self] in
+                navController.dismiss(animated: true) { [unowned self] in
+                    finish()
+                }
+            }
+        }
     }
 }

--- a/Sources/Tabs/TabManagerCoordinator.swift
+++ b/Sources/Tabs/TabManagerCoordinator.swift
@@ -64,7 +64,6 @@ final class TabManagerCoordinator: NSObject,
         guard walletAvailabilityService.shouldShowFeatureOnUniversalLink else {
             return
         }
-        addWalletTab()
         walletCoordinator?.handleUniversalLink(url)
     }
 }
@@ -100,7 +99,8 @@ extension TabManagerCoordinator {
     private func addProfileTab() {
         let pc = ProfileCoordinator(userProvider: sessionManager,
                                     analyticsService: analyticsCenter.analyticsService,
-                                    urlOpener: UIApplication.shared)
+                                    urlOpener: UIApplication.shared,
+                                    walletAvailabilityService: walletAvailabilityService)
         addTab(pc)
     }
 }

--- a/Sources/Tabs/TabManagerCoordinator.swift
+++ b/Sources/Tabs/TabManagerCoordinator.swift
@@ -93,7 +93,7 @@ extension TabManagerCoordinator {
         root.viewControllers?.sort {
             $0.tabBarItem.tag < $1.tabBarItem.tag
         }
-        walletAvailabilityService.hasAccessedPreviously()
+        walletAvailabilityService.accessedWalletFeature()
     }
     
     private func addProfileTab() {

--- a/Sources/Tabs/TabManagerCoordinator.swift
+++ b/Sources/Tabs/TabManagerCoordinator.swift
@@ -64,7 +64,7 @@ final class TabManagerCoordinator: NSObject,
         guard walletAvailabilityService.shouldShowFeatureOnUniversalLink else {
             return
         }
-        if (walletCoordinator == nil) {
+        if walletCoordinator == nil {
             addWalletTab()
         }
         walletCoordinator?.handleUniversalLink(url)

--- a/Sources/Tabs/TabManagerCoordinator.swift
+++ b/Sources/Tabs/TabManagerCoordinator.swift
@@ -139,6 +139,8 @@ extension TabManagerCoordinator: ParentCoordinator {
                     throw SecureStoreError.cantDeleteKey
                 }
                 #endif
+                // Reset the wallet service accessed before state to false
+                walletAvailabilityService.resetFeatureState()
                 try sessionManager.clearAllSessionData()
             } catch {
                 let viewModel = SignOutErrorViewModel(errorDescription: error.localizedDescription,

--- a/Sources/Tabs/TabManagerCoordinator.swift
+++ b/Sources/Tabs/TabManagerCoordinator.swift
@@ -64,6 +64,9 @@ final class TabManagerCoordinator: NSObject,
         guard walletAvailabilityService.shouldShowFeatureOnUniversalLink else {
             return
         }
+        if (walletCoordinator == nil) {
+            addWalletTab()
+        }
         walletCoordinator?.handleUniversalLink(url)
     }
 }
@@ -93,7 +96,7 @@ extension TabManagerCoordinator {
         root.viewControllers?.sort {
             $0.tabBarItem.tag < $1.tabBarItem.tag
         }
-        walletAvailabilityService.accessedWalletFeature()
+        walletAvailabilityService.accessedFeature()
     }
     
     private func addProfileTab() {

--- a/Sources/Tabs/TabManagerCoordinator.swift
+++ b/Sources/Tabs/TabManagerCoordinator.swift
@@ -45,7 +45,7 @@ final class TabManagerCoordinator: NSObject,
          analyticsCenter: AnalyticsCentral,
          networkClient: NetworkClient,
          sessionManager: SessionManager,
-         walletAvailabilityService: WalletFeatureAvailabilityService = WalletAvailabilityService()) {
+         walletAvailabilityService: WalletFeatureAvailabilityService) {
         self.appWindow = appWindow
         self.root = root
         self.analyticsCenter = analyticsCenter
@@ -96,7 +96,7 @@ extension TabManagerCoordinator {
         root.viewControllers?.sort {
             $0.tabBarItem.tag < $1.tabBarItem.tag
         }
-        walletAvailabilityService.accessedFeature()
+        walletAvailabilityService.hasAccessedBefore = true
     }
     
     private func addProfileTab() {
@@ -139,8 +139,6 @@ extension TabManagerCoordinator: ParentCoordinator {
                     throw SecureStoreError.cantDeleteKey
                 }
                 #endif
-                // Reset the wallet service accessed before state to false
-                walletAvailabilityService.resetFeatureState()
                 try sessionManager.clearAllSessionData()
             } catch {
                 let viewModel = SignOutErrorViewModel(errorDescription: error.localizedDescription,

--- a/Tests/UnitTests/Application/SceneLifecycleTests.swift
+++ b/Tests/UnitTests/Application/SceneLifecycleTests.swift
@@ -10,6 +10,7 @@ final class SceneLifecycleTests: XCTestCase {
     var mockAnalyticsPreferenceStore: MockAnalyticsPreferenceStore!
     var mockAnalyticsCenter: MockAnalyticsCenter!
     var mockSessionManager: MockSessionManager!
+    var mockWalletAvailabilityService: MockWalletAvailabilityService!
     var mockTabManagerCoordinator: TabManagerCoordinator!
     var sut: MockSceneDelegate!
     
@@ -21,11 +22,13 @@ final class SceneLifecycleTests: XCTestCase {
         mockAnalyticsCenter = MockAnalyticsCenter(analyticsService: mockAnalyticsService,
                                                   analyticsPreferenceStore: mockAnalyticsPreferenceStore)
         mockSessionManager = MockSessionManager()
+        mockWalletAvailabilityService = MockWalletAvailabilityService()
         mockTabManagerCoordinator = TabManagerCoordinator(appWindow: window,
                                               root: UITabBarController(),
                                               analyticsCenter: mockAnalyticsCenter,
                                               networkClient: NetworkClient(),
-                                              sessionManager: mockSessionManager)
+                                              sessionManager: mockSessionManager,
+                                              walletAvailabilityService: mockWalletAvailabilityService)
         sut = MockSceneDelegate(coordinator: mockTabManagerCoordinator,
                                 analyticsService: mockAnalyticsService)
     }
@@ -37,6 +40,7 @@ final class SceneLifecycleTests: XCTestCase {
         mockAnalyticsCenter = nil
         mockSessionManager = nil
         mockTabManagerCoordinator = nil
+        mockWalletAvailabilityService = nil
         sut = nil
         
         super.tearDown()

--- a/Tests/UnitTests/Application/TabManagerCoordinatorTests.swift
+++ b/Tests/UnitTests/Application/TabManagerCoordinatorTests.swift
@@ -189,7 +189,6 @@ extension TabManagerCoordinatorTests {
         // THEN a logout notification is sent
         await fulfillment(of: [exp], timeout: 5)
         // And the session should be cleared
-        XCTAssertFalse(mockWalletAvailabilityService.hasAccessedBefore)
         XCTAssertTrue(mockSessionManager.didCallClearAllSessionData)
     }
     

--- a/Tests/UnitTests/Application/TabManagerCoordinatorTests.swift
+++ b/Tests/UnitTests/Application/TabManagerCoordinatorTests.swift
@@ -182,7 +182,8 @@ extension TabManagerCoordinatorTests {
         try mockSessionManager.setupSession(returningUser: true)
         let profileCoordinator = ProfileCoordinator(userProvider: mockSessionManager,
                                                     analyticsService: mockAnalyticsService,
-                                                    urlOpener: MockURLOpener())
+                                                    urlOpener: MockURLOpener(),
+                                                    walletAvailabilityService: mockWalletAvailabilityService)
         // WHEN the TabManagerCoordinator's performChildCleanup method is called from ProfileCoordinator (on user sign out)
         sut.performChildCleanup(child: profileCoordinator)
         // THEN a logout notification is sent
@@ -201,7 +202,8 @@ extension TabManagerCoordinatorTests {
         try mockSessionManager.setupSession(returningUser: true)
         let profileCoordinator = ProfileCoordinator(userProvider: mockSessionManager,
                                                     analyticsService: mockAnalyticsService,
-                                                    urlOpener: MockURLOpener())
+                                                    urlOpener: MockURLOpener(),
+                                                    walletAvailabilityService: mockWalletAvailabilityService)
         // WHEN the TabManagerCoordinator's performChildCleanup method is called from ProfileCoordinator (on user sign out)
         // but there was an error in signing out
         sut.performChildCleanup(child: profileCoordinator)

--- a/Tests/UnitTests/Application/TabManagerCoordinatorTests.swift
+++ b/Tests/UnitTests/Application/TabManagerCoordinatorTests.swift
@@ -189,6 +189,7 @@ extension TabManagerCoordinatorTests {
         // THEN a logout notification is sent
         await fulfillment(of: [exp], timeout: 5)
         // And the session should be cleared
+        XCTAssertFalse(mockWalletAvailabilityService.hasAccessedBefore)
         XCTAssertTrue(mockSessionManager.didCallClearAllSessionData)
     }
     

--- a/Tests/UnitTests/Login/EnrolmentCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/EnrolmentCoordinatorTests.swift
@@ -65,6 +65,7 @@ extension EnrolmentCoordinatorTests {
         sut.start()
         // THEN the no screen is shown
         XCTAssertEqual(navigationController.viewControllers.count, 0)
+        waitForTruth(self.mockSessionManager.didCallSaveSession, timeout: 5)
     }
 
     @MainActor

--- a/Tests/UnitTests/Login/EnrolmentCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/EnrolmentCoordinatorTests.swift
@@ -65,7 +65,6 @@ extension EnrolmentCoordinatorTests {
         sut.start()
         // THEN the no screen is shown
         XCTAssertEqual(navigationController.viewControllers.count, 0)
-        waitForTruth(self.mockSessionManager.didCallSaveSession, timeout: 5)
     }
 
     @MainActor

--- a/Tests/UnitTests/Mocks/Sessions+Services/MockWalletAvailabilityService.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/MockWalletAvailabilityService.swift
@@ -2,8 +2,11 @@
 import XCTest
 
 class MockWalletAvailabilityService: WalletFeatureAvailabilityService {
+    var hasAccessedBefore = false
     var shouldShowFeature = false
     var shouldShowFeatureOnUniversalLink = false
     
-    func hasAccessedPreviously() { }
+    func accessedWalletFeature() {
+        hasAccessedBefore = true
+    }
 }

--- a/Tests/UnitTests/Mocks/Sessions+Services/MockWalletAvailabilityService.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/MockWalletAvailabilityService.swift
@@ -6,11 +6,7 @@ class MockWalletAvailabilityService: WalletFeatureAvailabilityService {
     var shouldShowFeature = false
     var shouldShowFeatureOnUniversalLink = false
     
-    func accessedFeature() {
-        hasAccessedBefore = true
-    }
-    
-    func resetFeatureState() {
+    func delete() throws {
         hasAccessedBefore = false
     }
 }

--- a/Tests/UnitTests/Mocks/Sessions+Services/MockWalletAvailabilityService.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/MockWalletAvailabilityService.swift
@@ -9,4 +9,8 @@ class MockWalletAvailabilityService: WalletFeatureAvailabilityService {
     func accessedFeature() {
         hasAccessedBefore = true
     }
+    
+    func resetFeatureState() {
+        hasAccessedBefore = false
+    }
 }

--- a/Tests/UnitTests/Mocks/Sessions+Services/MockWalletAvailabilityService.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/MockWalletAvailabilityService.swift
@@ -6,7 +6,7 @@ class MockWalletAvailabilityService: WalletFeatureAvailabilityService {
     var shouldShowFeature = false
     var shouldShowFeatureOnUniversalLink = false
     
-    func accessedWalletFeature() {
+    func accessedFeature() {
         hasAccessedBefore = true
     }
 }

--- a/Tests/UnitTests/Qualification/QualifyingCoordinatorTests.swift
+++ b/Tests/UnitTests/Qualification/QualifyingCoordinatorTests.swift
@@ -9,6 +9,7 @@ final class QualifyingCoordinatorTests: XCTestCase {
     private var networkClient: NetworkClient!
     private var qualifyingService: MockQualifyingService!
     private var analyticsCenter: MockAnalyticsCenter!
+    private var walletAvailabilityService: MockWalletAvailabilityService!
     private var window: UIWindow!
 
     private var sut: QualifyingCoordinator!
@@ -28,12 +29,15 @@ final class QualifyingCoordinatorTests: XCTestCase {
         qualifyingService = MockQualifyingService()
 
         networkClient = NetworkClient()
+        
+        walletAvailabilityService = MockWalletAvailabilityService()
 
         sut = QualifyingCoordinator(window: window,
                                     analyticsCenter: analyticsCenter,
                                     appQualifyingService: qualifyingService,
                                     sessionManager: sessionManager,
-                                    networkClient: networkClient)
+                                    networkClient: networkClient,
+                                    walletAvailibilityService: walletAvailabilityService)
     }
 
     override func tearDown() {
@@ -41,6 +45,7 @@ final class QualifyingCoordinatorTests: XCTestCase {
         networkClient = nil
         qualifyingService = nil
         analyticsCenter = nil
+        walletAvailabilityService = nil
         window = nil
 
         super.tearDown()

--- a/Tests/UnitTests/Qualification/QualifyingCoordinatorTests.swift
+++ b/Tests/UnitTests/Qualification/QualifyingCoordinatorTests.swift
@@ -37,7 +37,7 @@ final class QualifyingCoordinatorTests: XCTestCase {
                                     appQualifyingService: qualifyingService,
                                     sessionManager: sessionManager,
                                     networkClient: networkClient,
-                                    walletAvailibilityService: walletAvailabilityService)
+                                    walletAvailabilityService: walletAvailabilityService)
     }
 
     override func tearDown() {

--- a/Tests/UnitTests/Screens/Profile/SignOutPageViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Profile/SignOutPageViewModelTests.swift
@@ -65,7 +65,7 @@ extension SignOutPageViewModelTests {
         XCTAssertTrue(sut.buttonViewModel is AnalyticsButtonViewModel)
         XCTAssertEqual(sut.buttonViewModel.title, GDSLocalisedString(stringLiteral: "app_signOutAndDeletePreferences"))
         let button = try XCTUnwrap(sut.buttonViewModel as? AnalyticsButtonViewModel)
-        XCTAssertEqual(button.backgroundColor, .gdsRed)
+        XCTAssertEqual(button.backgroundColor, .gdsGreen)
     }
     
     func test_didAppear() throws {

--- a/Tests/UnitTests/Screens/Profile/SignOutPageViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Profile/SignOutPageViewModelTests.swift
@@ -1,11 +1,3 @@
-//
-//  SignOutPageViewModelTests.swift
-//  OneLogin
-//
-//  Created by Mihaila, Bianca on 25/09/2024.
-//
-
-
 import GDSAnalytics
 import GDSCommon
 @testable import OneLogin

--- a/Tests/UnitTests/Screens/Profile/SignOutPageViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Profile/SignOutPageViewModelTests.swift
@@ -36,8 +36,8 @@ final class SignOutPageViewModelTests: XCTestCase {
 
 extension SignOutPageViewModelTests {
     func test_pageConfiguration() throws {
-        XCTAssertEqual(sut.title.stringKey, "app_signOutConfirmationTitle")
-        XCTAssertEqual(sut.body, GDSLocalisedString(stringLiteral: "app_signOutConfirmationBody1").value)
+        XCTAssertEqual(sut.title.stringKey, "app_signOutConfirmationTitleNoWallet")
+        XCTAssertEqual(sut.body, GDSLocalisedString(stringLiteral: "app_signOutConfirmationBody1NoWallet").value)
         XCTAssertNil(sut.secondaryButtonViewModel)
         XCTAssertEqual(sut.rightBarButtonTitle, GDSLocalisedString(stringLiteral: "app_cancelButton"))
         XCTAssertTrue(sut.backButtonIsHidden)
@@ -48,29 +48,22 @@ extension SignOutPageViewModelTests {
         let bulletStack: UIStackView = try XCTUnwrap(bulletList.view?[child: "bullet-stack"])
         let firstBullet = try XCTUnwrap(bulletStack.subviews[0] as? UILabel)
         let firstBulletText = try XCTUnwrap(firstBullet.text)
-        XCTAssertTrue(firstBulletText.contains(GDSLocalisedString(stringLiteral: "app_signOutConfirmationBullet1").value))
+        XCTAssertTrue(firstBulletText.contains(GDSLocalisedString(stringLiteral: "app_signOutConfirmationBullet1iOSNoWallet").value))
         let secondBullet = try XCTUnwrap(bulletStack.subviews[1] as? UILabel)
         let secondBulletText = try XCTUnwrap(secondBullet.text)
-        XCTAssertTrue(secondBulletText.contains(GDSLocalisedString(stringLiteral: "app_signOutConfirmationBullet2").value))
-        let thirdBullet = try XCTUnwrap(bulletStack.subviews[2] as? UILabel)
-        let thirdBulletText = try XCTUnwrap(thirdBullet.text)
-        XCTAssertTrue(thirdBulletText.contains(GDSLocalisedString(stringLiteral: "app_signOutConfirmationBullet3").value))
+        XCTAssertTrue(secondBulletText.contains(GDSLocalisedString(stringLiteral: "app_signOutConfirmationBullet2NoWallet").value))
     }
     
     func test_viewConfiguration() throws {
-        XCTAssertEqual(try body2Label.text, GDSLocalisedString(stringLiteral: "app_signOutConfirmationBody2").value)
+        XCTAssertEqual(try body2Label.text, GDSLocalisedString(stringLiteral: "app_signOutConfirmationBody2NoWallet").value)
         XCTAssertTrue(try body2Label.adjustsFontForContentSizeCategory)
         XCTAssertEqual(try body2Label.numberOfLines, 0)
         XCTAssertEqual(try body2Label.font, .bodyBold)
-        XCTAssertEqual(try body3Label.text, GDSLocalisedString(stringLiteral: "app_signOutConfirmationBody3").value)
-        XCTAssertTrue(try body3Label.adjustsFontForContentSizeCategory)
-        XCTAssertEqual(try body3Label.numberOfLines, 0)
-        XCTAssertEqual(try body3Label.font, .body)
     }
     
     func test_buttonConfiuration() throws {
         XCTAssertTrue(sut.buttonViewModel is AnalyticsButtonViewModel)
-        XCTAssertEqual(sut.buttonViewModel.title, GDSLocalisedString(stringLiteral: "app_signOutAndDeleteAppDataButton"))
+        XCTAssertEqual(sut.buttonViewModel.title, GDSLocalisedString(stringLiteral: "app_signOutAndDeletePreferences"))
         let button = try XCTUnwrap(sut.buttonViewModel as? AnalyticsButtonViewModel)
         XCTAssertEqual(button.backgroundColor, .gdsRed)
     }
@@ -79,9 +72,9 @@ extension SignOutPageViewModelTests {
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 0)
         sut.didAppear()
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 1)
-        let screen = ScreenView(id: ProfileAnalyticsScreenID.signOutScreen.rawValue,
-                                screen: ProfileAnalyticsScreen.signOutScreen,
-                                titleKey: "app_signOutConfirmationTitle")
+        let screen = ScreenView(id: ProfileAnalyticsScreenID.signOutScreenNoWallet.rawValue,
+                                screen: ProfileAnalyticsScreen.signOutScreenNoWallet,
+                                titleKey: "app_signOutConfirmationTitleNoWallet")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
     }
@@ -117,12 +110,6 @@ extension SignOutPageViewModelTests {
     var body2Label: UILabel {
         get throws {
             try XCTUnwrap(sut.childView[child: "sign-out-body2-text"])
-        }
-    }
-    
-    var body3Label: UILabel {
-        get throws {
-            try XCTUnwrap(sut.childView[child: "sign-out-body3-text"])
         }
     }
 }

--- a/Tests/UnitTests/Screens/Profile/SignOutPageViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Profile/SignOutPageViewModelTests.swift
@@ -94,7 +94,7 @@ extension SignOutPageViewModelTests {
         sut.buttonViewModel.action()
         XCTAssertTrue(didCallButtonAction)
         XCTAssertEqual(mockAnalyticsService.eventsLogged.count, 1)
-        let event = ButtonEvent(textKey: "app_signOutAndDeleteAppDataButton")
+        let event = ButtonEvent(textKey: "app_signOutAndDeletePreferences")
         XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged, event.parameters)
     }
@@ -103,13 +103,13 @@ extension SignOutPageViewModelTests {
 extension SignOutPageViewModelTests {
     var bulletList: BulletView {
         get throws {
-            try XCTUnwrap(sut.childView[child: "sign-out-bullet-list"])
+            try XCTUnwrap(sut.childView[child: "sign-out-bullet-list-no-wallet"])
         }
     }
     
     var body2Label: UILabel {
         get throws {
-            try XCTUnwrap(sut.childView[child: "sign-out-body2-text"])
+            try XCTUnwrap(sut.childView[child: "sign-out-body2-text-no-wallet"])
         }
     }
 }

--- a/Tests/UnitTests/Screens/Profile/WalletSignOutPageViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Profile/WalletSignOutPageViewModelTests.swift
@@ -1,18 +1,10 @@
-//
-//  SignOutPageViewModelTests.swift
-//  OneLogin
-//
-//  Created by Mihaila, Bianca on 25/09/2024.
-//
-
-
 import GDSAnalytics
 import GDSCommon
 @testable import OneLogin
 import XCTest
 
 @MainActor
-final class SignOutPageViewModelTests: XCTestCase {
+final class WalletSignOutPageViewModelTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
     var sut: SignOutPageViewModel!
     
@@ -34,7 +26,7 @@ final class SignOutPageViewModelTests: XCTestCase {
     }
 }
 
-extension SignOutPageViewModelTests {
+extension WalletSignOutPageViewModelTests {
     func test_pageConfiguration() throws {
         XCTAssertEqual(sut.title.stringKey, "app_signOutConfirmationTitle")
         XCTAssertEqual(sut.body, GDSLocalisedString(stringLiteral: "app_signOutConfirmationBody1").value)
@@ -107,7 +99,7 @@ extension SignOutPageViewModelTests {
     }
 }
 
-extension SignOutPageViewModelTests {
+extension WalletSignOutPageViewModelTests {
     var bulletList: BulletView {
         get throws {
             try XCTUnwrap(sut.childView[child: "sign-out-bullet-list"])

--- a/Tests/UnitTests/Screens/Profile/WalletSignOutPageViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Profile/WalletSignOutPageViewModelTests.swift
@@ -71,8 +71,8 @@ extension WalletSignOutPageViewModelTests {
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 0)
         sut.didAppear()
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 1)
-        let screen = ScreenView(id: ProfileAnalyticsScreenID.signOutScreen.rawValue,
-                                screen: ProfileAnalyticsScreen.signOutScreen,
+        let screen = ScreenView(id: ProfileAnalyticsScreenID.signOutScreenWithWallet.rawValue,
+                                screen: ProfileAnalyticsScreen.signOutScreenWithWallet,
                                 titleKey: "app_signOutConfirmationTitle")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)

--- a/Tests/UnitTests/Screens/Profile/WalletSignOutPageViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Profile/WalletSignOutPageViewModelTests.swift
@@ -6,7 +6,7 @@ import XCTest
 @MainActor
 final class WalletSignOutPageViewModelTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
-    var sut: SignOutPageViewModel!
+    var sut: WalletSignOutPageViewModel!
     
     var didCallButtonAction = false
     
@@ -14,7 +14,7 @@ final class WalletSignOutPageViewModelTests: XCTestCase {
         super.setUp()
         
         mockAnalyticsService = MockAnalyticsService()
-        sut = SignOutPageViewModel(analyticsService: mockAnalyticsService) {
+        sut = WalletSignOutPageViewModel(analyticsService: mockAnalyticsService) {
             self.didCallButtonAction = true
         }
     }
@@ -102,19 +102,19 @@ extension WalletSignOutPageViewModelTests {
 extension WalletSignOutPageViewModelTests {
     var bulletList: BulletView {
         get throws {
-            try XCTUnwrap(sut.childView[child: "sign-out-bullet-list"])
+            try XCTUnwrap(sut.childView[child: "sign-out-bullet-list-with-wallet"])
         }
     }
     
     var body2Label: UILabel {
         get throws {
-            try XCTUnwrap(sut.childView[child: "sign-out-body2-text"])
+            try XCTUnwrap(sut.childView[child: "sign-out-body2-text-with-wallet"])
         }
     }
     
     var body3Label: UILabel {
         get throws {
-            try XCTUnwrap(sut.childView[child: "sign-out-body3-text"])
+            try XCTUnwrap(sut.childView[child: "sign-out-body3-text-with-wallet"])
         }
     }
 }

--- a/Tests/UnitTests/Service/WalletAvailabilityServiceTests.swift
+++ b/Tests/UnitTests/Service/WalletAvailabilityServiceTests.swift
@@ -43,7 +43,7 @@ extension WalletAvailabilityServiceTests {
             FeatureFlags.enableWalletVisibleToAll.rawValue: false,
             FeatureFlags.enableWalletVisibleIfExists.rawValue: true
         ])
-        sut.accessedWalletFeature()
+        sut.accessedFeature()
         
         XCTAssertTrue(sut.shouldShowFeature)
     }
@@ -61,7 +61,7 @@ extension WalletAvailabilityServiceTests {
         AppEnvironment.updateReleaseFlags([
             FeatureFlags.enableWalletVisibleToAll.rawValue: false
         ])
-        sut.accessedWalletFeature()
+        sut.accessedFeature()
         
         XCTAssertFalse(sut.shouldShowFeature)
     }

--- a/Tests/UnitTests/Service/WalletAvailabilityServiceTests.swift
+++ b/Tests/UnitTests/Service/WalletAvailabilityServiceTests.swift
@@ -43,7 +43,7 @@ extension WalletAvailabilityServiceTests {
             FeatureFlags.enableWalletVisibleToAll.rawValue: false,
             FeatureFlags.enableWalletVisibleIfExists.rawValue: true
         ])
-        sut.hasAccessedPreviously()
+        sut.accessedWalletFeature()
         
         XCTAssertTrue(sut.shouldShowFeature)
     }
@@ -61,7 +61,7 @@ extension WalletAvailabilityServiceTests {
         AppEnvironment.updateReleaseFlags([
             FeatureFlags.enableWalletVisibleToAll.rawValue: false
         ])
-        sut.hasAccessedPreviously()
+        sut.accessedWalletFeature()
         
         XCTAssertFalse(sut.shouldShowFeature)
     }

--- a/Tests/UnitTests/Service/WalletAvailabilityServiceTests.swift
+++ b/Tests/UnitTests/Service/WalletAvailabilityServiceTests.swift
@@ -43,7 +43,7 @@ extension WalletAvailabilityServiceTests {
             FeatureFlags.enableWalletVisibleToAll.rawValue: false,
             FeatureFlags.enableWalletVisibleIfExists.rawValue: true
         ])
-        sut.accessedFeature()
+        sut.hasAccessedBefore = true
         
         XCTAssertTrue(sut.shouldShowFeature)
     }
@@ -61,7 +61,7 @@ extension WalletAvailabilityServiceTests {
         AppEnvironment.updateReleaseFlags([
             FeatureFlags.enableWalletVisibleToAll.rawValue: false
         ])
-        sut.accessedFeature()
+        sut.hasAccessedBefore = true
         
         XCTAssertFalse(sut.shouldShowFeature)
     }

--- a/Tests/UnitTests/Tabs/ProfileCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/ProfileCoordinatorTests.swift
@@ -8,6 +8,7 @@ final class ProfileCoordinatorTests: XCTestCase {
     var window: UIWindow!
     var mockAnalyticsService: MockAnalyticsService!
     var mockSessionManager: MockSessionManager!
+    var mockWalletAvailabilityService: MockWalletAvailabilityService!
     var urlOpener: URLOpener!
     var sut: ProfileCoordinator!
     
@@ -20,7 +21,8 @@ final class ProfileCoordinatorTests: XCTestCase {
         urlOpener = MockURLOpener()
         sut = ProfileCoordinator(userProvider: mockSessionManager,
                                  analyticsService: mockAnalyticsService,
-                                 urlOpener: urlOpener)
+                                 urlOpener: urlOpener,
+                                 walletAvailabilityService: mockWalletAvailabilityService)
         window.rootViewController = sut.root
         window.makeKeyAndVisible()
     }

--- a/Tests/UnitTests/Tabs/ProfileCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/ProfileCoordinatorTests.swift
@@ -53,7 +53,7 @@ final class ProfileCoordinatorTests: XCTestCase {
     
     func test_openSignOutPageWithWallet() throws {
         // WHEN Wallet has been accessed before
-        mockWalletAvailabilityService.accessedFeature()
+        mockWalletAvailabilityService.hasAccessedBefore = true
         // WHEN the ProfileCoordinator is started
         sut.start()
         // WHEN the openSignOutPage method is called

--- a/Tests/UnitTests/Tabs/ProfileCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/ProfileCoordinatorTests.swift
@@ -18,6 +18,7 @@ final class ProfileCoordinatorTests: XCTestCase {
         window = .init()
         mockAnalyticsService = MockAnalyticsService()
         mockSessionManager = MockSessionManager()
+        mockWalletAvailabilityService = mockWalletAvailabilityService
         urlOpener = MockURLOpener()
         sut = ProfileCoordinator(userProvider: mockSessionManager,
                                  analyticsService: mockAnalyticsService,
@@ -31,6 +32,7 @@ final class ProfileCoordinatorTests: XCTestCase {
         window = nil
         mockAnalyticsService = nil
         mockSessionManager = nil
+        mockWalletAvailabilityService = nil
         urlOpener = nil
         sut = nil
         
@@ -49,7 +51,19 @@ final class ProfileCoordinatorTests: XCTestCase {
         XCTAssertEqual(sut.root.tabBarItem.tag, profileTab.tag)
     }
     
-    func test_openSignOutPage() throws {
+    func test_openSignOutPageWithWallet() throws {
+        // WHEN Wallet has been accessed before
+        mockWalletAvailabilityService.accessedWalletFeature()
+        // WHEN the ProfileCoordinator is started
+        sut.start()
+        // WHEN the openSignOutPage method is called
+        sut.openSignOutPage()
+        // THEN the presented view controller is the GDSInstructionsViewController
+        let presentedVC = try XCTUnwrap(sut.root.presentedViewController as? UINavigationController)
+        XCTAssertTrue(presentedVC.topViewController is GDSInstructionsViewController)
+    }
+    
+    func test_openSignOutPageNoWallet() throws {
         // WHEN the ProfileCoordinator is started
         sut.start()
         // WHEN the openSignOutPage method is called

--- a/Tests/UnitTests/Tabs/ProfileCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/ProfileCoordinatorTests.swift
@@ -53,7 +53,7 @@ final class ProfileCoordinatorTests: XCTestCase {
     
     func test_openSignOutPageWithWallet() throws {
         // WHEN Wallet has been accessed before
-        mockWalletAvailabilityService.accessedWalletFeature()
+        mockWalletAvailabilityService.accessedFeature()
         // WHEN the ProfileCoordinator is started
         sut.start()
         // WHEN the openSignOutPage method is called

--- a/Tests/UnitTests/Tabs/ProfileCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/ProfileCoordinatorTests.swift
@@ -18,7 +18,7 @@ final class ProfileCoordinatorTests: XCTestCase {
         window = .init()
         mockAnalyticsService = MockAnalyticsService()
         mockSessionManager = MockSessionManager()
-        mockWalletAvailabilityService = mockWalletAvailabilityService
+        mockWalletAvailabilityService = MockWalletAvailabilityService()
         urlOpener = MockURLOpener()
         sut = ProfileCoordinator(userProvider: mockSessionManager,
                                  analyticsService: mockAnalyticsService,

--- a/Tests/UnitTests/Utilities/Session/PersistentSessionManagerTests.swift
+++ b/Tests/UnitTests/Utilities/Session/PersistentSessionManagerTests.swift
@@ -10,6 +10,7 @@ final class PersistentSessionManagerTests: XCTestCase {
     private var localAuthentication: MockLocalAuthManager!
     private var secureTokenStore: MockSecureTokenStore!
     private var storedTokens: StoredTokens!
+    private var mockWalletAvilibilityService: MockWalletAvailabilityService!
 
     private var didCall_deleteSessionBoundData = false
 
@@ -21,6 +22,7 @@ final class PersistentSessionManagerTests: XCTestCase {
         unprotectedStore = MockDefaultsStore()
         localAuthentication = MockLocalAuthManager()
         secureTokenStore = MockSecureTokenStore()
+        mockWalletAvilibilityService = MockWalletAvailabilityService()
 
         sut = PersistentSessionManager(
             accessControlEncryptedStore: accessControlEncryptedStore,
@@ -289,6 +291,7 @@ extension PersistentSessionManagerTests {
         // WHEN I clear all session data
         try sut.clearAllSessionData()
         // THEN my session data is deleted
+        XCTAssertFalse(mockWalletAvilibilityService.hasAccessedBefore)
         XCTAssertEqual(unprotectedStore.savedData.count, 0)
         XCTAssertEqual(encryptedStore.savedItems, [:])
     }

--- a/Tests/UnitTests/Utilities/Session/PersistentSessionManagerTests.swift
+++ b/Tests/UnitTests/Utilities/Session/PersistentSessionManagerTests.swift
@@ -10,7 +10,7 @@ final class PersistentSessionManagerTests: XCTestCase {
     private var localAuthentication: MockLocalAuthManager!
     private var secureTokenStore: MockSecureTokenStore!
     private var storedTokens: StoredTokens!
-    private var mockWalletAvilibilityService: MockWalletAvailabilityService!
+    private var walletAvilabilityService: MockWalletAvailabilityService!
 
     private var didCall_deleteSessionBoundData = false
 
@@ -22,7 +22,7 @@ final class PersistentSessionManagerTests: XCTestCase {
         unprotectedStore = MockDefaultsStore()
         localAuthentication = MockLocalAuthManager()
         secureTokenStore = MockSecureTokenStore()
-        mockWalletAvilibilityService = MockWalletAvailabilityService()
+        walletAvilabilityService = MockWalletAvailabilityService()
 
         sut = PersistentSessionManager(
             accessControlEncryptedStore: accessControlEncryptedStore,
@@ -40,6 +40,7 @@ final class PersistentSessionManagerTests: XCTestCase {
         unprotectedStore = nil
         localAuthentication = nil
         secureTokenStore = nil
+        walletAvilabilityService = nil
         storedTokens = nil
 
         sut = nil
@@ -291,7 +292,6 @@ extension PersistentSessionManagerTests {
         // WHEN I clear all session data
         try sut.clearAllSessionData()
         // THEN my session data is deleted
-        XCTAssertFalse(mockWalletAvilibilityService.hasAccessedBefore)
         XCTAssertEqual(unprotectedStore.savedData.count, 0)
         XCTAssertEqual(encryptedStore.savedItems, [:])
     }


### PR DESCRIPTION
# Add SignOutPage when wallet not accessed

**Ticket Link:** 
[DCMAW-9638](https://govukverify.atlassian.net/browse/DCMAW-9638)
[DCMAW-10090](https://govukverify.atlassian.net/browse/DCMAW-10090)

**Description Of Changes:** 
Amend existing `SignOutPage` into `WalletSignOutPage` - displays when/ if user accessed wallet at some point. Create new `SignOutPage` - displayed only when the user has _never_ accessed wallet.

AC1b, AC2b, AC3b cannot be evidenced - I can quickly show this on a call if needed - those were met.

**Evidence:**

**_[DCMAW-9638](https://govukverify.atlassian.net/browse/DCMAW-9638)_**

https://github.com/user-attachments/assets/7330e38f-2fe4-4030-af0a-bf3da34a76e0


https://github.com/user-attachments/assets/3ccc5096-6b16-4975-9efb-1bda4ed25f5c


https://github.com/user-attachments/assets/06c7ae71-f456-4223-8dad-aa13450ce120


https://github.com/user-attachments/assets/5f3e5a11-7f9d-47e7-a6e6-be10538bb5c7


https://github.com/user-attachments/assets/86b64003-88f6-4705-b868-23407777b9c4


https://github.com/user-attachments/assets/7aecf4dd-b5c7-40db-95e6-8968b0e2c0d8


https://github.com/user-attachments/assets/924871e1-c219-47b5-837e-df5f1c234e48


**_[DCMAW-10090](https://govukverify.atlassian.net/browse/DCMAW-10090)_**

### AC1
```
11.2.0 - [FirebaseAnalytics][I-ACS023105] Event is not subject to real-time event count daily limit. Marking an event as real-time. Event name, parameters: screen_view (_vs), {
    _mst = 1;
    ga_debug (_dbg) = 1;
    ga_event_origin (_o) = app;
    ga_previous_class (_pc) = touchIDEnrollmentScreen;
    ga_previous_id (_pi) = -7445189895592028454;
    ga_previous_screen (_pn) = use touch id to sign in;
    ga_realtime (_r) = 1;
    ga_screen (_sn) = are you sure you want to sign out?;
    ga_screen_class (_sc) = signOutScreenNoWallet;
    ga_screen_id (_si) = -7445189895592028453;
    language = en;
    organisation = <OT1056>;
    primary_publishing_organisation = government digital service - digital identity;
    saved_doc_type = undefined;
    screen_id = 3e50cd12-4ee8-4787-add8-6a2ac7d4a840;
    taxonomy_level1 = one login mobile application;
    taxonomy_level2 = login;
    taxonomy_level3 = undefined;
    title = are you sure you want to sign out?;
}
```

### AC2
```
11.2.0 - [FirebaseAnalytics][I-ACS023072] Event logged. Event name, event params: screen_view (_vs), {
    _mst = 1;
    ga_debug (_dbg) = 1;
    ga_event_origin (_o) = app;
    ga_previous_class (_pc) = signOutScreenNoWallet;
    ga_previous_id (_pi) = 1991676583146903352;
    ga_previous_screen (_pn) = are you sure you want to sign out?;
    ga_realtime (_r) = 1;
    ga_screen (_sn) = gov.uk one login;
    ga_screen_class (_sc) = introWelcomeScreen;
    ga_screen_id (_si) = 1991676583146903353;
    language = en;
    organisation = <OT1056>;
    primary_publishing_organisation = government digital service - digital identity;
    saved_doc_type = undefined;
    screen_id = 30a6b339-75a8-44a2-a79a-e108546419bf;
    taxonomy_level1 = one login mobile application;
    taxonomy_level2 = login;
    taxonomy_level3 = undefined;
    title = gov.uk one login;
}
11.2.0 - [FirebaseAnalytics][I-ACS002001] Measurement timer fired
11.2.0 - [FirebaseAnalytics][I-ACS002003] Measurement timer canceled
11.2.0 - [FirebaseAnalytics][I-ACS023105] Event is not subject to real-time event count daily limit. Marking an event as real-time. Event name, parameters: navigation, {
    ga_debug (_dbg) = 1;
    ga_event_origin (_o) = app;
    ga_realtime (_r) = 1;
    ga_screen (_sn) = are you sure you want to sign out?;
    ga_screen_class (_sc) = signOutScreenNoWallet;
    ga_screen_id (_si) = 1991676583146903352;
    language = en;
    organisation = <OT1056>;
    primary_publishing_organisation = government digital service - digital identity;
    saved_doc_type = undefined;
    taxonomy_level1 = one login mobile application;
    taxonomy_level2 = login;
    taxonomy_level3 = undefined;
    text = sign out and delete preferences;
    type = submit form;
}
```

### AC3
```
11.2.0 - [FirebaseAnalytics][I-ACS023073] Debug mode is enabled. Marking event as debug and real-time. Event name, parameters: navigation, {
    ga_debug (_dbg) = 1;
    ga_event_origin (_o) = app;
    ga_realtime (_r) = 1;
    ga_screen (_sn) = are you sure you want to sign out?;
    ga_screen_class (_sc) = signOutScreenNoWallet;
    ga_screen_id (_si) = -7445189895592028448;
    language = en;
    organisation = <OT1056>;
    primary_publishing_organisation = government digital service - digital identity;
    saved_doc_type = undefined;
    taxonomy_level1 = one login mobile application;
    taxonomy_level2 = login;
    taxonomy_level3 = undefined;
    text = back;
    type = submit form;
}
11.2.0 - [FirebaseAnalytics][I-ACS023072] Event logged. Event name, event params: navigation, {
    ga_debug (_dbg) = 1;
    ga_event_origin (_o) = app;
    ga_realtime (_r) = 1;
    ga_screen (_sn) = are you sure you want to sign out?;
    ga_screen_class (_sc) = signOutScreenNoWallet;
    ga_screen_id (_si) = -7445189895592028448;
    language = en;
    organisation = <OT1056>;
    primary_publishing_organisation = government digital service - digital identity;
    saved_doc_type = undefined;
    taxonomy_level1 = one login mobile application;
    taxonomy_level2 = login;
    taxonomy_level3 = undefined;
    text = back;
    type = submit form;
}
11.2.0 - [FirebaseAnalytics][I-ACS002002] Measurement timer scheduled to fire in approx. (s): 0.9785468578338623
11.2.0 - [FirebaseAnalytics][I-ACS002001] Measurement timer fired
11.2.0 - [FirebaseAnalytics][I-ACS002003] Measurement timer canceled
11.2.0 - [FirebaseAnalytics][I-ACS023105] Event is not subject to real-time event count daily limit. Marking an event as real-time. Event name, parameters: navigation, {
    ga_debug (_dbg) = 1;
    ga_event_origin (_o) = app;
    ga_realtime (_r) = 1;
    ga_screen (_sn) = are you sure you want to sign out?;
    ga_screen_class (_sc) = signOutScreenNoWallet;
    ga_screen_id (_si) = -7445189895592028448;
    language = en;
    organisation = <OT1056>;
    primary_publishing_organisation = government digital service - digital identity;
    saved_doc_type = undefined;
    taxonomy_level1 = one login mobile application;
    taxonomy_level2 = login;
    taxonomy_level3 = undefined;
    text = back;
    type = submit form;
}
```

### AC4 (Welsh)
```
11.2.0 - [FirebaseAnalytics][I-ACS031029] Logging screen view with screen name and screen class: are you sure you want to sign out?, signOutScreenNoWallet
11.2.0 - [FirebaseAnalytics][I-ACS023051] Logging event: origin, name, params: app, screen_view (_vs), {
    _mst = 1;
    ga_event_origin (_o) = app;
    ga_previous_class (_pc) = touchIDEnrollmentScreen;
    ga_previous_id (_pi) = -9205768981192396352;
    ga_previous_screen (_pn) = use touch id to sign in;
    ga_screen (_sn) = are you sure you want to sign out?;
    ga_screen_class (_sc) = signOutScreenNoWallet;
    ga_screen_id (_si) = -9205768981192396351;
    language = cy;
    organisation = <OT1056>;
    primary_publishing_organisation = government digital service - digital identity;
    saved_doc_type = undefined;
    screen_id = 3e50cd12-4ee8-4787-add8-6a2ac7d4a840;
    taxonomy_level1 = one login mobile application;
    taxonomy_level2 = login;
    taxonomy_level3 = undefined;
    title = are you sure you want to sign out?;
}
11.2.0 - [FirebaseAnalytics][I-ACS023073] Debug mode is enabled. Marking event as debug and real-time. Event name, parameters: screen_view (_vs), {
    _mst = 1;
    ga_debug (_dbg) = 1;
    ga_event_origin (_o) = app;
    ga_previous_class (_pc) = touchIDEnrollmentScreen;
    ga_previous_id (_pi) = -9205768981192396352;
    ga_previous_screen (_pn) = use touch id to sign in;
    ga_realtime (_r) = 1;
    ga_screen (_sn) = are you sure you want to sign out?;
    ga_screen_class (_sc) = signOutScreenNoWallet;
    ga_screen_id (_si) = -9205768981192396351;
    language = cy;
    organisation = <OT1056>;
    primary_publishing_organisation = government digital service - digital identity;
    saved_doc_type = undefined;
    screen_id = 3e50cd12-4ee8-4787-add8-6a2ac7d4a840;
    taxonomy_level1 = one login mobile application;
    taxonomy_level2 = login;
    taxonomy_level3 = undefined;
    title = are you sure you want to sign out?;
}
```

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [ ] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.


[DCMAW-9638]: https://govukverify.atlassian.net/browse/DCMAW-9638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DCMAW-10090]: https://govukverify.atlassian.net/browse/DCMAW-10090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ