### PR TITLE
fix: updating proof of possession aud claim to sts base url

### DIFF
--- a/Sources/Qualification/AppAttestation/AppIntegrityJWT.swift
+++ b/Sources/Qualification/AppAttestation/AppIntegrityJWT.swift
@@ -11,7 +11,7 @@ enum AppIntegrityJWT {
         case .payload:
             [
                 "iss": AppEnvironment.stsClientID,
-                "aud": AppEnvironment.stsBaseURLString,
+                "aud": AppEnvironment.stsBaseURL.absoluteString,
                 "exp": Int(Date.now.timeIntervalSince1970) + 180,
                 "jti": UUID().uuidString
             ]

--- a/Tests/UnitTests/Qualification/AppAttestationTests/AppIntegrityJWTTests.swift
+++ b/Tests/UnitTests/Qualification/AppAttestationTests/AppIntegrityJWTTests.swift
@@ -21,7 +21,7 @@ import Testing
          let expiryDate = Int(Date().timeIntervalSince1970) + 180
 
          #expect(payload["iss"] as? String == AppEnvironment.stsClientID)
-         #expect(payload["aud"] as? String == AppEnvironment.stsBaseURLString)
+         #expect(payload["aud"] as? String == AppEnvironment.stsBaseURL.absoluteString)
          #expect(payload["exp"] as? Int == expiryDate)
          #expect((payload["jti"] as? String)?.count == 36)
      }


### PR DESCRIPTION
# fix: updating proof of possession aud claim to sts base url

The STS base url included in the app integrity proof of possession was missing the `https://` prefix.
This PR amends that incorrect configuration.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
~- [ ] Met all of the acceptance criteria specified in the user story on Jira~
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
