### PR TITLE
fix: continue proving identity card not on top of the homepage

### DIFF
--- a/Sources/Screens/Tabs/HomeViewController.swift
+++ b/Sources/Screens/Tabs/HomeViewController.swift
@@ -66,39 +66,51 @@ extension HomeViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         switch indexPath.section {
         case 0:
-            guard let cell = tableView.dequeueReusableCell(
-                withIdentifier: "ContentTileCell",
-                for: indexPath
-            ) as? ContentTileCell else {
-                preconditionFailure()
+            guard let idCheckCard else { return getOneLoginCard(indexPath: indexPath) }
+            if !idCheckCard.view.isHidden {
+                return getIDCheckCard(indexPath: indexPath)
             }
-            cell.viewModel = .oneLoginCard(analyticsService: analyticsService,
-                                           urlOpener: UIApplication.shared)
-            return cell
+            return getOneLoginCard(indexPath: indexPath)
         case 1:
-            guard let idCheckCard else {
-                preconditionFailure("")
-            }
-            let cell = tableView.dequeueReusableCell(
-                withIdentifier: "OneLoginHomeScreenCell",
-                for: indexPath
-            )
-            
-            idCheckCard.view.translatesAutoresizingMaskIntoConstraints = false
-            cell.isHidden = !AppEnvironment.criOrchestratorEnabled || idCheckCard.view.isHidden
-            cell.contentView.addSubview(idCheckCard.view)
-            
-            NSLayoutConstraint.activate([
-                idCheckCard.view.topAnchor.constraint(equalTo: cell.contentView.topAnchor),
-                idCheckCard.view.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor),
-                idCheckCard.view.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor),
-                idCheckCard.view.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor)
-            ])
-
-            return cell
+            return getOneLoginCard(indexPath: indexPath)
         default:
             return UITableViewCell()
         }
+    }
+    
+    func getOneLoginCard(indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(
+            withIdentifier: "ContentTileCell",
+            for: indexPath
+        ) as? ContentTileCell else {
+            preconditionFailure()
+        }
+        cell.viewModel = .oneLoginCard(analyticsService: analyticsService,
+                                       urlOpener: UIApplication.shared)
+        return cell
+    }
+    
+    func getIDCheckCard(indexPath: IndexPath) -> UITableViewCell {
+        guard let idCheckCard else {
+            preconditionFailure("")
+        }
+        let cell = tableView.dequeueReusableCell(
+            withIdentifier: "OneLoginHomeScreenCell",
+            for: indexPath
+        )
+        
+        idCheckCard.view.translatesAutoresizingMaskIntoConstraints = false
+        cell.isHidden = !AppEnvironment.criOrchestratorEnabled || idCheckCard.view.isHidden
+        cell.contentView.addSubview(idCheckCard.view)
+        
+        NSLayoutConstraint.activate([
+            idCheckCard.view.topAnchor.constraint(equalTo: cell.contentView.topAnchor),
+            idCheckCard.view.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor),
+            idCheckCard.view.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor),
+            idCheckCard.view.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor)
+        ])
+
+        return cell
     }
 }
 

--- a/Sources/Screens/Tabs/HomeViewController.swift
+++ b/Sources/Screens/Tabs/HomeViewController.swift
@@ -78,7 +78,7 @@ extension HomeViewController {
         }
     }
     
-    func getOneLoginCard(indexPath: IndexPath) -> UITableViewCell {
+    private func getOneLoginCard(indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(
             withIdentifier: "ContentTileCell",
             for: indexPath
@@ -90,7 +90,7 @@ extension HomeViewController {
         return cell
     }
     
-    func getIDCheckCard(indexPath: IndexPath) -> UITableViewCell {
+    private func getIDCheckCard(indexPath: IndexPath) -> UITableViewCell {
         guard let idCheckCard else {
             preconditionFailure("")
         }

--- a/Tests/UnitTests/Screens/Tabs/HomeViewControllerTests.swift
+++ b/Tests/UnitTests/Screens/Tabs/HomeViewControllerTests.swift
@@ -77,26 +77,34 @@ extension HomeViewControllerTests {
         XCTAssertTrue(servicesTile?.viewModel is OneLoginTileViewModel)
     }
     
-    func test_idCheckTileCell_isVisible() {
+    func test_idCheckTileCell_isDisplayed() {
         AppEnvironment.updateFlags(
             releaseFlags: [:],
             featureFlags: [FeatureFlagsName.enableCRIOrchestrator.rawValue: true]
         )
         UINavigationController().setViewControllers([sut], animated: false)
-        let servicesTile = sut.tableView(
+        let idCell = sut.tableView(
+            sut.tableView,
+            cellForRowAt: IndexPath(row: 0, section: 0)
+        )
+        let oneLoginCell = sut.tableView(
             sut.tableView,
             cellForRowAt: IndexPath(row: 0, section: 1)
         )
-        XCTAssertFalse(servicesTile.isHidden)
+        XCTAssertFalse(idCell.isHidden)
+        XCTAssertTrue((idCell as? ContentTileCell) == nil)
+        XCTAssertFalse(oneLoginCell.isHidden)
+        XCTAssertTrue((oneLoginCell as? ContentTileCell) != nil)
     }
     
-    func test_idCheckTileCell_isHidden() {
+    func test_idCheckTileCell_isNotDisplayed() {
         UINavigationController().setViewControllers([sut], animated: false)
-        let servicesTile = sut.tableView(
+        let oneLoginCell = sut.tableView(
             sut.tableView,
-            cellForRowAt: IndexPath(row: 0, section: 1)
+            cellForRowAt: IndexPath(row: 0, section: 0)
         )
-        XCTAssertTrue(servicesTile.isHidden)
+        XCTAssertFalse(oneLoginCell.isHidden)
+        XCTAssertTrue((oneLoginCell as? ContentTileCell) != nil)
     }
     
     func test_viewDidAppear() {


### PR DESCRIPTION
# DCMAW-12709: Prove your identity card doesn't stay at the top of the home page

https://github.com/user-attachments/assets/2d8ba73c-f328-4db0-a183-8d04bf1cb5aa


# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
~~- [ ] Created a `draft` pull request if it is not yet ready for review~~

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~~- [ ] Met all accessibility requirements?~~
    ~~- [ ] Checked dynamic type sizes are applied~~
    ~~- [ ] Checked VoiceOver can navigate your new code~~
    ~~- [ ] Checked a user can navigate only using a keyboard around your new code~~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
