### PR TITLE
feat: make content tile tap-able

### DIFF
--- a/Sources/Screens/Tabs/HomeViewController.swift
+++ b/Sources/Screens/Tabs/HomeViewController.swift
@@ -59,10 +59,6 @@ extension HomeViewController {
     }
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        didTapCard()
-    }
-    
-    func didTapCard() {
         viewModel.cardTapped()
     }
 }

--- a/Sources/Screens/Tabs/HomeViewController.swift
+++ b/Sources/Screens/Tabs/HomeViewController.swift
@@ -6,11 +6,14 @@ import UIKit
 final class HomeViewController: UITableViewController {
     let analyticsService: AnalyticsService
     let navigationTitle: GDSLocalisedString = "app_homeTitle"
+    let viewModel: ServicesTileViewModel
 
-    init(analyticsService: AnalyticsService) {
+    init(analyticsService: AnalyticsService,
+         viewModel: ServicesTileViewModel) {
         var tempAnalyticsService = analyticsService
         tempAnalyticsService.setAdditionalParameters(appTaxonomy: .home)
         self.analyticsService = tempAnalyticsService
+        self.viewModel = viewModel
         super.init(style: .insetGrouped)
     }
     
@@ -60,8 +63,6 @@ extension HomeViewController {
     }
     
     func didTapCard() {
-        let viewModel = ServicesTileViewModel.yourServices(analyticsService: analyticsService,
-                                                           urlOpener: UIApplication.shared)
         viewModel.cardTapped()
     }
 }

--- a/Sources/Screens/Tabs/HomeViewController.swift
+++ b/Sources/Screens/Tabs/HomeViewController.swift
@@ -54,6 +54,16 @@ extension HomeViewController {
         }
         return cell
     }
+    
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        didTapCard()
+    }
+    
+    func didTapCard() {
+        let viewModel = ServicesTileViewModel.yourServices(analyticsService: analyticsService,
+                                                           urlOpener: UIApplication.shared)
+        viewModel.cardTapped()
+    }
 }
 
 enum HomeScreenTile: Int, CaseIterable {

--- a/Sources/Tabs/HomeCoordinator.swift
+++ b/Sources/Tabs/HomeCoordinator.swift
@@ -24,7 +24,10 @@ final class HomeCoordinator: NSObject,
         root.tabBarItem = UITabBarItem(title: GDSLocalisedString(stringLiteral: "app_homeTitle").value,
                                        image: UIImage(systemName: "house"),
                                        tag: 0)
-        let hc = HomeViewController(analyticsService: analyticsService)
+        let viewModel = ServicesTileViewModel.yourServices(analyticsService: analyticsService,
+                                                           urlOpener: UIApplication.shared)
+        let hc = HomeViewController(analyticsService: analyticsService,
+                                    viewModel: viewModel)
         root.setViewControllers([hc], animated: true)
     }
 }

--- a/Sources/Views/ContentTile/ServicesTileViewModel.swift
+++ b/Sources/Views/ContentTile/ServicesTileViewModel.swift
@@ -11,9 +11,11 @@ struct ServicesTileViewModel: GDSContentTileViewModel,
     let showSeparatorLine: Bool = true
     let secondaryButtonViewModel: ButtonViewModel
     let backgroundColour: UIColor? = .secondarySystemGroupedBackground
