### PR TITLE
ci: prevent silent failures in deploy pipeline

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -168,7 +168,7 @@ platform :ios do
           submit_beta_review: true
         )
       rescue Spaceship::UnexpectedResponse => ex
-        if ex.error_info['code'] != 'You can’t submit a build for testing if another build is already in review. Wait until your other build has been reviewed, and resubmit this build.'
+        if ex.error_info['code'] != "You can’t submit a build for testing if another build is already in review. Wait until your other build has been reviewed, and resubmit this build."
           raise ex
         end
       end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -167,8 +167,10 @@ platform :ios do
           reject_build_waiting_for_review: false,
           submit_beta_review: true
         )
-      rescue => ex
-        UI.error("Something went wrong: #{ex}")
+      rescue UnexpectedResponse => ex
+        if ex.error_info["code"] != "You can’t submit a build for testing if another build is already in review. Wait until your other build has been reviewed, and resubmit this build."
+          raise ex
+        end
       end
     ensure
       delete_keychain(name: "signing_temp")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,14 +16,14 @@ require 'securerandom'
 ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "600"
 
 default_platform(:ios)
-xcode_select("/Applications/Xcode_16.app")
+xcode_select("/Applications/Xcode.app")
 
 platform :ios do
   desc "Run Tests without Sonar Coverage"
   lane :testWithoutCoverage do |options|
     run_tests(
       workspace: "OneLogin.xcworkspace",
-      device: "iPhone SE (3rd generation)",
+      device: "iPhone SE (3rd generation) (18.0)",
       scheme: options[:scheme],
       testplan: options[:testplan]
     )
@@ -33,7 +33,7 @@ platform :ios do
   lane :testWithoutCoverageForUITests do |options|
     run_tests(
       workspace: "OneLogin.xcworkspace",
-      device: "iPhone SE (3rd generation)",
+      device: "iPhone SE (3rd generation) (18.0)",
       scheme: options[:scheme],
       testplan: options[:testplan],
       prelaunch_simulator: true,
@@ -46,7 +46,7 @@ platform :ios do
   lane :test do |options|
     run_tests(
       workspace: "OneLogin.xcworkspace",
-      device: "iPhone SE (3rd generation)",
+      device: "iPhone SE (3rd generation) (18.0)",
       scheme: options[:scheme],
       testplan: options[:testplan],
       result_bundle: true
@@ -168,7 +168,7 @@ platform :ios do
           submit_beta_review: true
         )
       rescue Spaceship::UnexpectedResponse => ex
-        if ex.error_info["code"] != "You can’t submit a build for testing if another build is already in review. Wait until your other build has been reviewed, and resubmit this build."
+        if ex.error_info['code'] != 'You can’t submit a build for testing if another build is already in review. Wait until your other build has been reviewed, and resubmit this build.'
           raise ex
         end
       end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,7 +16,7 @@ require 'securerandom'
 ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "600"
 
 default_platform(:ios)
-xcode_select("/Applications/Xcode.app")
+xcode_select("/Applications/Xcode_16.app")
 
 platform :ios do
   desc "Run Tests without Sonar Coverage"
@@ -168,7 +168,7 @@ platform :ios do
           submit_beta_review: true
         )
       rescue Spaceship::UnexpectedResponse => ex
-        if ex.error_info['code'] != "You can’t submit a build for testing if another build is already in review. Wait until your other build has been reviewed, and resubmit this build."
+        if ex.error_info['code'] != "You can't submit a build for testing if another build is already in review. Wait until your other build has been reviewed, and resubmit this build."
           raise ex
         end
       end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -167,7 +167,7 @@ platform :ios do
           reject_build_waiting_for_review: false,
           submit_beta_review: true
         )
-      rescue UnexpectedResponse => ex
+      rescue Spaceship::UnexpectedResponse => ex
         if ex.error_info["code"] != "You can’t submit a build for testing if another build is already in review. Wait until your other build has been reviewed, and resubmit this build."
           raise ex
         end


### PR DESCRIPTION
# DCMAW-10159: iOS | Build pipeline fails silently if app build fails to upload to Testflight

We have been ignoring all exceptions thrown by the Fastlane `upload_to_testflight` action. The workflow has been failing silently whilst the GitHub action completes.

The workflow will now fail on all thrown exceptions other than an `UnexpectedResponse` where the `code` received in the `error_info` hash does not equal a string from the App Store Connect API describing that:
"You can’t submit a build for testing if another build is already in review. Wait until your other build has been reviewed, and resubmit this build."

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
~- [ ] Written Unit and Integration tests if needed~

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
