### PR TITLE
chore: updating taxonomy levels

### DIFF
--- a/Sources/Analytics/Taxonomy/OLTaxonomy.swift
+++ b/Sources/Analytics/Taxonomy/OLTaxonomy.swift
@@ -11,4 +11,7 @@ enum OLTaxonomyValue {
     static let settings = "settings"
     static let reauth = "re auth"
     static let undefined = "undefined"
+    static let biometrics = "biometrics"
+    static let unlock = "unlock"
+    static let error = "error"
 }

--- a/Sources/Screens/Enrolment/FaceIDEnrolmentViewModel.swift
+++ b/Sources/Screens/Enrolment/FaceIDEnrolmentViewModel.swift
@@ -24,7 +24,9 @@ struct FaceIDEnrolmentViewModel: GDSCentreAlignedViewModel,
     init(analyticsService: OneLoginAnalyticsService,
          primaryButtonAction: @escaping () -> Void,
          secondaryButtonAction: @escaping () -> Void) {
-        self.analyticsService = analyticsService
+        var tempAnalyticsService = analyticsService
+        tempAnalyticsService.setAdditionalParameters(appTaxonomy: .biometrics)
+        self.analyticsService = tempAnalyticsService
         self.primaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "app_enableFaceIDButton",
                                                                analyticsService: analyticsService) {
             primaryButtonAction()

--- a/Sources/Screens/Enrolment/FaceIDEnrolmentViewModel.swift
+++ b/Sources/Screens/Enrolment/FaceIDEnrolmentViewModel.swift
@@ -24,9 +24,10 @@ struct FaceIDEnrolmentViewModel: GDSCentreAlignedViewModel,
     init(analyticsService: OneLoginAnalyticsService,
          primaryButtonAction: @escaping () -> Void,
          secondaryButtonAction: @escaping () -> Void) {
-        var tempAnalyticsService = analyticsService
-        tempAnalyticsService.setAdditionalParameters(appTaxonomy: .biometrics)
-        self.analyticsService = tempAnalyticsService
+        self.analyticsService = analyticsService.addingAdditionalParameters([
+            OLTaxonomyKey.level2: OLTaxonomyValue.login,
+            OLTaxonomyKey.level3: OLTaxonomyValue.biometrics
+        ])
         self.primaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "app_enableFaceIDButton",
                                                                analyticsService: analyticsService) {
             primaryButtonAction()

--- a/Sources/Screens/Enrolment/TouchIDEnrolmentViewModel.swift
+++ b/Sources/Screens/Enrolment/TouchIDEnrolmentViewModel.swift
@@ -24,9 +24,10 @@ struct TouchIDEnrolmentViewModel: GDSCentreAlignedViewModel,
     init(analyticsService: OneLoginAnalyticsService,
          primaryButtonAction: @escaping () -> Void,
          secondaryButtonAction: @escaping () -> Void) {
-        var tempAnalyticsService = analyticsService
-        tempAnalyticsService.setAdditionalParameters(appTaxonomy: .biometrics)
-        self.analyticsService = tempAnalyticsService
+        self.analyticsService = analyticsService.addingAdditionalParameters([
+            OLTaxonomyKey.level2: OLTaxonomyValue.login,
+            OLTaxonomyKey.level3: OLTaxonomyValue.biometrics
+        ])
         self.primaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "app_enableTouchIDEnableButton",
                                                                analyticsService: analyticsService) {
             primaryButtonAction()

--- a/Sources/Screens/Enrolment/TouchIDEnrolmentViewModel.swift
+++ b/Sources/Screens/Enrolment/TouchIDEnrolmentViewModel.swift
@@ -24,7 +24,9 @@ struct TouchIDEnrolmentViewModel: GDSCentreAlignedViewModel,
     init(analyticsService: OneLoginAnalyticsService,
          primaryButtonAction: @escaping () -> Void,
          secondaryButtonAction: @escaping () -> Void) {
-        self.analyticsService = analyticsService
+        var tempAnalyticsService = analyticsService
+        tempAnalyticsService.setAdditionalParameters(appTaxonomy: .biometrics)
+        self.analyticsService = tempAnalyticsService
         self.primaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "app_enableTouchIDEnableButton",
                                                                analyticsService: analyticsService) {
             primaryButtonAction()

--- a/Sources/Screens/Errors/GenericErrorViewModel.swift
+++ b/Sources/Screens/Errors/GenericErrorViewModel.swift
@@ -19,7 +19,9 @@ struct GenericErrorViewModel: GDSErrorViewModelV2,
     init(analyticsService: OneLoginAnalyticsService,
          errorDescription: String,
          action: @escaping () -> Void) {
-        self.analyticsService = analyticsService
+        var tempAnalyticsService = analyticsService
+        tempAnalyticsService.setAdditionalParameters(appTaxonomy: .error)
+        self.analyticsService = tempAnalyticsService
         self.errorDescription = errorDescription
         let event = LinkEvent(textKey: "app_tryAgainButton",
                               linkDomain: AppEnvironment.mobileBaseURLString,

--- a/Sources/Screens/Errors/GenericErrorViewModel.swift
+++ b/Sources/Screens/Errors/GenericErrorViewModel.swift
@@ -19,9 +19,10 @@ struct GenericErrorViewModel: GDSErrorViewModelV2,
     init(analyticsService: OneLoginAnalyticsService,
          errorDescription: String,
          action: @escaping () -> Void) {
-        var tempAnalyticsService = analyticsService
-        tempAnalyticsService.setAdditionalParameters(appTaxonomy: .error)
-        self.analyticsService = tempAnalyticsService
+        self.analyticsService = analyticsService.addingAdditionalParameters([
+            OLTaxonomyKey.level2: OLTaxonomyValue.system,
+            OLTaxonomyKey.level3: OLTaxonomyValue.error
+        ])
         self.errorDescription = errorDescription
         let event = LinkEvent(textKey: "app_tryAgainButton",
                               linkDomain: AppEnvironment.mobileBaseURLString,

--- a/Sources/Screens/Errors/NetworkConnectionErrorViewModel.swift
+++ b/Sources/Screens/Errors/NetworkConnectionErrorViewModel.swift
@@ -16,7 +16,10 @@ struct NetworkConnectionErrorViewModel: GDSErrorViewModelV2,
     let backButtonIsHidden: Bool = true
     
     init(analyticsService: OneLoginAnalyticsService, action: @escaping () -> Void) {
-        self.analyticsService = analyticsService
+        self.analyticsService = analyticsService.addingAdditionalParameters([
+            OLTaxonomyKey.level2: OLTaxonomyValue.system,
+            OLTaxonomyKey.level3: OLTaxonomyValue.error
+        ])
         self.primaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "app_tryAgainButton",
                                                                analyticsService: analyticsService) {
             action()

--- a/Sources/Screens/Errors/UnableToLoginErrorViewModel.swift
+++ b/Sources/Screens/Errors/UnableToLoginErrorViewModel.swift
@@ -19,9 +19,10 @@ struct UnableToLoginErrorViewModel: GDSErrorViewModelV2,
     init(analyticsService: OneLoginAnalyticsService,
          errorDescription: String,
          action: @escaping () -> Void) {
-        var tempAnalyticsService = analyticsService
-        tempAnalyticsService.setAdditionalParameters(appTaxonomy: .loginError)
-        self.analyticsService = tempAnalyticsService
+        self.analyticsService = analyticsService.addingAdditionalParameters([
+            OLTaxonomyKey.level2: OLTaxonomyValue.login,
+            OLTaxonomyKey.level3: OLTaxonomyValue.error
+        ])
         self.errorDescription = errorDescription
         self.primaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "app_closeButton",
                                                                analyticsService: analyticsService) {

--- a/Sources/Screens/Errors/UnableToLoginErrorViewModel.swift
+++ b/Sources/Screens/Errors/UnableToLoginErrorViewModel.swift
@@ -19,7 +19,9 @@ struct UnableToLoginErrorViewModel: GDSErrorViewModelV2,
     init(analyticsService: OneLoginAnalyticsService,
          errorDescription: String,
          action: @escaping () -> Void) {
-        self.analyticsService = analyticsService
+        var tempAnalyticsService = analyticsService
+        tempAnalyticsService.setAdditionalParameters(appTaxonomy: .loginError)
+        self.analyticsService = tempAnalyticsService
         self.errorDescription = errorDescription
         self.primaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "app_closeButton",
                                                                analyticsService: analyticsService) {

--- a/Sources/Screens/Unlock/UnlockScreenViewModel.swift
+++ b/Sources/Screens/Unlock/UnlockScreenViewModel.swift
@@ -12,9 +12,10 @@ struct UnlockScreenViewModel: BaseViewModel {
     
     init(analyticsService: OneLoginAnalyticsService,
          primaryButtonAction: @escaping () -> Void ) {
-        var tempAnalyticsService = analyticsService
-        tempAnalyticsService.setAdditionalParameters(appTaxonomy: .unlock)
-        self.analyticsService = tempAnalyticsService
+        self.analyticsService = analyticsService.addingAdditionalParameters([
+            OLTaxonomyKey.level2: OLTaxonomyValue.login,
+            OLTaxonomyKey.level3: OLTaxonomyValue.unlock
+        ])
         self.primaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "app_unlockButton",
                                                                analyticsService: analyticsService) {
             primaryButtonAction()

--- a/Sources/Screens/Unlock/UnlockScreenViewModel.swift
+++ b/Sources/Screens/Unlock/UnlockScreenViewModel.swift
@@ -12,7 +12,9 @@ struct UnlockScreenViewModel: BaseViewModel {
     
     init(analyticsService: OneLoginAnalyticsService,
          primaryButtonAction: @escaping () -> Void ) {
-        self.analyticsService = analyticsService
+        var tempAnalyticsService = analyticsService
+        tempAnalyticsService.setAdditionalParameters(appTaxonomy: .unlock)
+        self.analyticsService = tempAnalyticsService
         self.primaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "app_unlockButton",
                                                                analyticsService: analyticsService) {
             primaryButtonAction()

--- a/Tests/UnitTests/Screens/Enrolment/FaceIDEnrolmentViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Enrolment/FaceIDEnrolmentViewModelTests.swift
@@ -74,7 +74,7 @@ extension FaceIDEnrolmentViewModelTests {
                                 titleKey: "app_enableFaceIDTitle")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String, AppTaxonomy.login.rawValue)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level3"] as? String, AppTaxonomy.biometrics.rawValue)
+        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String, OLTaxonomyValue.login)
+        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level3"] as? String, OLTaxonomyValue.biometrics)
     }
 }

--- a/Tests/UnitTests/Screens/Enrolment/FaceIDEnrolmentViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Enrolment/FaceIDEnrolmentViewModelTests.swift
@@ -74,5 +74,7 @@ extension FaceIDEnrolmentViewModelTests {
                                 titleKey: "app_enableFaceIDTitle")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
+        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String, AppTaxonomy.login.rawValue)
+        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level3"] as? String, AppTaxonomy.biometrics.rawValue)
     }
 }

--- a/Tests/UnitTests/Screens/Enrolment/TouchIDEnrolmentViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Enrolment/TouchIDEnrolmentViewModelTests.swift
@@ -74,5 +74,7 @@ extension TouchIDEnrolmentViewModelTests {
                                 titleKey: "app_enableTouchIDTitle")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
+        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String, AppTaxonomy.login.rawValue)
+        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level3"] as? String, AppTaxonomy.biometrics.rawValue)
     }
 }

--- a/Tests/UnitTests/Screens/Enrolment/TouchIDEnrolmentViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Enrolment/TouchIDEnrolmentViewModelTests.swift
@@ -74,7 +74,7 @@ extension TouchIDEnrolmentViewModelTests {
                                 titleKey: "app_enableTouchIDTitle")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String, AppTaxonomy.login.rawValue)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level3"] as? String, AppTaxonomy.biometrics.rawValue)
+        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String, OLTaxonomyValue.login)
+        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level3"] as? String, OLTaxonomyValue.biometrics)
     }
 }

--- a/Tests/UnitTests/Screens/Errors/GenericErrorViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Errors/GenericErrorViewModelTests.swift
@@ -77,5 +77,7 @@ extension GenericErrorViewModelTests {
                                      reason: sut.errorDescription)
         #expect(mockAnalyticsService.screensVisited == [screen.name])
         #expect(mockAnalyticsService.screenParamsLogged == screen.parameters)
+        #expect(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String == AppTaxonomy.system.rawValue)
+        #expect(mockAnalyticsService.additionalParameters["taxonomy_level3"] as? String == AppTaxonomy.error.rawValue)
     }
 }

