### PR TITLE
chore: remove cri orchestrator feature flag

### DIFF
--- a/Sources/Application/Environment/AppEnvironment.swift
+++ b/Sources/Application/Environment/AppEnvironment.swift
@@ -16,10 +16,6 @@ public final class AppEnvironment {
         isFeatureEnabled(for: .enableWalletVisibleToAll)
     }
     
-    static var criOrchestratorEnabled: Bool {
-        isFeatureEnabled(for: .enableCRIOrchestrator)
-    }
-    
     static var appIntegrityEnabled: Bool {
         isFeatureEnabled(for: .appCheckEnabled)
     }

--- a/Sources/Application/Environment/FlagManager.swift
+++ b/Sources/Application/Environment/FlagManager.swift
@@ -9,7 +9,6 @@ public enum FeatureFlagsName: String {
     case enableWalletVisibleViaDeepLink = "walletVisibleViaDeepLink"
     case enableWalletVisibleIfExists = "walletVisibleIfExists"
     case enableWalletVisibleToAll = "walletVisibleToAll"
-    case enableCRIOrchestrator = "enableCRIOrchestrator"
     case appCheckEnabled = "appCheckEnabled"
 }
 

--- a/Sources/Application/SupportingFiles/FeatureFlags/FeatureFlagsBuild.json
+++ b/Sources/Application/SupportingFiles/FeatureFlags/FeatureFlagsBuild.json
@@ -10,9 +10,5 @@
     {
         "name": "walletVisibleToAll",
         "isEnabled": true
-    },
-    {
-        "name": "enableCRIOrchestrator",
-        "isEnabled": false
     }
 ]

--- a/Sources/Application/SupportingFiles/FeatureFlags/FeatureFlagsIntegration.json
+++ b/Sources/Application/SupportingFiles/FeatureFlags/FeatureFlagsIntegration.json
@@ -10,9 +10,5 @@
     {
         "name": "walletVisibleToAll",
         "isEnabled": false
-    },
-    {
-        "name": "enableCRIOrchestrator",
-        "isEnabled": true
     }
 ]

--- a/Sources/Application/SupportingFiles/FeatureFlags/FeatureFlagsStaging.json
+++ b/Sources/Application/SupportingFiles/FeatureFlags/FeatureFlagsStaging.json
@@ -10,9 +10,5 @@
     {
         "name": "walletVisibleToAll",
         "isEnabled": true
-    },
-    {
-        "name": "enableCRIOrchestrator",
-        "isEnabled": true
     }
 ]

