### PR TITLE
fix: incorrect privacy notice footer text

### DIFF
--- a/Sources/Resources/cy-GB.lproj/Localizable.strings
+++ b/Sources/Resources/cy-GB.lproj/Localizable.strings
@@ -134,7 +134,7 @@
 
 "app_settingsAnalyticsToggle" = "Rhannu dadansoddeg yr ap";
 
-"app_settingsAnalyticsToggleFootnote" = "Gallwch rannu dadansoddeg anhysbys am sut rydych yn defnyddio'r ap i helpu'r tîm GOV.UK One Login i wneud gwelliannau. Darllenwch fwy yn yr hysbysiad preifatrwydd";
+"app_settingsAnalyticsToggleFootnote" = "Gallwch rannu dadansoddeg anhysbys am sut rydych yn defnyddio'r ap i helpu'r tîm GOV.UK One Login i wneud gwelliannau. Darllenwch fwy yn yr hysbysiad preifatrwydd GOV.UK One Login.";
 
 "app_privacyNoticeLink2" = "Rhybudd Preifatrwydd GOV.UK One Login";
 

--- a/Sources/Resources/en.lproj/Localizable.strings
+++ b/Sources/Resources/en.lproj/Localizable.strings
@@ -136,7 +136,7 @@
 
 "app_settingsAnalyticsToggle" = "Share app analytics";
 
-"app_settingsAnalyticsToggleFootnote" = "You can share anonymous analytics about how you use the app to help the GOV.UK One Login team make improvements. Read more in the privacy notice";
+"app_settingsAnalyticsToggleFootnote" = "You can share anonymous analytics about how you use the app to help the GOV.UK One Login team make improvements. Read more in the GOV.UK One Login privacy notice.";
 
 "app_privacyNoticeLink2" = "GOV.UK One Login privacy notice";
 

--- a/Tests/UnitTests/Resources/LocalizedEnglishStringTests.swift
+++ b/Tests/UnitTests/Resources/LocalizedEnglishStringTests.swift
@@ -147,7 +147,7 @@ final class LocalizedEnglishStringTests: XCTestCase {
         XCTAssertEqual("app_settingsAnalyticsToggle".getEnglishString(),
                        "Share app analytics")
         XCTAssertEqual("app_settingsAnalyticsToggleFootnote".getEnglishString(),
-                       "You can share anonymous analytics about how you use the app to help the GOV.UK One Login team make improvements. Read more in the privacy notice")
+                       "You can share anonymous analytics about how you use the app to help the GOV.UK One Login team make improvements. Read more in the GOV.UK One Login privacy notice.")
         XCTAssertEqual("app_accessibilityStatement".getEnglishString(),
                        "Accessibility statement")
     }

--- a/Tests/UnitTests/Resources/LocalizedWelshStringTests.swift
+++ b/Tests/UnitTests/Resources/LocalizedWelshStringTests.swift
@@ -147,7 +147,7 @@ final class LocalizedWelshStringTests: XCTestCase {
         XCTAssertEqual("app_settingsAnalyticsToggle".getWelshString(),
                        "Rhannu dadansoddeg yr ap")
         XCTAssertEqual("app_settingsAnalyticsToggleFootnote".getWelshString(),
-                       "Gallwch rannu dadansoddeg anhysbys am sut rydych yn defnyddio'r ap i helpu'r tîm GOV.UK One Login i wneud gwelliannau. Darllenwch fwy yn yr hysbysiad preifatrwydd")
+                       "Gallwch rannu dadansoddeg anhysbys am sut rydych yn defnyddio'r ap i helpu'r tîm GOV.UK One Login i wneud gwelliannau. Darllenwch fwy yn yr hysbysiad preifatrwydd GOV.UK One Login.")
         XCTAssertEqual("app_accessibilityStatement".getWelshString(),
                        "Datganiad hygyrchedd")
     }


### PR DESCRIPTION
# DCMAW-12893 incorrect analytics footer text

### **Welsh**
<img src="https://github.com/user-attachments/assets/ab73087c-d56f-46ad-af17-15bafbc2fa50" height="600">

### **English**
<img src="https://github.com/user-attachments/assets/778b3b13-c5f7-4518-980b-40042017c6c7" height="600">


# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
