### PR TITLE
chore: update deprecated view model protocols

### DIFF
--- a/Sources/Screens/Enrolment/FaceIDEnrolmentViewModel.swift
+++ b/Sources/Screens/Enrolment/FaceIDEnrolmentViewModel.swift
@@ -3,9 +3,10 @@ import GDSCommon
 import Logging
 import UIKit
 
-struct FaceIDEnrolmentViewModel: GDSInformationViewModelV2,
-                                 GDSInformationViewModelPrimaryButton,
-                                 GDSInformationViewModelWithSecondaryButton,
+struct FaceIDEnrolmentViewModel: GDSCentreAlignedViewModel,
+                                 GDSCentreAlignedViewModelWithImage,
+                                 GDSCentreAlignedViewModelWithPrimaryButton,
+                                 GDSCentreAlignedViewModelWithSecondaryButton,
                                  BaseViewModel {
     let image: String = "faceid"
     let imageWeight: UIFont.Weight? = .thin

--- a/Sources/Screens/Enrolment/TouchIDEnrolmentViewModel.swift
+++ b/Sources/Screens/Enrolment/TouchIDEnrolmentViewModel.swift
@@ -3,9 +3,10 @@ import GDSCommon
 import Logging
 import UIKit
 
-struct TouchIDEnrolmentViewModel: GDSInformationViewModelV2,
-                                  GDSInformationViewModelPrimaryButton,
-                                  GDSInformationViewModelWithSecondaryButton,
+struct TouchIDEnrolmentViewModel: GDSCentreAlignedViewModel,
+                                  GDSCentreAlignedViewModelWithImage,
+                                  GDSCentreAlignedViewModelWithPrimaryButton,
+                                  GDSCentreAlignedViewModelWithSecondaryButton,
                                   BaseViewModel {
     let image: String = "touchid"
     let imageWeight: UIFont.Weight? = .thin

--- a/Sources/Screens/Errors/AppUnavailableViewModel.swift
+++ b/Sources/Screens/Errors/AppUnavailableViewModel.swift
@@ -3,7 +3,8 @@ import GDSCommon
 import Logging
 import UIKit
 
-struct AppUnavailableViewModel: GDSInformationViewModelV2,
+struct AppUnavailableViewModel: GDSCentreAlignedViewModel,
+                                GDSCentreAlignedViewModelWithImage,
                                 BaseViewModel {
     let image: String = "exclamationmark.circle"
     let imageWeight: UIFont.Weight? = .regular

--- a/Sources/Screens/Errors/UpdateAppViewModel.swift
+++ b/Sources/Screens/Errors/UpdateAppViewModel.swift
@@ -3,8 +3,9 @@ import GDSCommon
 import Logging
 import UIKit
 
-struct UpdateAppViewModel: GDSInformationViewModelV2,
-                           GDSInformationViewModelPrimaryButton,
+struct UpdateAppViewModel: GDSCentreAlignedViewModel,
+                           GDSCentreAlignedViewModelWithImage,
+                           GDSCentreAlignedViewModelWithPrimaryButton,
                            BaseViewModel {
     let image: String = "exclamationmark.arrow.circlepath"
     let imageWeight: UIFont.Weight? = .regular

--- a/Sources/Screens/Tabs/SettingsTabViewModel.swift
+++ b/Sources/Screens/Tabs/SettingsTabViewModel.swift
@@ -29,7 +29,6 @@ struct SettingsTabViewModel: TabbedViewModel {
     let rightBarButtonTitle: GDSLocalisedString? = nil
     let backButtonIsHidden: Bool = true
     
-    
     @MainActor
     init(analyticsService: AnalyticsService,
          userProvider: UserProvider,


### PR DESCRIPTION
# chore: update deprecated view model protocols

There are several screens which still make use of view model protocols which have been marked as deprecated in updated versions of the GDSCommon package. This PR removes these and replaces with the new, segregated protocols.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
~- [ ] Written Unit and Integration tests if needed~

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
