### PR TITLE
feat: added 'typ' to app integrity pop header

### DIFF
--- a/Sources/Qualification/AppAttestation/AppIntegrityJWT.swift
+++ b/Sources/Qualification/AppAttestation/AppIntegrityJWT.swift
@@ -7,7 +7,10 @@ enum AppIntegrityJWT {
     func callAsFunction() -> [String: Any] {
         switch self {
         case .headers:
-            ["alg": "ES256"]
+            [
+                "alg": "ES256",
+                "typ": "oauth-client-attestation-pop+jwt"
+            ]
         case .payload:
             [
                 "iss": AppEnvironment.stsClientID,

--- a/Tests/UnitTests/Qualification/AppAttestationTests/AppIntegrityJWTTests.swift
+++ b/Tests/UnitTests/Qualification/AppAttestationTests/AppIntegrityJWTTests.swift
@@ -10,7 +10,8 @@ import Testing
     func initialiseJWTHeader() {
         let header = AppIntegrityJWT.headers()
 
-        #expect(header as? [String: String] == ["alg": "ES256"])
+        #expect(header as? [String: String] == ["alg": "ES256",
+                                                "typ": "oauth-client-attestation-pop+jwt"])
     }
      
      @Test("""


### PR DESCRIPTION
# DCMAW-11878: App Integrity | Update the proof of possession to include the `typ` header parameter

The app integrity spec has been updated to ensure that the client attestation includes a `typ` header equal to `oauth-client-attestation+jwt`. This PR aims to update the PoP accordingly.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
~- [ ] Created a `draft` pull request if it is not yet ready for review~

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
~- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.~
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~ 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
