### PR TITLE
feat: app info network error

### DIFF
--- a/MobilePlatformServices/Sources/MobilePlatformServices/App Info/AppInformationProvider.swift
+++ b/MobilePlatformServices/Sources/MobilePlatformServices/App Info/AppInformationProvider.swift
@@ -45,14 +45,14 @@ public final class AppInformationService: AppInformationProvider {
             cache.set(data, forKey: "appInfoResponse")
             return appInfo
         } catch {
-            return try loadFromDefaults()
+            return try loadFromDefaults(appInfoError: error)
         }
     }
     
-    private func loadFromDefaults() throws -> App {
+    private func loadFromDefaults(appInfoError: Error) throws -> App {
         guard let cachedResponse = cache.data(forKey: "appInfoResponse") else {
-            let error = URLError.notConnectedToInternet
-            if error.rawValue == NSURLErrorNotConnectedToInternet {
+            if let error = appInfoError as? URLError,
+               error.code == .notConnectedToInternet || error.code == .networkConnectionLost {
                 throw AppInfoError.notConnectedToInternet
             }
             throw AppInfoError.invalidResponse

--- a/Sources/Qualification/QualifyingCoordinator.swift
+++ b/Sources/Qualification/QualifyingCoordinator.swift
@@ -73,7 +73,7 @@ final class QualifyingCoordinator: NSObject,
             displayUnlockWindow()
         case .offline:
             let viewModel = NetworkConnectionErrorViewModel(analyticsService: analyticsService) {
-                
+                self.appQualifyingService.initiate()
             }
             displayViewController(GDSErrorViewController(viewModel: viewModel))
         case .error:

--- a/Sources/Qualification/QualifyingCoordinator.swift
+++ b/Sources/Qualification/QualifyingCoordinator.swift
@@ -72,8 +72,8 @@ final class QualifyingCoordinator: NSObject,
         case .notChecked:
             displayUnlockWindow()
         case .offline:
-            let viewModel = NetworkConnectionErrorViewModel(analyticsService: analyticsService) {
-                self.appQualifyingService.initiate()
+            let viewModel = NetworkConnectionErrorViewModel(analyticsService: analyticsService) { [unowned self] in
+                appQualifyingService.initiate()
             }
             displayViewController(GDSErrorViewController(viewModel: viewModel))
         case .error:

--- a/Sources/Qualification/QualifyingCoordinator.swift
+++ b/Sources/Qualification/QualifyingCoordinator.swift
@@ -72,8 +72,10 @@ final class QualifyingCoordinator: NSObject,
         case .notChecked:
             displayUnlockWindow()
         case .offline:
-            // TODO: DCMAW-9866 | display error screen for app offline and no cached data
-            return
+            let viewModel = NetworkConnectionErrorViewModel(analyticsService: analyticsService) {
+                
+            }
+            displayViewController(GDSErrorViewController(viewModel: viewModel))
         case .error:
             // TODO: DCMAW-9866 | display generic error screen?
             return

--- a/Sources/Qualification/State/AppQualifyingService.swift
+++ b/Sources/Qualification/State/AppQualifyingService.swift
@@ -22,9 +22,6 @@ final class AppQualifyingService: QualifyingService {
     
     private var appInfoState: AppInformationState = .notChecked {
         didSet {
-            if appInfoState == .offline {
-                // Query cache?
-            }
             Task {
                 await delegate?.didChangeAppInfoState(state: appInfoState)
             }
@@ -76,7 +73,7 @@ final class AppQualifyingService: QualifyingService {
             appInfoState = .qualified
         } catch AppInfoError.invalidResponse {
             appInfoState = .unavailable
-        } catch URLError.notConnectedToInternet {
+        } catch AppInfoError.notConnectedToInternet {
             appInfoState = .offline
         } catch {
             // This would account for all non-successful server responses & any other error

--- a/Sources/Qualification/State/AppQualifyingService.swift
+++ b/Sources/Qualification/State/AppQualifyingService.swift
@@ -5,6 +5,7 @@ import SecureStore
 
 protocol QualifyingService: AnyObject {
     var delegate: AppQualifyingServiceDelegate? { get set }
+    func initiate()
     func evaluateUser() async
 }
 
@@ -45,7 +46,7 @@ final class AppQualifyingService: QualifyingService {
         subscribe()
     }
     
-    func initiate() {
+    public func initiate() {
         Task {
             await qualifyAppVersion()
             await evaluateUser()

--- a/Tests/UnitTests/Mocks/Qualification/MockQualifyingService.swift
+++ b/Tests/UnitTests/Mocks/Qualification/MockQualifyingService.swift
@@ -2,9 +2,10 @@
 
 final class MockQualifyingService: QualifyingService {
     var delegate: (any OneLogin.AppQualifyingServiceDelegate)?
+    var didCallInitiate: Bool = false
     
     func initiate() {
-
+        didCallInitiate = true
     }
     
     func evaluateUser() async {

--- a/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
+++ b/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
@@ -97,20 +97,6 @@ extension AppQualifyingServiceTests {
         XCTAssertEqual(AppEnvironment.remoteReleaseFlags.flags, releaseFlags)
     }
 
-    func test_offlineApp_setsStateCorrectly() {
-        // GIVEN the app is offline
-        appInformationProvider.errorFromFetchAppInfo = URLError(.notConnectedToInternet)
-
-        sut.delegate = self
-        sut.initiate()
-
-        // THEN the offline state is set
-        waitForTruth(
-            self.appState == .offline,
-            timeout: 5
-        )
-    }
-
     func test_errorThrown_setsStateCorrectly() {
         // GIVEN `appInfo` cannot be accessed
         appInformationProvider.errorFromFetchAppInfo = URLError(.timedOut)
@@ -125,7 +111,21 @@ extension AppQualifyingServiceTests {
         )
     }
     
-    func test_appInfoError_setsStateCorrectly() {
+    func test_appInfoOfflineError_setsStateCorrectly() {
+        // GIVEN the app is offline
+        appInformationProvider.errorFromFetchAppInfo = AppInfoError.notConnectedToInternet
+
+        sut.delegate = self
+        sut.initiate()
+
+        // THEN the offline state is set
+        waitForTruth(
+            self.appState == .offline,
+            timeout: 5
+        )
+    }
+    
+    func test_appInfoInvalidError_setsStateCorrectly() {
         appInformationProvider.errorFromFetchAppInfo = AppInfoError.invalidResponse
         
         sut.delegate = self

--- a/Tests/UnitTests/Qualification/QualifyingCoordinatorTests.swift
+++ b/Tests/UnitTests/Qualification/QualifyingCoordinatorTests.swift
@@ -85,6 +85,30 @@ extension QualifyingCoordinatorTests {
         )
         XCTAssertTrue(vc.viewModel is UpdateAppViewModel)
     }
+    
+    @MainActor
+    func test_appOffline_displaysNetworkErrorScreen() throws {
+        // GIVEN I reopen the app
+        // AND I receive an offline result from `appInfo`
+        sut.didChangeAppInfoState(state: .offline)
+        // THEN I am shown the Network Error screen
+        let vc = try XCTUnwrap(
+            window.rootViewController as? GDSErrorViewController
+        )
+        XCTAssertTrue(vc.viewModel is NetworkConnectionErrorViewModel)
+    }
+    
+    @MainActor
+    func test_networkError_buttonAction() throws {
+        sut.didChangeAppInfoState(state: .offline)
+        
+        let vc = try XCTUnwrap(
+            window.rootViewController as? GDSErrorViewController
+        )
+        _ = vc.viewModel.primaryButtonViewModel.action()
+        
+        XCTAssertTrue(qualifyingService.didCallInitiate)
+    }
 }
 
 // MARK: - User State updates


### PR DESCRIPTION
# DCMAW-12259: User sees Network Connection Error when offline (/appInfo)

This PR is to update the app behaviour to surface a network connection error screen when the user is not connected to the internet and they have no app info saved.

### QA Evidence

https://github.com/user-attachments/assets/b5ba5587-5703-430e-b3c5-30638493ea22


# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
~- [ ] Created a `draft` pull request if it is not yet ready for review~

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
~- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.~
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~ 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