--- a/Tests/UnitTests/Screens/Errors/GenericErrorViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Errors/GenericErrorViewModelTests.swift
@@ -77,7 +77,7 @@ extension GenericErrorViewModelTests {
                                      reason: sut.errorDescription)
         #expect(mockAnalyticsService.screensVisited == [screen.name])
         #expect(mockAnalyticsService.screenParamsLogged == screen.parameters)
-        #expect(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String == AppTaxonomy.system.rawValue)
-        #expect(mockAnalyticsService.additionalParameters["taxonomy_level3"] as? String == AppTaxonomy.error.rawValue)
+        #expect(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String == OLTaxonomyValue.system)
+        #expect(mockAnalyticsService.additionalParameters["taxonomy_level3"] as? String == OLTaxonomyValue.error)
     }
 }

--- a/Tests/UnitTests/Screens/Errors/NetworkConnectionErrorViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Errors/NetworkConnectionErrorViewModelTests.swift
@@ -59,5 +59,7 @@ extension NetworkConnectionErrorViewModelTests {
                                      reason: "network connection error")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
+        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String, AppTaxonomy.system.rawValue)
+        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level3"] as? String, AppTaxonomy.error.rawValue)
     }
 }

--- a/Tests/UnitTests/Screens/Errors/NetworkConnectionErrorViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Errors/NetworkConnectionErrorViewModelTests.swift
@@ -59,7 +59,7 @@ extension NetworkConnectionErrorViewModelTests {
                                      reason: "network connection error")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String, AppTaxonomy.system.rawValue)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level3"] as? String, AppTaxonomy.error.rawValue)