+    let cardTapped: (() -> Void)
     
     init(analyticsService: AnalyticsService,
          action: @escaping () -> Void) {
+        self.cardTapped = action
         let event = LinkEvent(textKey: "app_yourServicesCardLink",
                               linkDomain: AppEnvironment.yourServicesLink,
                               external: .false)

--- a/Tests/UnitTests/Screens/Tabs/HomeViewControllerTests.swift
+++ b/Tests/UnitTests/Screens/Tabs/HomeViewControllerTests.swift
@@ -6,16 +6,23 @@ import XCTest
 final class HomeViewControllerTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
     var sut: HomeViewController!
+    var mockURLOpener: MockURLOpener!
     
     override func setUp() {
         super.setUp()
         
         mockAnalyticsService = MockAnalyticsService()
-        sut = HomeViewController(analyticsService: mockAnalyticsService)
+        mockURLOpener = MockURLOpener()
+        
+        let viewModel = ServicesTileViewModel.yourServices(analyticsService: mockAnalyticsService,
+                                                           urlOpener: mockURLOpener)
+        sut = HomeViewController(analyticsService: mockAnalyticsService,
+                                 viewModel: viewModel)
     }
     
     override func tearDown() {
         mockAnalyticsService = nil
+        mockURLOpener = nil
         sut = nil
         
         super.tearDown()
@@ -43,6 +50,11 @@ extension HomeViewControllerTests {
             cellForRowAt: IndexPath(row: 0, section: 0)
         ) as? ContentTileCell
         XCTAssertTrue(servicesTile?.viewModel is ServicesTileViewModel)
+    }
+    
+    func test_contentTileCell_opensURL() {
+        sut.didTapCard()
+        XCTAssertTrue(mockURLOpener.didOpenURL)
     }
     
     func test_viewDidAppear() {

--- a/Tests/UnitTests/Screens/Tabs/HomeViewControllerTests.swift
+++ b/Tests/UnitTests/Screens/Tabs/HomeViewControllerTests.swift
@@ -53,7 +53,7 @@ extension HomeViewControllerTests {
     }
     
     func test_contentTileCell_opensURL() {
-        sut.didTapCard()
+        sut.tableView(sut.tableView, didSelectRowAt: IndexPath(row: 0, section: 0))
         XCTAssertTrue(mockURLOpener.didOpenURL)
     }
     

--- a/Tests/UnitTests/Views/ServicesTileViewModelTests.swift
+++ b/Tests/UnitTests/Views/ServicesTileViewModelTests.swift
@@ -9,6 +9,7 @@ final class ServicesTileViewModelTests: XCTestCase {
     var sut: ServicesTileViewModel!
     
     var didCallButtonAction = false
+    var didTapCard = false
     
     override func setUp() {
         super.setUp()
@@ -16,6 +17,7 @@ final class ServicesTileViewModelTests: XCTestCase {
         mockAnalyticsService = MockAnalyticsService()
         sut = ServicesTileViewModel(analyticsService: mockAnalyticsService) {
             self.didCallButtonAction = true
+            self.didTapCard = true
         }
     }
     
@@ -24,6 +26,7 @@ final class ServicesTileViewModelTests: XCTestCase {
         sut = nil
         
         didCallButtonAction = false
+        didTapCard = false
         
         super.tearDown()
     }
@@ -60,5 +63,12 @@ extension ServicesTileViewModelTests {
                                                                              urlOpener: mockURLOpener)
         yourServicesTileViewModel.secondaryButtonViewModel.action()
         XCTAssertTrue(mockURLOpener.didOpenURL)
+    }
+    
+    func test_cardTap() {
+        XCTAssertFalse(didTapCard)
+        sut.cardTapped()
+        XCTAssertTrue(didTapCard)
+        
     }
 }

--- a/Tests/UnitTests/Views/ServicesTileViewModelTests.swift
+++ b/Tests/UnitTests/Views/ServicesTileViewModelTests.swift
@@ -69,6 +69,5 @@ extension ServicesTileViewModelTests {
         XCTAssertFalse(didTapCard)
         sut.cardTapped()
         XCTAssertTrue(didTapCard)
-        
     }
 }


### PR DESCRIPTION
# DCMAW-10253: Make the 'Your Services' tile tap-able

Ensuring the ‘Your services’ tile can be tapped as a whole - tapping anywhere on the tile should behave in the same way as tapping the 'Go to your services' link currently on the tile.

### QA Evidence:
https://github.com/user-attachments/assets/d0ba66ea-51ae-4917-8293-d50bebcac283


# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
~- [ ] Created a `draft` pull request if it is not yet ready for review~

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
