### PR TITLE
fix: removed bold weight from signout screen

### DIFF
--- a/Sources/Screens/SignOut/SignOutPageViewModel.swift
+++ b/Sources/Screens/SignOut/SignOutPageViewModel.swift
@@ -50,7 +50,7 @@ struct SignOutPageViewModel: GDSInstructionsViewModel, BaseViewModel {
             label.text = GDSLocalisedString(stringLiteral: "app_signOutConfirmationBody2NoWallet").value
             label.adjustsFontForContentSizeCategory = true
             label.numberOfLines = 0
-            label.font = .bodyBold
+            label.font = .body
             label.accessibilityIdentifier = "sign-out-body2-text-no-wallet"
             return label
         }()

--- a/Tests/UnitTests/Screens/SignOut/SignOutPageViewModelTests.swift
+++ b/Tests/UnitTests/Screens/SignOut/SignOutPageViewModelTests.swift
@@ -53,7 +53,7 @@ extension SignOutPageViewModelTests {
         XCTAssertEqual(try body2Label.text, GDSLocalisedString(stringLiteral: "app_signOutConfirmationBody2NoWallet").value)
         XCTAssertTrue(try body2Label.adjustsFontForContentSizeCategory)
         XCTAssertEqual(try body2Label.numberOfLines, 0)
-        XCTAssertEqual(try body2Label.font, .bodyBold)
+        XCTAssertEqual(try body2Label.font, .body)
     }
     
     func test_button() throws {


### PR DESCRIPTION
# fix: removed bold weight from signout screen

DCMAW-10653 | Exploratory testing | Incorrect Bold Text

Changes the body font from bold to regular body on sign out confirmation screen (no wallet)

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [ ] ~Created a `draft` pull request if it is not yet ready for review~

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
