### PR TITLE
feat: clear session data on access_denied error

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -3062,8 +3062,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/govuk-one-login/mobile-ios-authentication.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.0;
+				branch = "feature/dcmaw-11375-access-denied-authentication-error";
+				kind = branch;
 			};
 		};
 		C8A13CA72AFBD0CC00FCBD36 /* XCRemoteSwiftPackageReference "mobile-ios-logging" */ = {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-authentication.git",
       "state" : {
-        "revision" : "1a1aa6b2e4598f1a90bd7106d383154d3e5e354c",
-        "version" : "2.1.2"
+        "branch" : "feature/dcmaw-11375-access-denied-authentication-error",
+        "revision" : "423c0f02656c10c10b8b67c9c98baa89dcffcfe3"
       }
     },
     {

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -102,6 +102,8 @@ final class LoginCoordinator: NSObject,
                     let error as LoginError where error == .clientError,
                     let error as LoginError where error == .serverError {
                 showUnableToLoginErrorScreen(error)
+            } catch let error as LoginError where error == .accessDenied {
+                showDataDeletedWarningScreen()
             } catch let error as JWTVerifierError {
                 showUnableToLoginErrorScreen(error)
             } catch {

--- a/Sources/Login/WebAuthenticationService.swift
+++ b/Sources/Login/WebAuthenticationService.swift
@@ -27,6 +27,9 @@ final class WebAuthenticationService: AuthenticationService {
             let userCancelEvent = ButtonEvent(textKey: "back")
             analyticsService.logEvent(userCancelEvent)
             throw error
+        } catch let error as LoginError where error == .accessDenied {
+            try sessionManager.clearAllSessionData()
+            throw error
         }
     }
     

--- a/Tests/UnitTests/Login/AuthenticationServiceTests.swift
+++ b/Tests/UnitTests/Login/AuthenticationServiceTests.swift
@@ -39,7 +39,7 @@ final class AuthenticationServiceTests: XCTestCase {
 }
 
 extension AuthenticationServiceTests {
-    func test_loginError_userCancelled() async throws {
+    func test_loginError_userCancelled() async {
         mockSessionManager.errorFromStartSession = LoginError.userCancelled
         do {
             try await sut.startWebSession()
@@ -55,7 +55,21 @@ extension AuthenticationServiceTests {
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["text"], userCancelledEvent.parameters["text"])
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged["type"], userCancelledEvent.parameters["type"])
     }
-        
+    
+    func test_loginError_accessDenied() async {
+        mockSessionManager.errorFromStartSession = LoginError.accessDenied
+        do {
+            try await sut.startWebSession()
+        } catch {
+            guard let error = error as? LoginError else {
+                XCTFail("Error should be a LoginError")
+                return
+            }
+            XCTAssertTrue(error == .accessDenied)
+        }
+        XCTAssertTrue(mockSessionManager.didCallClearAllSessionData)
+    }
+    
     @MainActor
     func test_handleUniversalLink_catchAllError() throws {
         mockLoginSession.errorFromFinalise = AuthenticationError.generic

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -213,6 +213,19 @@ extension LoginCoordinatorTests {
     }
     
     @MainActor
+    func test_launchAuthenticationService_accessDenied() throws {
+        // GIVEN the authentication session returns a serverError error
+        mockSessionManager.errorFromStartSession = LoginError.accessDenied
+        // WHEN the LoginCoordinator's launchAuthenticationService method is called
+        sut.launchAuthenticationService()
+        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
+        // THEN the visible view controller should be the GDSErrorViewController
+        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorViewController)
+        // THEN the visible view controller's view model should be the UnableToLoginErrorViewModel
+        XCTAssertTrue(vc.viewModel is DataDeletedWarningViewModel)
+    }
+    
+    @MainActor
     func test_launchAuthenticationService_jwtFetchError() throws {
         // GIVEN the authentication session returns a unableToFetchJWKs error
         mockSessionManager.errorFromStartSession = JWTVerifierError.unableToFetchJWKs


### PR DESCRIPTION
# feat: clear session data on access_denied error

The auth `access_denied` error should be treated as destructive. Clearing all the user's session information and taking them back to the sign in screen where they can sign in as a fresh user.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
