### PR TITLE
fix: remove persistentSessionID on signout

### DIFF
--- a/Sources/Utilities/Storage/DefaultsStorable.swift
+++ b/Sources/Utilities/Storage/DefaultsStorable.swift
@@ -12,5 +12,6 @@ extension UserDefaults: SessionBoundData {
     func delete() throws {
         removeObject(forKey: OLString.returningUser)
         removeObject(forKey: OLString.accessTokenExpiry)
+        removeObject(forKey: OLString.persistentSessionID)
     }
 }

--- a/Tests/UnitTests/Extensions/UserDefaults+OneLoginTests.swift
+++ b/Tests/UnitTests/Extensions/UserDefaults+OneLoginTests.swift
@@ -21,9 +21,14 @@ struct UserDefaultsTests {
             123456789,
             forKey: OLString.accessTokenExpiry
         )
+        sut.set(
+            "123456789",
+            forKey: OLString.persistentSessionID
+        )
         try sut.delete()
         #expect(sut.object(forKey: "returningUser") == nil)
         #expect(sut.object(forKey: "accessTokenExpiry") == nil)
+        #expect(sut.object(forKey: "persistentSessionID") == nil)
     }
     
     @Test("Check that validAttestation is true if valid")


### PR DESCRIPTION
DCMAW-12583 Remove persistent session id from user default if user logs out

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
~~- [] Created a `draft` pull request if it is not yet ready for review~~

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~~- [ ] Met all accessibility requirements?~~
    ~~- [ ] Checked dynamic type sizes are applied~~
    ~~- [ ] Checked VoiceOver can navigate your new code~~
    ~~- [ ] Checked a user can navigate only using a keyboard around your new code~~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
