### PR TITLE
feat: implement the request to client-attestion endpoint

### DIFF
--- a/AppIntegrity/Sources/AppIntegrity/ClientAssertionRequest.swift
+++ b/AppIntegrity/Sources/AppIntegrity/ClientAssertionRequest.swift
@@ -1,4 +1,0 @@
-// TODO: DCMAW-10320 | Encode PoP Key correctly as JWK
-struct ClientAssertionRequest: Encodable {
-    let jwk: String
-}

--- a/AppIntegrity/Sources/AppIntegrity/ClientAssertionResponse.swift
+++ b/AppIntegrity/Sources/AppIntegrity/ClientAssertionResponse.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+struct ClientAssertionResponse: Decodable {
+    let attestationJWT: String
+    let expiryDate: Date
+
+    enum CodingKeys: String, CodingKey {
+        case attestationJWT = "client_attestation"
+        case expiresIn = "expires_in"
+    }
+
+    init(from decoder: any Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        attestationJWT = try values.decode(String.self, forKey: .attestationJWT)
+
+        let expiresIn = try values.decode(Double.self, forKey: .expiresIn)
+        expiryDate = Date(timeIntervalSinceNow: expiresIn)
+    }
+}

--- a/AppIntegrity/Sources/AppIntegrity/ProofOfPossessionProvider.swift
+++ b/AppIntegrity/Sources/AppIntegrity/ProofOfPossessionProvider.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-protocol ProofOfPossessionProvider {
+public protocol ProofOfPossessionProvider {
     var publicKey: Data { get }
     func sign(data: Data) -> Data
 }

--- a/AppIntegrity/Sources/AppIntegrity/URLRequest+Integrity.swift
+++ b/AppIntegrity/Sources/AppIntegrity/URLRequest+Integrity.swift
@@ -1,14 +1,17 @@
 import Foundation
 
 extension URLRequest {
-    static func clientAttestation(baseURL: URL, token: String) throws -> URLRequest {
+    static func clientAttestation(baseURL: URL,
+                                  token: String,
+                                  body: Data) throws -> URLRequest {
         var request = URLRequest(url: baseURL.appendingPathComponent("client-attestation"))
         request.httpMethod = "POST"
 
-        let encoder = JSONEncoder()
-        request.httpBody = try encoder.encode(ClientAssertionRequest(jwk: token))
-        
         request.addValue(token, forHTTPHeaderField: "X-Firebase-AppCheck")
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        request.httpBody = body
+
         return request
     }
 }

--- a/AppIntegrity/Tests/AppIntegrity/Mocks/MockProofOfPossessionProvider.swift
+++ b/AppIntegrity/Tests/AppIntegrity/Mocks/MockProofOfPossessionProvider.swift
@@ -1,0 +1,23 @@
+import AppIntegrity
+import Foundation
+import Testing
+
+final class MockProofOfPossessionProvider: ProofOfPossessionProvider {
+    var publicKey: Data {
+        Data("""
+        {
+          "jwk": {
+            "kty": EC",
+            "use": "sig",
+            "crv": "P-256",
+            "x": "18wHLeIgW9wVN6VD1Txgpqy2LszYkMf6J8njVAibvhM",
+            "y": "-V4dS4UaLMgP_4fY4j8ir7cl1TXlFdAgcx55o7TkcSA"
+          }
+        }
+        """.utf8)
+    }
+
+    func sign(data: Data) -> Data {
+        Data()
+    }
+}


### PR DESCRIPTION
# DCMAW-10293: Client Attestation request

Sending the App Check token and the public key of the app’s proof-of-possession key pair to the `client-attestion` endpoint in exchange for a client attestation JWT.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] ~~Met all accessibility requirements?~~ - No user facing change.

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
