### PR TITLE
fix: updating bundle id and firebase plist within one login

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -380,8 +380,6 @@
 		C873B1E12AF826D3002C39E8 /* StagingAppEnvironmentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StagingAppEnvironmentTests.swift; sourceTree = "<group>"; };
 		C87913C32B27B7A300545B33 /* ErrorAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorAnalytics.swift; sourceTree = "<group>"; };
 		C880DDE12AEAB6C100020796 /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
-		C882F0742CC1245600E33376 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
-		C882F0762CC1249D00E33376 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		C885C8952CB45EAD001BE99C /* ServicesTileViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServicesTileViewModelTests.swift; sourceTree = "<group>"; };
 		C889587E2C7E4CBD00663299 /* LALocalAuthenticationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LALocalAuthenticationManager.swift; sourceTree = "<group>"; };
 		C88958812C7E795200663299 /* MockLocalAuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLocalAuthManager.swift; sourceTree = "<group>"; };
@@ -423,6 +421,8 @@
 		C8C343A82B923DB300E92FB9 /* StandardButtonViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandardButtonViewModel.swift; sourceTree = "<group>"; };
 		C8C57CE32B0237620010D395 /* OneLoginUI.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = OneLoginUI.xctestplan; sourceTree = "<group>"; };
 		C8C6665D2BD007BD00CF249B /* OutdatedTokenResponse.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = OutdatedTokenResponse.json; sourceTree = "<group>"; };
+		C8C7A3FB2CC25DED0037586F /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		C8C7A3FD2CC25E0C0037586F /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		C8D6781F2C519B7E000AA26C /* DataDeletedWarningViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataDeletedWarningViewModel.swift; sourceTree = "<group>"; };
 		C8D678212C540297000AA26C /* DataDeletedWarningViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataDeletedWarningViewModelTests.swift; sourceTree = "<group>"; };
 		C8E1090A2BEE6C4500B21038 /* ProfileTabViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTabViewModel.swift; sourceTree = "<group>"; };
@@ -806,7 +806,7 @@
 		C803C2152B8F8865008DE774 /* BuildConfig */ = {
 			isa = PBXGroup;
 			children = (
-				C882F0742CC1245600E33376 /* GoogleService-Info.plist */,
+				C8C7A3FB2CC25DED0037586F /* GoogleService-Info.plist */,
 			);
 			path = BuildConfig;
 			sourceTree = "<group>";
@@ -1072,7 +1072,7 @@
 		C86B706F2B8F5F2D00F4C9BF /* StagingConfig */ = {
 			isa = PBXGroup;
 			children = (
-				C882F0762CC1249D00E33376 /* GoogleService-Info.plist */,
+				C8C7A3FD2CC25E0C0037586F /* GoogleService-Info.plist */,
 			);
 			path = StagingConfig;
 			sourceTree = "<group>";

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -328,8 +328,6 @@
 		ABAFD44B2C7DF30800E00A88 /* WalletAvailabilityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletAvailabilityService.swift; sourceTree = "<group>"; };
 		ABBD21AB2C6E1D6B00B0C959 /* MockAppInfoService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAppInfoService.swift; sourceTree = "<group>"; };
 		ABBE421B2C775C7E00607A7A /* AppEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironmentTests.swift; sourceTree = "<group>"; };
-		C803C21D2B8F8D73008DE774 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
-		C803C21F2B8F8D9C008DE774 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		C8098B962AEFF1AB001517A0 /* LoginSessionConfiguration+OneLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoginSessionConfiguration+OneLogin.swift"; sourceTree = "<group>"; };
 		C8098B982AEFF287001517A0 /* AnalyticsService+GDS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnalyticsService+GDS.swift"; sourceTree = "<group>"; };
 		C80B87192B029E230087C6D5 /* LoginUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginUITests.swift; sourceTree = "<group>"; };
@@ -382,6 +380,8 @@
 		C873B1E12AF826D3002C39E8 /* StagingAppEnvironmentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StagingAppEnvironmentTests.swift; sourceTree = "<group>"; };
 		C87913C32B27B7A300545B33 /* ErrorAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorAnalytics.swift; sourceTree = "<group>"; };
 		C880DDE12AEAB6C100020796 /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
+		C882F0742CC1245600E33376 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		C882F0762CC1249D00E33376 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		C885C8952CB45EAD001BE99C /* ServicesTileViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServicesTileViewModelTests.swift; sourceTree = "<group>"; };
 		C889587E2C7E4CBD00663299 /* LALocalAuthenticationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LALocalAuthenticationManager.swift; sourceTree = "<group>"; };
 		C88958812C7E795200663299 /* MockLocalAuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLocalAuthManager.swift; sourceTree = "<group>"; };
@@ -806,7 +806,7 @@
 		C803C2152B8F8865008DE774 /* BuildConfig */ = {
 			isa = PBXGroup;
 			children = (
-				C803C21D2B8F8D73008DE774 /* GoogleService-Info.plist */,
+				C882F0742CC1245600E33376 /* GoogleService-Info.plist */,
 			);
 			path = BuildConfig;
 			sourceTree = "<group>";
@@ -1072,7 +1072,7 @@
 		C86B706F2B8F5F2D00F4C9BF /* StagingConfig */ = {
 			isa = PBXGroup;
 			children = (
-				C803C21F2B8F8D9C008DE774 /* GoogleService-Info.plist */,
+				C882F0762CC1249D00E33376 /* GoogleService-Info.plist */,
 			);
 			path = StagingConfig;
 			sourceTree = "<group>";
@@ -2221,7 +2221,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = N8W395F695;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "OneLogin-Info.plist";
@@ -2236,7 +2236,6 @@
 				);
 				MARKETING_VERSION = 1.0.0;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = "uk.gov.one-login.staging";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -2255,7 +2254,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = N8W395F695;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "OneLogin-Info.plist";
@@ -2270,7 +2269,6 @@
 				);
 				MARKETING_VERSION = 1.0.0;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = "uk.gov.one-login";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -2559,7 +2557,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OneLoginStaging.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = N8W395F695;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "OneLogin-Info.plist";
@@ -2574,7 +2572,6 @@
 				);
 				MARKETING_VERSION = 1.0.0;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = "uk.gov.one-login.staging";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -2760,7 +2757,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OneLoginBuild.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = N8W395F695;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "OneLogin-Info.plist";
@@ -2775,7 +2772,6 @@
 				);
 				MARKETING_VERSION = 1.0.0;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = "uk.gov.one-login.build";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/Sources/Application/Environment/Configuration/Build.xcconfig
