### PR TITLE
build: adding info plist entry for app encryption

### DIFF
--- a/OneLogin-Info.plist
+++ b/OneLogin-Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>App Store URL</key>
+	<string>apps.apple.com</string>
 	<key>Base URL</key>
 	<string>$(BASE_URL)</string>
 	<key>Configuration</key>
@@ -19,6 +21,8 @@
 	<false/>
 	<key>GOOGLE_ANALYTICS_REGISTRATION_WITH_AD_NETWORK_ENABLED</key>
 	<false/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>One Login Authorize URL</key>
 	<string>$(ONE_LOGIN_AUTHORIZE_URL)</string>
 	<key>One Login Client ID</key>
@@ -29,8 +33,6 @@
 	<string>$(STS_BASE_URL)</string>
 	<key>STS Client ID</key>
 	<string>$(STS_CLIENT_ID)</string>
-	<key>App Store URL</key>
-	<string>apps.apple.com</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
# DCMAW-10333: iOS | Declare encryption exemption for uploading to App Store Connect

A change to requirements in uploading to App Store Connect means a new entry must be added to the app property list file to declare exemption from US encryption export regulations.

https://developer.apple.com/documentation/security/complying-with-encryption-export-regulations

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
~- [ ] Written Unit and Integration tests if needed~

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