+        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String, OLTaxonomyValue.system)
+        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level3"] as? String, OLTaxonomyValue.error)
     }
 }

--- a/Tests/UnitTests/Screens/Errors/UnableToLoginErrorViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Errors/UnableToLoginErrorViewModelTests.swift
@@ -58,7 +58,7 @@ extension UnableToLoginErrorViewModelTests {
                                      reason: "error description")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String, AppTaxonomy.login.rawValue)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level3"] as? String, AppTaxonomy.error.rawValue)
+        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String, OLTaxonomyValue.login)
+        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level3"] as? String, OLTaxonomyValue.error)
     }
 }

--- a/Tests/UnitTests/Screens/Errors/UnableToLoginErrorViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Errors/UnableToLoginErrorViewModelTests.swift
@@ -58,5 +58,7 @@ extension UnableToLoginErrorViewModelTests {
                                      reason: "error description")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
+        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String, AppTaxonomy.login.rawValue)
+        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level3"] as? String, AppTaxonomy.error.rawValue)
     }
 }

--- a/Tests/UnitTests/Screens/Unlock/UnlockScreenViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Unlock/UnlockScreenViewModelTests.swift
@@ -50,7 +50,7 @@ extension UnlockScreenViewModelTests {
                                 titleKey: "one login unlock screen")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String, AppTaxonomy.login.rawValue)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level3"] as? String, AppTaxonomy.unlock.rawValue)
