### PR TITLE
fix: fixed constraints with displaying tableview

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -135,6 +135,7 @@
 		C85E21042ACEE34900AF8B4E /* TabManagerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85E21032ACEE34900AF8B4E /* TabManagerCoordinator.swift */; };
 		C85E210D2ACEE93C00AF8B4E /* OneLoginIntroViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85E210C2ACEE93C00AF8B4E /* OneLoginIntroViewModel.swift */; };
 		C85E21182ACEECD800AF8B4E /* AnalyticsButtonViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85E21172ACEECD800AF8B4E /* AnalyticsButtonViewModel.swift */; };
+		C8603B1F2D9EC40400B4AD28 /* MockCRIORchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8603B1E2D9EC3F400B4AD28 /* MockCRIORchestrator.swift */; };
 		C865444D2BD7D55000433897 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = C865444C2BD7D55000433897 /* PrivacyInfo.xcprivacy */; };
 		C865E6522C21DC24001FA62D /* UniversalLinkQualifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C865E6512C21DC24001FA62D /* UniversalLinkQualifier.swift */; };
 		C865E6542C21DDA5001FA62D /* UniversalLinkQualifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C865E6532C21DDA5001FA62D /* UniversalLinkQualifierTests.swift */; };
@@ -399,6 +400,7 @@
 		C85E21032ACEE34900AF8B4E /* TabManagerCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerCoordinator.swift; sourceTree = "<group>"; };
 		C85E210C2ACEE93C00AF8B4E /* OneLoginIntroViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneLoginIntroViewModel.swift; sourceTree = "<group>"; };
 		C85E21172ACEECD800AF8B4E /* AnalyticsButtonViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsButtonViewModel.swift; sourceTree = "<group>"; };
+		C8603B1E2D9EC3F400B4AD28 /* MockCRIORchestrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCRIORchestrator.swift; sourceTree = "<group>"; };
 		C865444C2BD7D55000433897 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		C865E6512C21DC24001FA62D /* UniversalLinkQualifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversalLinkQualifier.swift; sourceTree = "<group>"; };
 		C865E6532C21DDA5001FA62D /* UniversalLinkQualifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversalLinkQualifierTests.swift; sourceTree = "<group>"; };
@@ -1036,6 +1038,7 @@
 		C85DF8432AEBFDCC0064F68E /* Sessions+Services */ = {
 			isa = PBXGroup;
 			children = (
+				C8603B1E2D9EC3F400B4AD28 /* MockCRIORchestrator.swift */,
 				C8C3439E2B92226900E92FB9 /* Analytics */,
 				C8E6A3E92BBC05DB005015AF /* Application */,
 				C88958832C7E8A1100663299 /* LocalAuth */,
@@ -2012,6 +2015,7 @@
 				D08B0B5C2BD8046200769CEA /* HomeCoordinatorTests.swift in Sources */,
 				413C58762BF261D300171C06 /* HomeViewControllerTests.swift in Sources */,
 				D0BE24452BEBCB5000759529 /* JWTVerifierTests.swift in Sources */,
+				C8603B1F2D9EC40400B4AD28 /* MockCRIORchestrator.swift in Sources */,
 				C88958852C7F1E7000663299 /* LALocalAuthenticationManagerTests.swift in Sources */,
 				C8B05F452B7AA7B3009D4283 /* LocalizedEnglishStringTests.swift in Sources */,
 				C8B05F472B7AA816009D4283 /* LocalizedWelshStringTests.swift in Sources */,

--- a/Sources/Screens/Tabs/HomeViewController.swift
+++ b/Sources/Screens/Tabs/HomeViewController.swift
@@ -9,13 +9,13 @@ final class HomeViewController: UITableViewController {
     let navigationTitle: GDSLocalisedString = "app_homeTitle"
     private var analyticsService: OneLoginAnalyticsService
     private let networkClient: NetworkClient
-    private let criOrchestrator: CRIOrchestrator
+    private let criOrchestrator: CRIOrchestration
     
     private var idCheckCard: UIViewController?
 
     init(analyticsService: OneLoginAnalyticsService,
          networkClient: NetworkClient,
-         criOrchestrator: CRIOrchestrator) {
+         criOrchestrator: CRIOrchestration) {
         self.analyticsService = analyticsService.addingAdditionalParameters([
             OLTaxonomyKey.level2: OLTaxonomyValue.home,
             OLTaxonomyKey.level3: OLTaxonomyValue.undefined
@@ -102,3 +102,15 @@ extension HomeViewController {
         }
     }
 }
+
+@MainActor
+protocol CRIOrchestration {
+    func continueIdentityCheckIfRequired(over viewController: UIViewController)
+    
+    func getIDCheckCard(
+        viewController: UIViewController,
+        completion: @escaping () -> Void
+    ) -> UIViewController
+}
+
+extension CRIOrchestrator: CRIOrchestration { }

--- a/Sources/Screens/Tabs/HomeViewController.swift
+++ b/Sources/Screens/Tabs/HomeViewController.swift
@@ -10,6 +10,8 @@ final class HomeViewController: UITableViewController {
     private var analyticsService: OneLoginAnalyticsService
     private let networkClient: NetworkClient
     private let criOrchestrator: CRIOrchestrator
+    
+    private var idCheckCard: UIViewController?
 
     init(analyticsService: OneLoginAnalyticsService,
          networkClient: NetworkClient,
@@ -32,9 +34,14 @@ final class HomeViewController: UITableViewController {
         title = navigationTitle.value
         navigationController?.navigationBar.prefersLargeTitles = true
         navigationController?.navigationBar.sizeToFit()
+        tableView.register(ContentTileCell.self, forCellReuseIdentifier: "ContentTileCell")
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: "OneLoginHomeScreenCell")
         if AppEnvironment.criOrchestratorEnabled {
             criOrchestrator.continueIdentityCheckIfRequired(over: self)
+        }
+        
+        idCheckCard = criOrchestrator.getIDCheckCard(viewController: self) { [unowned self] in
+            self.tableView.reloadData()
         }
     }
     
@@ -49,7 +56,8 @@ final class HomeViewController: UITableViewController {
 
 extension HomeViewController {
     override func numberOfSections(in tableView: UITableView) -> Int {
-        2
+        guard let idCheckCard else { return 1 }
+        return idCheckCard.view.isHidden ? 1 : 2
     }
     
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -59,30 +67,36 @@ extension HomeViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         switch indexPath.section {
         case 0:
-            let cell = ContentTileCell()
+            guard let cell = tableView.dequeueReusableCell(
+                withIdentifier: "ContentTileCell",
+                for: indexPath
+            ) as? ContentTileCell else {
+                preconditionFailure()
+            }
             cell.viewModel = .oneLoginCard(analyticsService: analyticsService,
                                            urlOpener: UIApplication.shared)
             return cell
         case 1:
-            let idCheckCard = criOrchestrator.getIDCheckCard(viewController: self) {
-                tableView.reloadData()
+            guard let idCheckCard else {
+                preconditionFailure("")
             }
-            let tableViewCell = tableView.dequeueReusableCell(
+            let cell = tableView.dequeueReusableCell(
                 withIdentifier: "OneLoginHomeScreenCell",
                 for: indexPath
             )
             
-            tableViewCell.addSubview(idCheckCard.view)
-            tableViewCell.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-                tableViewCell.topAnchor.constraint(equalTo: idCheckCard.view.topAnchor),
-                tableViewCell.bottomAnchor.constraint(equalTo: idCheckCard.view.bottomAnchor),
-                tableViewCell.leadingAnchor.constraint(equalTo: idCheckCard.view.leadingAnchor),
-                tableViewCell.trailingAnchor.constraint(equalTo: idCheckCard.view.trailingAnchor)
-            ])
-            tableViewCell.isHidden = !AppEnvironment.criOrchestratorEnabled
+            idCheckCard.view.translatesAutoresizingMaskIntoConstraints = false
+            cell.isHidden = !AppEnvironment.criOrchestratorEnabled || idCheckCard.view.isHidden
+            cell.contentView.addSubview(idCheckCard.view)
             
-            return tableViewCell
+            NSLayoutConstraint.activate([
+                idCheckCard.view.topAnchor.constraint(equalTo: cell.contentView.topAnchor),
+                idCheckCard.view.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor),
+                idCheckCard.view.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor),
+                idCheckCard.view.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor)
+            ])
+
+            return cell
         default:
             return UITableViewCell()
         }

--- a/Sources/Screens/Tabs/HomeViewController.swift
+++ b/Sources/Screens/Tabs/HomeViewController.swift
@@ -36,12 +36,11 @@ final class HomeViewController: UITableViewController {
         navigationController?.navigationBar.sizeToFit()
         tableView.register(ContentTileCell.self, forCellReuseIdentifier: "ContentTileCell")
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: "OneLoginHomeScreenCell")
-        if AppEnvironment.criOrchestratorEnabled {
-            criOrchestrator.continueIdentityCheckIfRequired(over: self)
-        }
-        
         idCheckCard = criOrchestrator.getIDCheckCard(viewController: self) { [unowned self] in
             self.tableView.reloadData()
+        }
+        if AppEnvironment.criOrchestratorEnabled {
+            criOrchestrator.continueIdentityCheckIfRequired(over: self)
         }
     }
     

--- a/Tests/UnitTests/Mocks/Sessions+Services/MockCRIORchestrator.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/MockCRIORchestrator.swift
@@ -2,13 +2,14 @@
 import UIKit
 
 class MockCRIOrchestrator: CRIOrchestration {
+    private var hostingViewController: UIViewController = UIViewController()
+    
     func continueIdentityCheckIfRequired(over viewController: UIViewController) {
-        
+        hostingViewController.view.isHidden = false
     }
     
     func getIDCheckCard(viewController: UIViewController, completion: @escaping () -> Void) -> UIViewController {
-        let vc = UIViewController()
-        vc.view.isHidden = false
-        return vc
+        hostingViewController.view.isHidden = true
+        return hostingViewController
     }
 }

--- a/Tests/UnitTests/Mocks/Sessions+Services/MockCRIORchestrator.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/MockCRIORchestrator.swift
@@ -1,0 +1,14 @@
+@testable import OneLogin
+import UIKit
+
+class MockCRIOrchestrator: CRIOrchestration {
+    func continueIdentityCheckIfRequired(over viewController: UIViewController) {
+        
+    }
+    
+    func getIDCheckCard(viewController: UIViewController, completion: @escaping () -> Void) -> UIViewController {
+        let vc = UIViewController()
+        vc.view.isHidden = false
+        return vc
+    }
+}

--- a/Tests/UnitTests/Screens/Tabs/HomeViewControllerTests.swift
+++ b/Tests/UnitTests/Screens/Tabs/HomeViewControllerTests.swift
@@ -48,8 +48,8 @@ extension HomeViewControllerTests {
         XCTAssertEqual(sut.navigationTitle.stringKey, "app_homeTitle")
     }
     
-    func test_numberOfSections() {
-        XCTAssertEqual(sut.numberOfSections(in: sut.tableView), 2)
+    func test_numberOfSectionsWithIDCheck() {
+        XCTAssertEqual(sut.numberOfSections(in: sut.tableView), 1)
     }
 
     func test_numbeOfRowsInSection() {
@@ -75,7 +75,7 @@ extension HomeViewControllerTests {
             sut.tableView,
             cellForRowAt: IndexPath(row: 0, section: 1)
         )
-        XCTAssertFalse(servicesTile.isHidden)
+        waitForTruth(!servicesTile.isHidden, timeout: 5)
     }
 
     func test_idCheckTileCell_isHidden() {

--- a/Tests/UnitTests/Screens/Tabs/HomeViewControllerTests.swift
+++ b/Tests/UnitTests/Screens/Tabs/HomeViewControllerTests.swift
@@ -47,14 +47,28 @@ extension HomeViewControllerTests {
     }
     
     func test_numberOfSectionsWithIDCheck() {
+        AppEnvironment.updateFlags(
+            releaseFlags: [:],
+            featureFlags: [FeatureFlagsName.enableCRIOrchestrator.rawValue: true]
+        )
+        UINavigationController().setViewControllers([sut], animated: false)
         XCTAssertEqual(sut.numberOfSections(in: sut.tableView), 2)
     }
-
+    
+    func test_numberOfSectionsWithoutIDCheck() {
+        AppEnvironment.updateFlags(
+            releaseFlags: [:],
+            featureFlags: [FeatureFlagsName.enableCRIOrchestrator.rawValue: false]
+        )
+        UINavigationController().setViewControllers([sut], animated: false)
+        XCTAssertEqual(sut.numberOfSections(in: sut.tableView), 1)
+    }
+    
     func test_numbeOfRowsInSection() {
         XCTAssertEqual(sut.tableView(sut.tableView, numberOfRowsInSection: 0), 1)
         XCTAssertEqual(sut.tableView(sut.tableView, numberOfRowsInSection: 1), 1)
     }
-
+    
     func test_contentTileCell_viewModel() {
         let servicesTile = sut.tableView(
             sut.tableView,
@@ -75,7 +89,7 @@ extension HomeViewControllerTests {
         )
         waitForTruth(!servicesTile.isHidden, timeout: 5)
     }
-
+    
     func test_idCheckTileCell_isHidden() {
         UINavigationController().setViewControllers([sut], animated: false)
         let servicesTile = sut.tableView(

--- a/Tests/UnitTests/Screens/Tabs/HomeViewControllerTests.swift
+++ b/Tests/UnitTests/Screens/Tabs/HomeViewControllerTests.swift
@@ -8,7 +8,7 @@ import XCTest
 final class HomeViewControllerTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
     var mockNetworkClient: NetworkClient!
-    var criOrchestrator: CRIOrchestrator!
+    var criOrchestrator: MockCRIOrchestrator!
     var sut: HomeViewController!
     
     override func setUp() {
@@ -18,9 +18,7 @@ final class HomeViewControllerTests: XCTestCase {
         mockNetworkClient = NetworkClient()
         mockNetworkClient.authorizationProvider = MockAuthenticationProvider()
         
-        criOrchestrator = CRIOrchestrator(analyticsService: mockAnalyticsService,
-                                          networkClient: mockNetworkClient,
-                                          criURLs: OneLoginCRIURLs())
+        criOrchestrator = MockCRIOrchestrator()
         sut = HomeViewController(analyticsService: mockAnalyticsService,
                                  networkClient: mockNetworkClient,
                                  criOrchestrator: criOrchestrator)
@@ -49,7 +47,7 @@ extension HomeViewControllerTests {
     }
     
     func test_numberOfSectionsWithIDCheck() {
-        XCTAssertEqual(sut.numberOfSections(in: sut.tableView), 1)
+        XCTAssertEqual(sut.numberOfSections(in: sut.tableView), 2)
     }
 
     func test_numbeOfRowsInSection() {


### PR DESCRIPTION
# DCMAW-12402: ID Check Journey UI Card doesn't show on OneLogin's home page after cancelling ID Check Journey Modal

The HomeViewController was not correctly configured to display the ID Check card. This PR amends the configuration in that view controller.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
