### PR TITLE
fix: update Wallet SDK for data deletion

### DIFF
--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-id-check-ios-sdk.git",
       "state" : {
-        "revision" : "7e16013b79505633d23c707af2151e68264445d6",
-        "version" : "6.1.1"
+        "revision" : "62d7d00ba89ebc5255f0af6d370ed9065b6ef4cb",
+        "version" : "6.6.0"
       }
     },
     {
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-common.git",
       "state" : {
-        "revision" : "646c4ba85f6101465e2398a4557b491a76fd8f30",
-        "version" : "2.7.1"
+        "revision" : "66016a4a82c5e62b36286cebdfd78341ccafcdb6",
+        "version" : "2.8.0"
       }
     },
     {
@@ -194,8 +194,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-wallet-ios.git",
       "state" : {
-        "revision" : "0ae8f1501e8a3a2cfba5a2b161b06be5944a931c",
-        "version" : "10.3.0"
+        "revision" : "92dbb351515d101ec938f7838c7ecc6214c101e0",
+        "version" : "10.9.0"
       }
     },
     {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-id-check-ios-sdk.git",
       "state" : {
-        "revision" : "62d7d00ba89ebc5255f0af6d370ed9065b6ef4cb",
-        "version" : "6.6.0"
+        "revision" : "1f15839f82761f2c72c1ec478203ab49aa391f8b",
+        "version" : "6.7.0"
       }
     },
     {

--- a/Sources/Login/WebAuthenticationService.swift
+++ b/Sources/Login/WebAuthenticationService.swift
@@ -28,7 +28,7 @@ final class WebAuthenticationService: AuthenticationService {
             analyticsService.logEvent(userCancelEvent)
             throw error
         } catch let error as LoginError where error == .accessDenied {
-            try sessionManager.clearAllSessionData()
+            try await sessionManager.clearAllSessionData()
             throw error
         }
     }