+        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String, OLTaxonomyValue.login)
+        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level3"] as? String, OLTaxonomyValue.unlock)
     }
 }

--- a/Tests/UnitTests/Screens/Unlock/UnlockScreenViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Unlock/UnlockScreenViewModelTests.swift
@@ -50,5 +50,7 @@ extension UnlockScreenViewModelTests {
                                 titleKey: "one login unlock screen")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
+        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level2"] as? String, AppTaxonomy.login.rawValue)
+        XCTAssertEqual(mockAnalyticsService.additionalParameters["taxonomy_level3"] as? String, AppTaxonomy.unlock.rawValue)
     }
 }


### PR DESCRIPTION
# DCMAW-11962: Update GA4 taxonomy levels to align with Android

Updated taxonomy levels for the following screens:
- Enable Face ID page
- Enable Touch ID page
- Unlock Screen page 
- Generic Error page
- Sign In Error page 
- Network Connection Error page

### QA Evidence
Enable FaceID Screen
![Screenshot 2025-03-19 at 16 02 54](https://github.com/user-attachments/assets/893d653a-0a38-43b4-81ab-85729dc62909)

Enable TouchID Screen
![Screenshot 2025-03-19 at 16 07 23](https://github.com/user-attachments/assets/1c957d03-f589-436f-bdb1-e00bf62d6a3b)

Unlock Screen
<img width="745" alt="Screenshot 2025-03-25 at 15 48 04" src="https://github.com/user-attachments/assets/085dd563-5740-4636-807d-fb68423f182c" />

Generic Error Screen
![Screenshot 2025-03-19 at 16 10 25](https://github.com/user-attachments/assets/19526c67-8af5-4ac6-9564-07ca5ce1db4e)

Sign In Error Screen
![Screenshot 2025-03-19 at 16 00 33](https://github.com/user-attachments/assets/e638cf3d-e6ad-4ba0-87c8-a8f49e6eab33)

Network Error Screen
![Screenshot 2025-03-19 at 13 09 00](https://github.com/user-attachments/assets/df8098df-4599-4b41-b7d2-220d188f7516)


# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~ 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