--- a/Sources/Screens/Tabs/HomeViewController.swift
+++ b/Sources/Screens/Tabs/HomeViewController.swift
@@ -58,9 +58,7 @@ final class HomeViewController: BaseViewController {
         idCheckCard = criOrchestrator.getIDCheckCard(viewController: self) { [unowned self] in
             tableView.insertSections(IndexSet(integer: 0), with: .fade)
         }
-        if AppEnvironment.criOrchestratorEnabled {
-            criOrchestrator.continueIdentityCheckIfRequired(over: self)
-        }
+        criOrchestrator.continueIdentityCheckIfRequired(over: self)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -153,7 +151,7 @@ extension HomeViewController: UITableViewDataSource, UITableViewDelegate {
         )
         
         idCheckCard.view.translatesAutoresizingMaskIntoConstraints = false
-        cell.isHidden = !AppEnvironment.criOrchestratorEnabled || idCheckCard.view.isHidden
+        cell.isHidden = idCheckCard.view.isHidden
         cell.contentView.addSubview(idCheckCard.view)
         
         NSLayoutConstraint.activate([

--- a/Sources/Utilities/Storage/Session/Authorization/TokenHolder.swift
+++ b/Sources/Utilities/Storage/Session/Authorization/TokenHolder.swift
@@ -38,14 +38,9 @@ extension TokenHolder: AuthorizationProvider {
             subjectToken: subjectToken,
             scope: scope
         )
-
-        do {
-            let serviceTokenResponse = try await client.makeRequest(serviceTokenRequest)
-            return try decodeServiceToken(data: serviceTokenResponse)
-        } catch let error as ServerError where error.errorCode == 400 {
-            NotificationCenter.default.post(name: .sessionExpired)
-            throw error
-        }
+        
+        let serviceTokenResponse = try await client.makeRequest(serviceTokenRequest)
+        return try decodeServiceToken(data: serviceTokenResponse)
     }
 
     private func decodeServiceToken(data: Data) throws -> ServiceTokenResponse {

--- a/Tests/ConfigTests/OneLoginBuildConfig/OneLoginBuildAppEnvironmentTests.swift
+++ b/Tests/ConfigTests/OneLoginBuildConfig/OneLoginBuildAppEnvironmentTests.swift
@@ -14,7 +14,6 @@ final class OneLoginBuildAppEnvironmentTests: XCTestCase {
         XCTAssertTrue(sut.walletVisibleViaDeepLink)
         XCTAssertTrue(sut.walletVisibleIfExists)
         XCTAssertTrue(sut.walletVisibleToAll)
-        XCTAssertFalse(sut.criOrchestratorEnabled)
     }
     
     func test_appEnvironment_helpers() {

--- a/Tests/ConfigTests/OneLoginIntegrationConfig/OneLoginIntegrationAppEnvironmentTests.swift
+++ b/Tests/ConfigTests/OneLoginIntegrationConfig/OneLoginIntegrationAppEnvironmentTests.swift
@@ -14,7 +14,6 @@ final class OneLoginIntegrationAppEnvironmentTests: XCTestCase {
         XCTAssertFalse(sut.walletVisibleViaDeepLink)
         XCTAssertFalse(sut.walletVisibleIfExists)
         XCTAssertFalse(sut.walletVisibleToAll)
-        XCTAssertTrue(sut.criOrchestratorEnabled)
     }
     
     func test_appEnvironment_helpers() {

--- a/Tests/ConfigTests/OneLoginReleaseConfig/OneLoginReleaseAppEnvironmentTests.swift
+++ b/Tests/ConfigTests/OneLoginReleaseConfig/OneLoginReleaseAppEnvironmentTests.swift
@@ -14,7 +14,6 @@ final class OneLoginReleaseAppEnvironmentTests: XCTestCase {
         XCTAssertFalse(sut.walletVisibleViaDeepLink)
         XCTAssertFalse(sut.walletVisibleIfExists)
         XCTAssertFalse(sut.walletVisibleToAll)
-        XCTAssertFalse(sut.criOrchestratorEnabled)
     }
     
     func test_appEnvironment_helpers() {

--- a/Tests/ConfigTests/OneLoginStagingConfig/OneLoginStagingAppEnvironmentTests.swift
+++ b/Tests/ConfigTests/OneLoginStagingConfig/OneLoginStagingAppEnvironmentTests.swift
@@ -14,7 +14,6 @@ final class OneLoginStagingAppEnvironmentTests: XCTestCase {
         XCTAssertTrue(sut.walletVisibleViaDeepLink)
         XCTAssertTrue(sut.walletVisibleIfExists)
         XCTAssertTrue(sut.walletVisibleToAll)
-        XCTAssertTrue(sut.criOrchestratorEnabled)
     }
     
     func test_appEnvironment_helpers() {

--- a/Tests/UnitTests/Application/Environment/AppEnvironmentTests.swift
+++ b/Tests/UnitTests/Application/Environment/AppEnvironmentTests.swift
@@ -12,7 +12,6 @@ final class AppEnvironmentTests: XCTestCase {
         XCTAssertTrue(sut.walletVisibleViaDeepLink)
         XCTAssertTrue(sut.walletVisibleIfExists)
         XCTAssertTrue(sut.walletVisibleToAll)
-        XCTAssertFalse(sut.criOrchestratorEnabled)
     }
     
     func test_appEnvironment_helpers() {

--- a/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
+++ b/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
@@ -141,8 +141,6 @@ extension AppQualifyingServiceTests {
 // MARK: - User State Evaluation
 extension AppQualifyingServiceTests {
     func test_oneTimeUser_userConfirmed() {
-        let releaseFlags = ["TestFlag": true]
-        appInformationProvider.releaseFlags = releaseFlags
         sessionManager.isOneTimeUser = true
         sut.delegate = self
         sut.initiate()
@@ -156,8 +154,6 @@ extension AppQualifyingServiceTests {
     }
     
     func test_noExpiryDate_userUnconfirmed() {
-        let releaseFlags = ["TestFlag": true]
-        appInformationProvider.releaseFlags = releaseFlags
         sut.delegate = self
         sut.initiate()
         
@@ -170,8 +166,6 @@ extension AppQualifyingServiceTests {
     }
     
     func test_sessionInvalid_userExpired() {
-        let releaseFlags = ["TestFlag": true]
-        appInformationProvider.releaseFlags = releaseFlags
         sessionManager.expiryDate = .distantFuture
         sut.delegate = self
         sut.initiate()
@@ -185,8 +179,6 @@ extension AppQualifyingServiceTests {
     }
     
     func test_resumeSession_userConfirmed() {
-        let releaseFlags = ["TestFlag": true]
-        appInformationProvider.releaseFlags = releaseFlags
         sessionManager.expiryDate = .distantFuture
         sessionManager.isSessionValid = true
         sut.delegate = self
@@ -201,8 +193,6 @@ extension AppQualifyingServiceTests {
     }
     
     func test_resumeSession_userCancelledBiometrics_error() {
-        let releaseFlags = ["TestFlag": true]
-        appInformationProvider.releaseFlags = releaseFlags
         sessionManager.expiryDate = .distantFuture
         sessionManager.isSessionValid = true
         sessionManager.errorFromResumeSession = SecureStoreError.biometricsCancelled
@@ -218,8 +208,6 @@ extension AppQualifyingServiceTests {
     }
     
     func test_resumeSession_nonCantDecryptData_error() {
-        let releaseFlags = ["TestFlag": true]
-        appInformationProvider.releaseFlags = releaseFlags
         sessionManager.expiryDate = .distantFuture
         sessionManager.isSessionValid = true
         sessionManager.errorFromResumeSession = SecureStoreError.unableToRetrieveFromUserDefaults
@@ -237,8 +225,6 @@ extension AppQualifyingServiceTests {
     }
     
     func test_resumeSession_nonCantDecryptData_error_clearSessionData_error() {
-        let releaseFlags = ["TestFlag": true]
-        appInformationProvider.releaseFlags = releaseFlags
         sessionManager.expiryDate = .distantFuture
         sessionManager.isSessionValid = true
         sessionManager.errorFromResumeSession = SecureStoreError.unableToRetrieveFromUserDefaults

--- a/Tests/UnitTests/Qualification/QualifyingCoordinatorTests.swift
+++ b/Tests/UnitTests/Qualification/QualifyingCoordinatorTests.swift
@@ -23,6 +23,7 @@ final class QualifyingCoordinatorTests: XCTestCase {
         mockAnalyticsService = MockAnalyticsService()
         mockAnalyticsPreferenceStore = MockAnalyticsPreferenceStore()
         networkClient = NetworkClient()
+        networkClient.authorizationProvider = MockAuthenticationProvider()
         qualifyingService = MockQualifyingService()
         sut = QualifyingCoordinator(appWindow: window,
                                     appQualifyingService: qualifyingService,

--- a/Tests/UnitTests/Screens/Tabs/HomeViewControllerTests.swift
+++ b/Tests/UnitTests/Screens/Tabs/HomeViewControllerTests.swift
@@ -60,7 +60,7 @@ extension HomeViewControllerTests {
     func test_welcomeTileCell_viewModel() throws {
         let servicesTile = sut.tableView(
             try sut.tableView,
-            cellForRowAt: IndexPath(row: 0, section: 0)
+            cellForRowAt: IndexPath(row: 0, section: 1)
         ) as? ContentTileCell
         XCTAssertTrue(servicesTile?.viewModel is WelcomeTileViewModel)
     }
@@ -68,7 +68,7 @@ extension HomeViewControllerTests {
     func test_purposeTileCell_viewModel() throws {
         let servicesTile = sut.tableView(
             try sut.tableView,
-            cellForRowAt: IndexPath(row: 0, section: 1)
+            cellForRowAt: IndexPath(row: 0, section: 2)
         ) as? ContentTileCell
         XCTAssertTrue(servicesTile?.viewModel is PurposeTileViewModel)
     }
@@ -91,22 +91,6 @@ extension HomeViewControllerTests {
         XCTAssertTrue((idCell as? ContentTileCell) == nil)
         XCTAssertFalse(welcomeCell.isHidden)
         XCTAssertTrue((welcomeCell as? ContentTileCell) != nil)
-        XCTAssertFalse(purposeCell.isHidden)
-        XCTAssertTrue((purposeCell as? ContentTileCell) != nil)
-    }
-    
-    func test_idCheckTileCell_isNotDisplayed() throws {
-        UINavigationController().setViewControllers([sut], animated: false)
-        let welcomeCell = sut.tableView(
-            try sut.tableView,
-            cellForRowAt: IndexPath(row: 0, section: 0)
-        )
-        XCTAssertFalse(welcomeCell.isHidden)
-        XCTAssertTrue((welcomeCell as? ContentTileCell) != nil)
-        let purposeCell = sut.tableView(
-            try sut.tableView,
-            cellForRowAt: IndexPath(row: 0, section: 1)
-        )
         XCTAssertFalse(purposeCell.isHidden)
         XCTAssertTrue((purposeCell as? ContentTileCell) != nil)
     }

--- a/Tests/UnitTests/Screens/Tabs/HomeViewControllerTests.swift
+++ b/Tests/UnitTests/Screens/Tabs/HomeViewControllerTests.swift
@@ -47,21 +47,8 @@ extension HomeViewControllerTests {
     }
     
     func test_numberOfSectionsWithIDCheck() {
-        AppEnvironment.updateFlags(
-            releaseFlags: [:],
-            featureFlags: [FeatureFlagsName.enableCRIOrchestrator.rawValue: true]
-        )
         UINavigationController().setViewControllers([sut], animated: false)
         XCTAssertEqual(sut.numberOfSections(in: try sut.tableView), 3)
-    }
-    
-    func test_numberOfSectionsWithoutIDCheck() {
-        AppEnvironment.updateFlags(
-            releaseFlags: [:],
-            featureFlags: [FeatureFlagsName.enableCRIOrchestrator.rawValue: false]
-        )
-        UINavigationController().setViewControllers([sut], animated: false)
-        XCTAssertEqual(sut.numberOfSections(in: try sut.tableView), 2)
     }
     
     func test_numbeOfRowsInSection() {
@@ -87,10 +74,6 @@ extension HomeViewControllerTests {
     }
     
     func test_idCheckTileCell_isDisplayed() throws {
-        AppEnvironment.updateFlags(
-            releaseFlags: [:],
-            featureFlags: [FeatureFlagsName.enableCRIOrchestrator.rawValue: true]
-        )
         UINavigationController().setViewControllers([sut], animated: false)
         let idCell = sut.tableView(
             try sut.tableView,

--- a/Tests/UnitTests/Tabs/HomeCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/HomeCoordinatorTests.swift
@@ -14,6 +14,7 @@ final class HomeCoordinatorTests: XCTestCase {
 
         mockAnalyticsService = MockAnalyticsService()
         mockNetworkClient = NetworkClient()
+        mockNetworkClient.authorizationProvider = MockAuthenticationProvider()
         sut = HomeCoordinator(analyticsService: mockAnalyticsService,
                               networkClient: mockNetworkClient)
     }

--- a/Tests/UnitTests/Tabs/SettingsCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/SettingsCoordinatorTests.swift
@@ -21,6 +21,7 @@ final class SettingsCoordinatorTests: XCTestCase {
         mockAnalyticsPreferenceStore =  MockAnalyticsPreferenceStore()
         mockSessionManager = MockSessionManager()
         mockNetworkClient = NetworkClient()
+        mockNetworkClient.authorizationProvider = MockAuthenticationProvider()
         urlOpener = MockURLOpener()
         sut = SettingsCoordinator(analyticsService: mockAnalyticsService,
                                   analyticsPreferenceStore: mockAnalyticsPreferenceStore,

--- a/Tests/UnitTests/Utilities/JWTVerifierTests.swift
+++ b/Tests/UnitTests/Utilities/JWTVerifierTests.swift
@@ -14,6 +14,7 @@ final class JWTVerifierTests: XCTestCase {
         configuration.protocolClasses = [MockURLProtocol.self]
         
         networkClient = NetworkClient(configuration: configuration)
+        networkClient.authorizationProvider = MockAuthenticationProvider()
         sut = JWTVerifier(networkClient: networkClient)
     }
 

--- a/Tests/UnitTests/Utilities/Session/Authorization/TokenHolderTests.swift
+++ b/Tests/UnitTests/Utilities/Session/Authorization/TokenHolderTests.swift
@@ -131,27 +131,4 @@ extension TokenHolderTests {
 
         await fulfillment(of: [exp], timeout: 5)
     }
-
-    func testFetchToken_sendsExpiredSessionNotification() async {
-        // GIVEN I am connected to the internet
-        let exp = XCTNSNotificationExpectation(
-            name: .sessionExpired,
-            object: nil,
-            notificationCenter: NotificationCenter.default
-        )
-        exp.assertForOverFulfill = true
-
-        MockURLProtocol.handler = {
-            (Data(), HTTPURLResponse(statusCode: 400))
-        }
-
-        // WHEN my access token has expired
-        Task {
-            sut.update(subjectToken: "abc")
-            _ = try await sut.fetchToken(withScope: "sts.hello-world.read")
-        }
-
-        // THEN an XCTNSNotificationExpectation is sent
-        await fulfillment(of: [exp], timeout: 5)
-    }
 }


### PR DESCRIPTION
# chore: remove cri orchestrator feature flag

Removing the feature flag for calling APIs on the CRI Orchestrator, this is not included in the /appInfo file which determines feature flags for the app.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
