### PR TITLE
Dependabot fix: swift packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,9 @@ updates:
 
   - package-ecosystem: swift
     directories:
-      - /OneLogin.xcodeproj/project.xcworkspace/xcshareddata/swiftpm
+      - /AppIntegrity
+      - /LocalAuthenticationWrapper
+      - /MobilePlatformServices
       - /OneLogin.xcworkspace/xcshareddata/swiftpm
     schedule:
       interval: weekly


### PR DESCRIPTION
The dependabot workflow runs for swift failed due to a reference to a missing directory. 

This change updates the dependabot configuration to point to any folder with a Package.swift or Package.resolved file.