+++ b/Sources/Application/Environment/Configuration/Build.xcconfig
@@ -1,3 +1,5 @@
+PRODUCT_BUNDLE_IDENTIFIER = uk.gov.onelogin.build
+
 INFOPLIST_KEY_CFBundleDisplayName = One Login - Build
 INFOPLIST_KEY_NSCameraUsageDescription = This app does not use the camera
 

--- a/Sources/Application/Environment/Configuration/Debug.xcconfig
+++ b/Sources/Application/Environment/Configuration/Debug.xcconfig
@@ -1,3 +1,5 @@
+PRODUCT_BUNDLE_IDENTIFIER = uk.gov.onelogin.staging
+
 INFOPLIST_KEY_CFBundleDisplayName = One Login - Debug
 INFOPLIST_KEY_NSCameraUsageDescription = This app does not use the camera
 

--- a/Sources/Application/Environment/Configuration/Release.xcconfig
+++ b/Sources/Application/Environment/Configuration/Release.xcconfig
@@ -1,3 +1,5 @@
+PRODUCT_BUNDLE_IDENTIFIER = uk.gov.onelogin
+
 INFOPLIST_KEY_CFBundleDisplayName = One Login
 INFOPLIST_KEY_NSCameraUsageDescription = This app does not use the camera
 

--- a/Sources/Application/Environment/Configuration/Staging.xcconfig
+++ b/Sources/Application/Environment/Configuration/Staging.xcconfig
@@ -1,3 +1,5 @@
+PRODUCT_BUNDLE_IDENTIFIER = uk.gov.onelogin.staging
+
 INFOPLIST_KEY_CFBundleDisplayName = One Login - Staging
 INFOPLIST_KEY_NSCameraUsageDescription = This app does not use the camera
 

--- a/Sources/Application/Firebase/BuildConfig/GoogleService-Info.plist
+++ b/Sources/Application/Firebase/BuildConfig/GoogleService-Info.plist
@@ -3,17 +3,17 @@
 <plist version="1.0">
 <dict>
 	<key>API_KEY</key>
-	<string>AIzaSyAyDI5-ciJEYk08jjysBWWhQSoulERtWFo</string>
+	<string>AIzaSyAZwOaM95E4AoQlUX5dBgJQxTnzDs00QUM</string>
 	<key>GCM_SENDER_ID</key>
-	<string>1099188154796</string>
+	<string>231299341389</string>
 	<key>PLIST_VERSION</key>
 	<string>1</string>
 	<key>BUNDLE_ID</key>
-	<string>uk.gov.one-login.build</string>
+	<string>uk.gov.onelogin.build</string>
 	<key>PROJECT_ID</key>
-	<string>one-login-build</string>
+	<string>mobile-one-login-build</string>
 	<key>STORAGE_BUCKET</key>
