### PR TITLE
fix: adding dependency for badges into deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,6 +54,10 @@ jobs:
             di-ipv-dca-mob-ios/github-actions-v2
           parse-json-secrets: true
 
+      - name: Install required app dependencies
+        run: |
+          brew install imagemagick
+
       - name: Build App, Deploy to App Store Connect
         env:
           LC_ALL: "en_US.UTF-8"


### PR DESCRIPTION
# fix: adding dependency for badges into deploy workflow  

Fixes deployment failure of [previous PR](https://github.com/govuk-one-login/mobile-ios-one-login-app/pull/332) to add a badge to the app icons

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
~- [ ] Created a `draft` pull request if it is not yet ready for review~

## Before your pull request can be reviewed:
~- [ ] Met all of the acceptance criteria specified in the user story on Jira~
- [x] Reviewed your own code to ensure you are following the style guidelines
~- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.~
~- [ ] Written Unit and Integration tests if needed~

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~ 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