--- a/Sources/Qualification/State/AppQualifyingService.swift
+++ b/Sources/Qualification/State/AppQualifyingService.swift
@@ -117,7 +117,7 @@ final class AppQualifyingService: QualifyingService {
             } catch {
                 do {
                     analyticsService.logCrash(error)
-                    try sessionManager.clearAllSessionData()
+                    try await sessionManager.clearAllSessionData()
                 } catch {
                     userState = .failed(error)
                 }

--- a/Sources/Service/WalletSessionData+OneLogin.swift
+++ b/Sources/Service/WalletSessionData+OneLogin.swift
@@ -1,9 +1,7 @@
 import Wallet
 
 struct WalletSessionData: SessionBoundData {
-    func delete() throws {
-        Task {
-            try await WalletSDK.deleteData()
-        }
+    func delete() async throws {
+        try await WalletSDK.deleteData()
     }
 }

--- a/Sources/Tabs/TabManagerCoordinator.swift
+++ b/Sources/Tabs/TabManagerCoordinator.swift
@@ -97,18 +97,20 @@ final class TabManagerCoordinator: NSObject,
 extension TabManagerCoordinator: ParentCoordinator {
     func performChildCleanup(child: ChildCoordinator) {
         if child is SettingsCoordinator {
-            do {
-                #if DEBUG
-                if AppEnvironment.signoutErrorEnabled {
-                    throw SecureStoreError.cantDeleteKey
+            Task {
+                do {
+                    #if DEBUG
+                    if AppEnvironment.signoutErrorEnabled {
+                        throw SecureStoreError.cantDeleteKey
+                    }
+                    #endif
+                    try await sessionManager.clearAllSessionData()
+                } catch {
+                    let viewModel = SignOutErrorViewModel(analyticsService: analyticsService,
+                                                          error: error)
+                    let signOutErrorScreen = GDSErrorViewController(viewModel: viewModel)
+                    root.present(signOutErrorScreen, animated: true)
                 }
-                #endif
-                try sessionManager.clearAllSessionData()
-            } catch {
-                let viewModel = SignOutErrorViewModel(analyticsService: analyticsService,
-                                                      error: error)
-                let signOutErrorScreen = GDSErrorViewController(viewModel: viewModel)
-                root.present(signOutErrorScreen, animated: true)
             }
         }
     }

--- a/Sources/Utilities/Factories/TabbedViewSectionFactory.swift
+++ b/Sources/Utilities/Factories/TabbedViewSectionFactory.swift
@@ -78,7 +78,6 @@ extension TabbedViewSectionModel {
     }
     
     static func signOutSection(analyticsService: OneLoginAnalyticsService, action: @escaping () -> Void) -> Self {
-        var analyticsService = analyticsService
         return TabbedViewSectionModel(sectionTitle: nil,
                                       sectionFooter: nil,
                                       tabModels: [.init(cellTitle: "app_signOutButton",

--- a/Sources/Utilities/Storage/Session/PersistentSessionManager.swift
+++ b/Sources/Utilities/Storage/Session/PersistentSessionManager.swift
@@ -166,7 +166,7 @@ final class PersistentSessionManager: SessionManager {
             secureStoreManager.encryptedStore.deleteItem(itemName: OLString.persistentSessionID)
         }
         
-        unprotectedStore.set(tokenResponse.expiryDate,
+        unprotectedStore.set(Date.distantPast,
                              forKey: OLString.accessTokenExpiry)
         unprotectedStore.set(true, forKey: OLString.returningUser)
     }

--- a/Sources/Utilities/Storage/Session/PersistentSessionManager.swift
+++ b/Sources/Utilities/Storage/Session/PersistentSessionManager.swift
@@ -166,7 +166,7 @@ final class PersistentSessionManager: SessionManager {
             secureStoreManager.encryptedStore.deleteItem(itemName: OLString.persistentSessionID)
         }
         
-        unprotectedStore.set(Date.distantPast,
+        unprotectedStore.set(tokenResponse.expiryDate,
                              forKey: OLString.accessTokenExpiry)
         unprotectedStore.set(true, forKey: OLString.returningUser)
     }

--- a/Sources/Utilities/Storage/Session/PersistentSessionManager.swift
+++ b/Sources/Utilities/Storage/Session/PersistentSessionManager.swift
@@ -26,7 +26,7 @@ enum PersistentSessionError: Error, Equatable {
 }
 
 protocol SessionBoundData {
-    func delete() throws
+    func delete() async throws
 }
 
 final class PersistentSessionManager: SessionManager {
@@ -104,7 +104,7 @@ final class PersistentSessionManager: SessionManager {
             //
             // I need to delete my session & Wallet data before I can login
             do {
-                try clearAllSessionData()
+                try await clearAllSessionData()
             } catch {
                 throw PersistentSessionError.cannotDeleteData(error)
             }
@@ -203,9 +203,9 @@ final class PersistentSessionManager: SessionManager {
         user.send(nil)
     }
     
-    func clearAllSessionData() throws {
-        try sessionBoundData.forEach {
-            try $0.delete()
+    func clearAllSessionData() async throws {
+        for each in sessionBoundData {
+            try await each.delete()
         }
         endCurrentSession()
         

--- a/Sources/Utilities/Storage/Session/SessionManager.swift
+++ b/Sources/Utilities/Storage/Session/SessionManager.swift
@@ -36,5 +36,5 @@ protocol SessionManager: UserProvider {
     func endCurrentSession()
 
     /// Completely removes all user session data (including the persistent session and Wallet data) from the device
-    func clearAllSessionData() throws
+    func clearAllSessionData() async throws
 }

--- a/Tests/TestPlans/OneLoginUnit.xctestplan
+++ b/Tests/TestPlans/OneLoginUnit.xctestplan
@@ -20,13 +20,6 @@
   "testTargets" : [
     {
       "target" : {
-        "containerPath" : "container:LocalAuthenticationWrapper",
-        "identifier" : "LocalAuthenticationWrapperTests",
-        "name" : "LocalAuthenticationWrapperTests"
-      }
-    },
-    {
-      "target" : {
         "containerPath" : "container:AppIntegrity",
         "identifier" : "AppIntegrityTests",
         "name" : "AppIntegrityTests"
@@ -34,9 +27,9 @@
     },
     {
       "target" : {
-        "containerPath" : "container:OneLogin.xcodeproj",
-        "identifier" : "219601FC2A976305008F3427",
-        "name" : "OneLoginUnitTests"
+        "containerPath" : "container:LocalAuthenticationWrapper",
+        "identifier" : "LocalAuthenticationWrapperTests",
+        "name" : "LocalAuthenticationWrapperTests"
       }
     },
     {
@@ -44,6 +37,13 @@
         "containerPath" : "container:MobilePlatformServices",
         "identifier" : "MobilePlatformServicesTests",
         "name" : "MobilePlatformServicesTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:OneLogin.xcodeproj",
+        "identifier" : "219601FC2A976305008F3427",
+        "name" : "OneLoginUnitTests"
       }
     }
   ],

--- a/Tests/UnitTests/Tabs/TabManagerCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/TabManagerCoordinatorTests.swift
@@ -80,10 +80,10 @@ extension TabManagerCoordinatorTests {
                                                       urlOpener: MockURLOpener())
         // WHEN the TabManagerCoordinator's performChildCleanup method is called from SettingsCoordinator (on user sign out)
         sut.performChildCleanup(child: settingsCoordinator)
-        // THEN the session should not be cleared
-        XCTAssertTrue(mockSessionManager.didCallClearAllSessionData)
         // THEN a logout notification is sent
         await fulfillment(of: [exp], timeout: 5)
+        // THEN the session should be cleared
+        XCTAssertTrue(mockSessionManager.didCallClearAllSessionData)
     }
     
     @MainActor
@@ -102,8 +102,8 @@ extension TabManagerCoordinatorTests {
         // but there was an error in signing out
         sut.performChildCleanup(child: settingsCoordinator)
         // THEN the sign out error screen should be presented
-        let errorVC = try XCTUnwrap(sut.root.presentedViewController as? GDSErrorViewController)
-        XCTAssertTrue(errorVC.viewModel is SignOutErrorViewModel)
+        waitForTruth(self.sut.root.presentedViewController is GDSErrorViewController, timeout: 5)
+        XCTAssertTrue((try XCTUnwrap(sut.root.presentedViewController as? GDSErrorViewController)).viewModel is SignOutErrorViewModel)
         // THEN the session should not be cleared
         XCTAssertFalse(mockSessionManager.didCallEndCurrentSession)
     }

--- a/Tests/UnitTests/Utilities/Session/PersistentSessionManagerTests.swift
+++ b/Tests/UnitTests/Utilities/Session/PersistentSessionManagerTests.swift
@@ -320,7 +320,7 @@ extension PersistentSessionManagerTests {
         XCTAssertEqual(mockAccessControlEncryptedStore.savedItems, [:])
     }
     
-    func testEndCurrentSession_clearsAllPersistedData() throws {
+    func testEndCurrentSession_clearsAllPersistedData() async throws {
         // GIVEN I have an expired session
         mockUnprotectedStore.savedData = [
             OLString.returningUser: true,
@@ -331,7 +331,7 @@ extension PersistentSessionManagerTests {
         ]
         sut.registerSessionBoundData([mockUnprotectedStore, mockEncryptedStore])
         // WHEN I clear all session data
-        try sut.clearAllSessionData()
+        try await sut.clearAllSessionData()
         // THEN my session data is deleted
         XCTAssertEqual(mockUnprotectedStore.savedData.count, 0)
         XCTAssertEqual(mockEncryptedStore.savedItems, [:])

--- a/scripts-configs/sonar-project.properties
+++ b/scripts-configs/sonar-project.properties
@@ -3,8 +3,8 @@ sonar.projectName=di-mobile-ios-onelogin-app
 sonar.organization=govuk-one-login
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
-sonar.sources=Sources,AppIntegrity/Sources,MobilePlatformServices/Sources
-sonar.tests=Tests,AppIntegrity/Tests,MobilePlatformServices/Tests
+sonar.sources=Sources,AppIntegrity/Sources,LocalAuthenticationWrapper/Sources,MobilePlatformServices/Sources
+sonar.tests=Tests,AppIntegrity/Tests,LocalAuthenticationWrapper/Tests,MobilePlatformServices/Tests
 
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
# DCMAW-12354: Wallet Credentials do not delete after re-auth error & signing in with a different account.

Updating the Wallet SDK to the latest version where a bug has been fixed for deleting data in the One Login host app.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
