### PR TITLE
chore: ID Check NFC permissions

### DIFF
--- a/Sources/Application/Environment/Entitlements/OneLoginBuild.entitlements
+++ b/Sources/Application/Environment/Entitlements/OneLoginBuild.entitlements
@@ -2,11 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.devicecheck.appattest-environment</key>
+	<string>production</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:mobile.build.account.gov.uk</string>
 	</array>
-	<key>com.apple.developer.devicecheck.appattest-environment</key>
-	<string>production</string>
+	<key>com.apple.developer.nfc.readersession.formats</key>
+	<array>
+		<string>TAG</string>
+	</array>
 </dict>
 </plist>

--- a/Sources/Application/Environment/Entitlements/OneLoginDebug.entitlements
+++ b/Sources/Application/Environment/Entitlements/OneLoginDebug.entitlements
@@ -2,11 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.devicecheck.appattest-environment</key>
+	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:mobile.build.account.gov.uk</string>
 	</array>
-	<key>com.apple.developer.devicecheck.appattest-environment</key>
-	<string>development</string>
+	<key>com.apple.developer.nfc.readersession.formats</key>
+	<array>
+		<string>TAG</string>
+	</array>
 </dict>
 </plist>

--- a/Sources/Application/Environment/Entitlements/OneLoginRelease.entitlements
+++ b/Sources/Application/Environment/Entitlements/OneLoginRelease.entitlements
@@ -4,6 +4,10 @@
 <dict>
 	<key>com.apple.developer.devicecheck.appattest-environment</key>
 	<string>production</string>
+    <key>com.apple.developer.nfc.readersession.formats</key>
+    <array>
+        <string>TAG</string>
+    </array>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:mobile.account.gov.uk</string>

--- a/Sources/Application/Environment/Entitlements/OneLoginRelease.entitlements
+++ b/Sources/Application/Environment/Entitlements/OneLoginRelease.entitlements
@@ -4,13 +4,13 @@
 <dict>
 	<key>com.apple.developer.devicecheck.appattest-environment</key>
 	<string>production</string>
+    <key>com.apple.developer.associated-domains</key>
+    <array>
+        <string>applinks:mobile.account.gov.uk</string>
+    </array>
     <key>com.apple.developer.nfc.readersession.formats</key>
     <array>
         <string>TAG</string>
     </array>
-	<key>com.apple.developer.associated-domains</key>
-	<array>
-		<string>applinks:mobile.account.gov.uk</string>
-	</array>
 </dict>
 </plist>

--- a/Sources/Application/Environment/Entitlements/OneLoginStaging.entitlements
+++ b/Sources/Application/Environment/Entitlements/OneLoginStaging.entitlements
@@ -2,11 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.devicecheck.appattest-environment</key>
+	<string>production</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:mobile.staging.account.gov.uk</string>
 	</array>
-	<key>com.apple.developer.devicecheck.appattest-environment</key>
-	<string>production</string>
+	<key>com.apple.developer.nfc.readersession.formats</key>
+	<array>
+		<string>TAG</string>
+	</array>
 </dict>
 </plist>

--- a/Sources/Application/OneLogin-Info.plist
+++ b/Sources/Application/OneLogin-Info.plist
@@ -47,7 +47,6 @@
 		<key>iProov URL</key>
 		<string>gds.rp.secure.iproov.me</string>
 	</dict>
-
 	<key>FIREBASE_ANALYTICS_COLLECTION_ENABLED</key>
 	<false/>
 	<key>FirebaseAutomaticScreenReportingEnabled</key>

--- a/Sources/Application/OneLogin-Info.plist
+++ b/Sources/Application/OneLogin-Info.plist
@@ -47,11 +47,7 @@
 		<key>iProov URL</key>
 		<string>gds.rp.secure.iproov.me</string>
 	</dict>
-    <key>com.apple.developer.nfc.readersession.iso7816.select-identifiers</key>
-    <array>
-        <string>A0000002471001</string>
-        <string>A00000045645444C2D3031</string>
-    </array>
+
 	<key>FIREBASE_ANALYTICS_COLLECTION_ENABLED</key>
 	<false/>
 	<key>FirebaseAutomaticScreenReportingEnabled</key>
@@ -62,6 +58,11 @@
 	<false/>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+    <key>com.apple.developer.nfc.readersession.iso7816.select-identifiers</key>
+    <array>
+        <string>A0000002471001</string>
+        <string>A00000045645444C2D3031</string>
+    </array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Sources/Application/OneLogin-Info.plist
+++ b/Sources/Application/OneLogin-Info.plist
@@ -47,6 +47,11 @@
 		<key>iProov URL</key>
 		<string>gds.rp.secure.iproov.me</string>
 	</dict>
+    <key>com.apple.developer.nfc.readersession.iso7816.select-identifiers</key>
+    <array>
+        <string>A0000002471001</string>
+        <string>A00000045645444C2D3031</string>
+    </array>
 	<key>FIREBASE_ANALYTICS_COLLECTION_ENABLED</key>
 	<false/>
 	<key>FirebaseAutomaticScreenReportingEnabled</key>

--- a/Sources/Resources/cy-GB.lproj/InfoPlist.strings
+++ b/Sources/Resources/cy-GB.lproj/InfoPlist.strings
@@ -2,4 +2,4 @@
 "NSFaceIDUsageDescription" = "Nid yw eich Face ID yn cael ei rannu gyda GOV.UK One Login.";
 
 // MARK: ReadID NFC permission prompt
-"NFCReaderUsageDescription" = "This is required to scan the chip on your document"
+"NFCReaderUsageDescription" = "This is required to scan the chip on your document";

--- a/Sources/Resources/cy-GB.lproj/InfoPlist.strings
+++ b/Sources/Resources/cy-GB.lproj/InfoPlist.strings
@@ -1,2 +1,5 @@
 // MARK: Face ID enrolment prompt
 "NSFaceIDUsageDescription" = "Nid yw eich Face ID yn cael ei rannu gyda GOV.UK One Login.";
+
+// MARK: ReadID NFC permission prompt
+"NFCReaderUsageDescription" = "This is required to scan the chip on your document"

--- a/Sources/Resources/en.lproj/InfoPlist.strings
+++ b/Sources/Resources/en.lproj/InfoPlist.strings
@@ -2,4 +2,4 @@
 "NSFaceIDUsageDescription" = "Your Face ID is not shared with GOV.UK One Login.";
 
 // MARK: ReadID NFC permission prompt
-"NFCReaderUsageDescription" = "This is required to scan the chip on your document"
+"NFCReaderUsageDescription" = "This is required to scan the chip on your document";

--- a/Sources/Resources/en.lproj/InfoPlist.strings
+++ b/Sources/Resources/en.lproj/InfoPlist.strings
@@ -1,2 +1,5 @@
 // MARK: Face ID enrolment prompt
 "NSFaceIDUsageDescription" = "Your Face ID is not shared with GOV.UK One Login.";
+
+// MARK: ReadID NFC permission prompt
+"NFCReaderUsageDescription" = "This is required to scan the chip on your document"


### PR DESCRIPTION
# DCMAW-12328: Document Selection not shown in the One Login app

Running the ID Check SDK in the One Login app the SDK does not have the permissions to access the NFC scanner on the device. This PR sets up those permissions in the host app.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
~- [ ] Written Unit and Integration tests if needed~

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
