### PR TITLE
fix: UI tests for GDSErrorScreen

### DIFF
--- a/Tests/UITests/LoginUITests.swift
+++ b/Tests/UITests/LoginUITests.swift
@@ -75,7 +75,6 @@ extension LoginUITests {
         // Redirect with OAuth error
         let errorScreen = loginModal.tapBrowserRedirectWithOAuthErrorButton()
         XCTAssertEqual(errorScreen.title.label, "There was a problem signing you in")
-        XCTAssertEqual(errorScreen.body.label, "You can try signing in again.\n\nIf this does not work, you may need to try again later.")
         XCTAssertEqual(errorScreen.closeButton.label, "Close")
     }
     
@@ -92,7 +91,6 @@ extension LoginUITests {
         // Redirect with invalid state
         let errorScreen = loginModal.tapBrowserNoAuthCodeErrorButton()
         XCTAssertEqual(errorScreen.title.label, "There was a problem signing you in")
-        XCTAssertEqual(errorScreen.body.label, "You can try signing in again.\n\nIf this does not work, you may need to try again later.")
         XCTAssertEqual(errorScreen.closeButton.label, "Close")
     }
     
@@ -113,7 +111,6 @@ extension LoginUITests {
         // Second Modal Screen
         let errorScreen = loginModalSecondScreen.tapBrowserLoginButton()
         XCTAssertEqual(errorScreen.title.label, "There was a problem signing you in")
-        XCTAssertEqual(errorScreen.body.label, "You can try signing in again.\n\nIf this does not work, you may need to try again later.")
         XCTAssertEqual(errorScreen.closeButton.label, "Close")
     }
     
@@ -134,7 +131,6 @@ extension LoginUITests {
         // Second Modal Screen
         let errorScreen = loginModalSecondScreen.tapBrowserLoginButton()
         XCTAssertEqual(errorScreen.title.label, "There was a problem signing you in")
-        XCTAssertEqual(errorScreen.body.label, "You can try signing in again.\n\nIf this does not work, you may need to try again later.")
         XCTAssertEqual(errorScreen.closeButton.label, "Close")
     }
 }

--- a/Tests/UITests/ScreenObjects/App/ErrorScreen.swift
+++ b/Tests/UITests/ScreenObjects/App/ErrorScreen.swift
@@ -8,15 +8,11 @@ struct ErrorScreen: ScreenObject {
     }
     
     var title: XCUIElement {
-        app.staticTexts["error-title"]
-    }
-    
-    var body: XCUIElement {
-        app.staticTexts["error-body"]
+        app.staticTexts["error-screen-title"]
     }
     
     var closeButton: XCUIElement {
-        app.buttons["error-primary-button"]
+        app.buttons["error-screen-button-0"]
     }
     
     func tapCloseButton() {

--- a/Tests/UITests/ScreenObjects/App/HomeScreen.swift
+++ b/Tests/UITests/ScreenObjects/App/HomeScreen.swift
@@ -8,6 +8,6 @@ struct HomeScreen: ScreenObject {
     }
     
     var title: XCUIElement {
-        return app.navigationBars.staticTexts.firstMatch
+        app.navigationBars.staticTexts.firstMatch
     }
 }

--- a/Tests/UITests/ScreenObjects/App/LoginModal.swift
+++ b/Tests/UITests/ScreenObjects/App/LoginModal.swift
@@ -42,7 +42,7 @@ struct LoginModal: ScreenObject {
     func tapBrowserLoginButton() -> HomeScreen {
         loginButton.tap()
         
-        return HomeScreen(app: app).waitForAppearance()
+        return HomeScreen(app: app).waitForAppearance(timeout: 15)
     }
     
     func tapBrowserRedirectWithOAuthErrorButton() -> ErrorScreen {
@@ -66,8 +66,8 @@ struct LoginModal: ScreenObject {
             secondModalScreen.title,
             secondModalScreen.loginButton
         ]
-        _ = browserElements.map {
-            $0.waitForExistence(timeout: .timeout)
+        browserElements.forEach {
+            _ = $0.waitForExistence(timeout: .timeout)
         }
         return secondModalScreen
     }
@@ -81,8 +81,8 @@ struct LoginModal: ScreenObject {
             secondModalScreen.title,
             secondModalScreen.loginButton
         ]
-        _ = browserElements.map {
-            $0.waitForExistence(timeout: .timeout)
+        browserElements.forEach {
+            _ = $0.waitForExistence(timeout: .timeout)
         }
         return secondModalScreen
     }

--- a/Tests/UITests/ScreenObjects/App/WelcomeScreen.swift
+++ b/Tests/UITests/ScreenObjects/App/WelcomeScreen.swift
@@ -32,8 +32,8 @@ struct WelcomeScreen: ScreenObject {
             loginModal.fourHundredResponseErrorButton,
             loginModal.fiveHundredResponseErrorButton
         ]
-        _ = browserElements.map {
-            $0.waitForExistence(timeout: .timeout)
+        browserElements.map {
+            _ = $0.waitForExistence(timeout: .timeout)
         }
         return loginModal
     }

--- a/Tests/UITests/ScreenObjects/ScreenObject.swift
+++ b/Tests/UITests/ScreenObjects/ScreenObject.swift
@@ -9,8 +9,8 @@ extension ScreenObject {
         view.isHittable
     }
     
-    func waitForAppearance() -> Self {
-        _ = view.waitForExistence(timeout: .timeout)
+    func waitForAppearance(timeout: TimeInterval = .timeout) -> Self {
+        _ = view.waitForExistence(timeout: timeout)
         return self
     }
 }


### PR DESCRIPTION
# fix: UI tests for GDSErrorScreen

Removing use of the deprecated error screen for a newer version of the screen from our common package has inadvertently broken our UI tests.

This PR fixes them.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
~- [ ] Met all of the acceptance criteria specified in the user story on Jira~
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