-	<string>one-login-build.appspot.com</string>
+	<string>mobile-one-login-build.appspot.com</string>
 	<key>IS_ADS_ENABLED</key>
 	<false/>
 	<key>IS_ANALYTICS_ENABLED</key>
@@ -25,6 +25,6 @@
 	<key>IS_SIGNIN_ENABLED</key>
 	<false/>
 	<key>GOOGLE_APP_ID</key>
-	<string>1:1099188154796:ios:ee4d870949fe453ec7ca09</string>
+	<string>1:231299341389:ios:b34e2542bf47b0cd6dd004</string>
 </dict>
 </plist>

--- a/Sources/Application/Firebase/BuildConfig/GoogleService-Info.plist
+++ b/Sources/Application/Firebase/BuildConfig/GoogleService-Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>API_KEY</key>
-	<string>AIzaSyAZwOaM95E4AoQlUX5dBgJQxTnzDs00QUM</string>
+	<string>AIzaSyADkrCIAINOBKh5oAsU9cDLROFsBsw3hdo</string>
 	<key>GCM_SENDER_ID</key>
 	<string>231299341389</string>
 	<key>PLIST_VERSION</key>
@@ -25,6 +25,6 @@
 	<key>IS_SIGNIN_ENABLED</key>
 	<false/>
 	<key>GOOGLE_APP_ID</key>
-	<string>1:231299341389:ios:b34e2542bf47b0cd6dd004</string>
+	<string>1:231299341389:ios:9621b0f5d84ae14b6dd004</string>
 </dict>
 </plist>

--- a/Sources/Application/Firebase/StagingConfig/GoogleService-Info.plist
+++ b/Sources/Application/Firebase/StagingConfig/GoogleService-Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>API_KEY</key>
-	<string>AIzaSyBTwo0wNNB8o-_V3NwPhbqi4UPNogxR07I</string>
+	<string>AIzaSyDKvrXaf9WMuRbcGu0rfDejYYOt5iCvmEo</string>
 	<key>GCM_SENDER_ID</key>
 	<string>792769336852</string>
 	<key>PLIST_VERSION</key>
@@ -25,6 +25,6 @@
 	<key>IS_SIGNIN_ENABLED</key>
 	<false/>
 	<key>GOOGLE_APP_ID</key>
-	<string>1:792769336852:ios:b2ec6feaf56cf4ca90b901</string>
+	<string>1:792769336852:ios:156bc812cca9635390b901</string>
 </dict>
 </plist>

--- a/Sources/Application/Firebase/StagingConfig/GoogleService-Info.plist
+++ b/Sources/Application/Firebase/StagingConfig/GoogleService-Info.plist
@@ -3,17 +3,17 @@
 <plist version="1.0">
 <dict>
 	<key>API_KEY</key>
-	<string>AIzaSyA5r_bH4zNOYUbKD4g_0oXbIeNJjdllpKM</string>
+	<string>AIzaSyBTwo0wNNB8o-_V3NwPhbqi4UPNogxR07I</string>
 	<key>GCM_SENDER_ID</key>
-	<string>533083083023</string>
+	<string>792769336852</string>
 	<key>PLIST_VERSION</key>
 	<string>1</string>
 	<key>BUNDLE_ID</key>
-	<string>uk.gov.one-login.staging</string>
+	<string>uk.gov.onelogin.staging</string>
 	<key>PROJECT_ID</key>
-	<string>one-login-staging</string>
+	<string>mobile-one-login-staging</string>
 	<key>STORAGE_BUCKET</key>
-	<string>one-login-staging.appspot.com</string>
+	<string>mobile-one-login-staging.appspot.com</string>
 	<key>IS_ADS_ENABLED</key>
 	<false/>
 	<key>IS_ANALYTICS_ENABLED</key>
@@ -25,6 +25,6 @@
 	<key>IS_SIGNIN_ENABLED</key>
 	<false/>
 	<key>GOOGLE_APP_ID</key>
-	<string>1:533083083023:ios:c5af0a2a36ff5d0a0eae7a</string>
+	<string>1:792769336852:ios:b2ec6feaf56cf4ca90b901</string>
 </dict>
 </plist>

