### PR TITLE
fix: CRI Orchestrator feature flag off by default

### DIFF
--- a/Sources/Application/SupportingFiles/FeatureFlags/FeatureFlagsStaging.json
+++ b/Sources/Application/SupportingFiles/FeatureFlags/FeatureFlagsStaging.json
@@ -21,6 +21,6 @@
     },
     {
         "name": "EnableCRIOrchestrator",
-        "isEnabled": true
+        "isEnabled": false
     }
 ]

--- a/Tests/ConfigTests/StagingConfig/StagingAppEnvironmentTests.swift
+++ b/Tests/ConfigTests/StagingConfig/StagingAppEnvironmentTests.swift
@@ -23,6 +23,6 @@ final class StagingAppEnvironmentTests: XCTestCase {
         XCTAssertFalse(sut.walletVisibleToAll)
         XCTAssertFalse(sut.walletVisibleIfExists)
         XCTAssertFalse(sut.walletVisibleViaDeepLink)
-        XCTAssertTrue(sut.criOrchestratorEnabled)
+        XCTAssertFalse(sut.criOrchestratorEnabled)
     }
 }


### PR DESCRIPTION
# fix: CRI Orchestrator feature flag off by default

Disabling the CRI Orchestrator feature flag for the Staging app by default.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
