### PR TITLE
fix: adding accessibility hint to analytics opt-in page

### DIFF
--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-common.git",
       "state" : {
-        "revision" : "66016a4a82c5e62b36286cebdfd78341ccafcdb6",
-        "version" : "2.8.0"
+        "revision" : "28ab01aefc1ed9fbd2dd13bb58e707b44851734c",
+        "version" : "2.9.0"
       }
     },
     {

--- a/Sources/Screens/Analytics/AnalyticsPreferenceViewModel.swift
+++ b/Sources/Screens/Analytics/AnalyticsPreferenceViewModel.swift
@@ -26,7 +26,8 @@ struct AnalyticsPreferenceViewModel: ModalInfoWithButtons {
         self.secondaryButtonViewModel = StandardButtonViewModel(titleKey: "app_doNotShareAnalytics") {
             secondaryButtonAction()
         }
-        self.textButtonViewModel = StandardButtonViewModel(titleKey: "app_privacyNoticeLink") {
+        self.textButtonViewModel = StandardButtonViewModel(titleKey: "app_privacyNoticeLink",
+                                                           accessibilityHint: "app_externalBrowser") {
             textButtonAction()
         }
     }

--- a/Sources/Views/Buttons/StandardButtonViewModel.swift
+++ b/Sources/Views/Buttons/StandardButtonViewModel.swift
@@ -5,16 +5,19 @@ struct StandardButtonViewModel: ButtonViewModel {
     let icon: ButtonIconViewModel?
     let shouldLoadOnTap: Bool
     let action: (() -> Void)
+    let accessibilityHint: GDSLocalisedString?
     
     init(titleKey: String,
          titleStringVariableKeys: String...,
          icon: ButtonIconViewModel? = nil,
          shouldLoadOnTap: Bool = false,
+         accessibilityHint: GDSLocalisedString? = nil,
          action: @escaping () -> Void) {
         self.title = GDSLocalisedString(stringKey: titleKey,
                                         variableKeys: titleStringVariableKeys)
         self.icon = icon
         self.shouldLoadOnTap = shouldLoadOnTap
+        self.accessibilityHint = accessibilityHint
         self.action = action
     }
 }

--- a/Tests/UnitTests/Screens/Analytics/AnalyticsPreferenceViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Analytics/AnalyticsPreferenceViewModelTests.swift
@@ -44,6 +44,7 @@ extension AnalyticsPreferenceViewModelTests {
         XCTAssertFalse(didCallPrimaryButtonAction)
         sut.primaryButtonViewModel.action()
         XCTAssertTrue(didCallPrimaryButtonAction)
+        XCTAssertNil(sut.primaryButtonViewModel.accessibilityHint)
     }
 
     func test_secondaryButton_action() throws {
@@ -51,6 +52,7 @@ extension AnalyticsPreferenceViewModelTests {
         XCTAssertFalse(didCallSecondaryButtonAction)
         sut.secondaryButtonViewModel.action()
         XCTAssertTrue(didCallSecondaryButtonAction)
+        XCTAssertNil(sut.secondaryButtonViewModel.accessibilityHint)
     }
 
     func test_textButton_action() throws {
@@ -58,5 +60,6 @@ extension AnalyticsPreferenceViewModelTests {
         XCTAssertFalse(didCallTextButtonAction)
         sut.textButtonViewModel.action()
         XCTAssertTrue(didCallTextButtonAction)
+        XCTAssertEqual(sut.textButtonViewModel.accessibilityHint, "app_externalBrowser")
     }
 }


### PR DESCRIPTION
# DCMAW-12205: Adding accessibility hint for privacy notice on Analytics Opt-in page

Following a missed requirement in [DCMAW-7383](https://govukverify.atlassian.net/browse/DCMAW-7873), this PR aims to add an accessibility hint to the privacy notice on the Analytics Opt-in page.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
~- [ ] Created a `draft` pull request if it is not yet ready for review~

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
~- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.~
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    ~- [ ] Checked dynamic type sizes are applied~
    - [x] Checked VoiceOver can navigate your new code
    ~- [ ] Checked a user can navigate only using a keyboard around your new code~ 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.

[DCMAW-7383]: https://govukverify.atlassian.net/browse/DCMAW-7383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