--- a/Tests/ConfigTests/BuildConfig/BuildAppEnvironmentTests.swift
+++ b/Tests/ConfigTests/BuildConfig/BuildAppEnvironmentTests.swift
@@ -4,6 +4,8 @@ import XCTest
 final class BuildAppEnvironmentTests: XCTestCase {
     func test_defaultEnvironment_retrieveFromPlist() throws {
         let sut = AppEnvironment.self
+        XCTAssertEqual(Bundle.main.bundleIdentifier, "uk.gov.onelogin.build")
+        XCTAssertEqual(Bundle.main.infoDictionary?["CFBundleDisplayName"] as? String, "One Login - Build")
         XCTAssertEqual(sut.oneLoginAuthorize, URL(string: "https://auth-stub.mobile.build.account.gov.uk/authorize"))
         XCTAssertEqual(sut.stsAuthorize, URL(string: "https://token.build.account.gov.uk/authorize"))
         XCTAssertEqual(sut.oneLoginToken, URL(string: "https://mobile.build.account.gov.uk/token"))
@@ -17,7 +19,6 @@ final class BuildAppEnvironmentTests: XCTestCase {
         XCTAssertEqual(sut.stsHelloWorld, URL(string: "https://hello-world.token.build.account.gov.uk/hello-world"))
         XCTAssertEqual(sut.jwksURL, URL(string: "https://token.build.account.gov.uk/.well-known/jwks.json"))
         XCTAssertEqual(sut.appInfoURL, URL(string: "https://mobile.build.account.gov.uk/appInfo"))
-        XCTAssertEqual(sut.isLocaleWelsh, false)
         XCTAssertEqual(sut.appStoreURL, URL(string: "https://apps.apple.com"))
         XCTAssertEqual(sut.appStore, URL(string: "https://apps.apple.com/gb.app.uk.gov.digital-identity"))
         XCTAssertEqual(sut.yourServicesURL, URL(string: "https://home.account.gov.uk/your-services?lng=en"))

--- a/Tests/ConfigTests/StagingConfig/StagingAppEnvironmentTests.swift
+++ b/Tests/ConfigTests/StagingConfig/StagingAppEnvironmentTests.swift
@@ -4,6 +4,8 @@ import XCTest
 final class StagingAppEnvironmentTests: XCTestCase {
     func test_defaultEnvironment_retrieveFromPlist() throws {
         let sut = AppEnvironment.self
+        XCTAssertEqual(Bundle.main.bundleIdentifier, "uk.gov.onelogin.staging")
+        XCTAssertEqual(Bundle.main.infoDictionary?["CFBundleDisplayName"] as? String, "One Login - Staging")
         XCTAssertEqual(sut.oneLoginAuthorize, URL(string: "https://oidc.integration.account.gov.uk/authorize"))
         XCTAssertEqual(sut.stsAuthorize, URL(string: "https://token.staging.account.gov.uk/authorize"))
         XCTAssertEqual(sut.oneLoginToken, URL(string: "https://mobile.staging.account.gov.uk/token"))
@@ -17,7 +19,6 @@ final class StagingAppEnvironmentTests: XCTestCase {
         XCTAssertEqual(sut.stsHelloWorld, URL(string: "https://hello-world.token.staging.account.gov.uk/hello-world"))
         XCTAssertEqual(sut.jwksURL, URL(string: "https://token.staging.account.gov.uk/.well-known/jwks.json"))
         XCTAssertEqual(sut.appInfoURL, URL(string: "https://mobile.staging.account.gov.uk/appInfo"))
-        XCTAssertEqual(sut.isLocaleWelsh, false)
         XCTAssertEqual(sut.appStoreURL, URL(string: "https://apps.apple.com"))
         XCTAssertEqual(sut.appStore, URL(string: "https://apps.apple.com/gb.app.uk.gov.digital-identity"))
         XCTAssertEqual(sut.yourServicesURL, URL(string: "https://home.account.gov.uk/your-services?lng=en"))

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -107,7 +107,7 @@ platform :ios do
 
       project_name = "OneLogin.xcodeproj"
       profile_name = "One Login"
-      app_identifier = "uk.gov.one-login"
+      app_identifier = "uk.gov.onelogin"
 
       if options[:configuration] == "Staging" then
         profile_name += " Staging"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -125,14 +125,6 @@ platform :ios do
 
       version = get_version_number(xcodeproj: project_name)
 
-      #
-      # App Store Connect considers 1.0.0 and 1.0 the same
-      # but will only return results for 1.0 as this was uploaded first
-      #
-      if version == "1.0.0" then
-        version = "1.0"
-      end
-
       build_number = latest_testflight_build_number(
         app_identifier: app_identifier,
         version: version


### PR DESCRIPTION
# fix: updating bundle id and firebase plist within one login

App Integrity and subsequent closer management of Firebase has led to new firebase projects.
A change to the app's bundle id is needed in order to align iOS and Android applications from an infrastructure-as-code management perspective.

This PR replaces the plist file for firebase and alters the app bundle id from `uk.gov.one-login${environment}` to `uk.gov.onelogin${environment}` (removing the hyphen "-")

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
~- [ ] Written Unit and Integration tests if needed~

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
