### PR TITLE
fix: ensuring card hides when needed

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -3739,8 +3739,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/govuk-one-login/mobile-id-check-ios-sdk.git";
 			requirement = {
-				branch = "feature/initial-work-on-card-bug";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 8.0.0;
 			};
 		};
 		AB7B56222D6CD9A100193241 /* XCRemoteSwiftPackageReference "mobile-wallet-ios" */ = {

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -3739,8 +3739,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/govuk-one-login/mobile-id-check-ios-sdk.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 7.0.0;
+				branch = "feature/initial-work-on-card-bug";
+				kind = branch;
 			};
 		};
 		AB7B56222D6CD9A100193241 /* XCRemoteSwiftPackageReference "mobile-wallet-ios" */ = {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -132,7 +132,7 @@
       "location" : "https://github.com/govuk-one-login/mobile-id-check-ios-sdk.git",
       "state" : {
         "branch" : "feature/initial-work-on-card-bug",
-        "revision" : "c05100c74821395fce21173e10c1f999a04264c0"
+        "revision" : "1f7aaab94e1d284bf366fe66b6ae5b3a8bd25a4a"
       }
     },
     {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-id-check-ios-sdk.git",
       "state" : {
-        "branch" : "feature/initial-work-on-card-bug",
-        "revision" : "1f7aaab94e1d284bf366fe66b6ae5b3a8bd25a4a"
+        "revision" : "5626aac346b21847b9994c099891fb1d647504bc",
+        "version" : "8.0.0"
       }
     },
     {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-id-check-ios-sdk.git",
       "state" : {
-        "revision" : "d1b4768a87a412e88e738e2079e6fad1ef3242d9",
-        "version" : "7.7.1"
+        "branch" : "feature/initial-work-on-card-bug",
+        "revision" : "c05100c74821395fce21173e10c1f999a04264c0"
       }
     },
     {

--- a/Sources/Screens/Tabs/HomeViewController.swift
+++ b/Sources/Screens/Tabs/HomeViewController.swift
@@ -16,9 +16,9 @@ final class HomeViewController: BaseViewController {
     
     private var idCheckCard: UIViewController?
     
-    private let idCheckCardUpdateStream = AsyncStream.makeStream(of: Void.self)
+    private let idCheckCardUpdateStream = AsyncStream.makeStream(of: CardStatus.self)
 
-    var stream: AsyncStream<Void> {
+    var stream: AsyncStream<CardStatus> {
         idCheckCardUpdateStream.stream
     }
 
@@ -70,8 +70,13 @@ final class HomeViewController: BaseViewController {
     
     func listenForCardUpdates() {
         Task {
-            for await _ in idCheckCardUpdateStream.stream {
-                tableView.insertSections(IndexSet(integer: 0), with: .fade)
+            for await status in idCheckCardUpdateStream.stream {
+                switch status {
+                case .hide:
+                    tableView.deleteSections(IndexSet(integer: 0), with: .fade)
+                case .show:
+                    tableView.insertSections(IndexSet(integer: 0), with: .fade)
+                }
             }
         }
     }

--- a/Sources/Screens/Tabs/HomeViewController.swift
+++ b/Sources/Screens/Tabs/HomeViewController.swift
@@ -16,7 +16,7 @@ final class HomeViewController: BaseViewController {
     
     private var idCheckCard: UIViewController?
     
-    private let idCheckCardUpdateStream = AsyncStream.makeStream(of: CardStatus.self)
+    let idCheckCardUpdateStream = AsyncStream.makeStream(of: CardStatus.self)
 
     var stream: AsyncStream<CardStatus> {
         idCheckCardUpdateStream.stream

--- a/Tests/UnitTests/Mocks/Sessions+Services/MockCRIORchestrator.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/MockCRIORchestrator.swift
@@ -1,16 +1,20 @@
-@testable import CRIOrchestrator
+import CRIOrchestrator
 @testable import OneLogin
 import UIKit
 
 class MockCRIOrchestrator: CRIOrchestration {
-    private var hostingViewController: UIViewController = UIViewController()
+    var idCheckJourney = false
+    var streamContinuation: AsyncStream<CardStatus>.Continuation?
+    var hostingViewController = UIViewController()
     
-    func continueIdentityCheckIfRequired(over viewController: UIViewController) {
-        hostingViewController.view.isHidden = false
-    }
+    func continueIdentityCheckIfRequired(over viewController: UIViewController) { }
     
-    func getIDCheckCard(viewController: UIViewController, externalStream: IDCheckExternalStream) -> UIViewController {
-        hostingViewController.view.isHidden = true
+    func getIDCheckCard(
+        viewController: UIViewController,
+        externalStream: IDCheckExternalStream
+    ) -> UIViewController {
+        streamContinuation = externalStream.continuation
+        hostingViewController.view.isHidden = !idCheckJourney
         return hostingViewController
     }
 }

--- a/Tests/UnitTests/Mocks/Sessions+Services/MockCRIORchestrator.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/MockCRIORchestrator.swift
@@ -1,3 +1,4 @@
+@testable import CRIOrchestrator
 @testable import OneLogin
 import UIKit
 
@@ -8,7 +9,7 @@ class MockCRIOrchestrator: CRIOrchestration {
         hostingViewController.view.isHidden = false
     }
     
-    func getIDCheckCard(viewController: UIViewController, completion: @escaping () -> Void) -> UIViewController {
+    func getIDCheckCard(viewController: UIViewController, externalStream: IDCheckExternalStream) -> UIViewController {
         hostingViewController.view.isHidden = true
         return hostingViewController
     }

--- a/Tests/UnitTests/Screens/Tabs/HomeViewControllerTests.swift
+++ b/Tests/UnitTests/Screens/Tabs/HomeViewControllerTests.swift
@@ -46,12 +46,25 @@ extension HomeViewControllerTests {
         XCTAssertEqual(sut.navigationTitle.stringKey, "app_homeTitle")
     }
     
+    func testStream() async throws {
+        var event: CardStatus?
+        
+        sut.idCheckCardUpdateStream.continuation.yield(.hide)
+
+        for await status in sut.idCheckCardUpdateStream.stream {
+            event = status
+            break
+        }
+
+        waitForTruth(event == .hide, timeout: 3)
+    }
+    
     func test_numberOfSectionsWithIDCheck() {
         UINavigationController().setViewControllers([sut], animated: false)
         XCTAssertEqual(sut.numberOfSections(in: try sut.tableView), 3)
     }
     
-    func test_numbeOfRowsInSection() {
+    func test_numberOfRowsInSection() {
         XCTAssertEqual(sut.tableView(try sut.tableView, numberOfRowsInSection: 0), 1)
         XCTAssertEqual(sut.tableView(try sut.tableView, numberOfRowsInSection: 1), 1)
         XCTAssertEqual(sut.tableView(try sut.tableView, numberOfRowsInSection: 2), 1)

--- a/Tests/UnitTests/Screens/Tabs/HomeViewControllerTests.swift
+++ b/Tests/UnitTests/Screens/Tabs/HomeViewControllerTests.swift
@@ -8,7 +8,7 @@ import XCTest
 final class HomeViewControllerTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
     var mockNetworkClient: NetworkClient!
-    var criOrchestrator: MockCRIOrchestrator!
+    var mockCRIOrchestrator: MockCRIOrchestrator!
     var sut: HomeViewController!
     
     override func setUp() {
@@ -18,53 +18,67 @@ final class HomeViewControllerTests: XCTestCase {
         mockNetworkClient = NetworkClient()
         mockNetworkClient.authorizationProvider = MockAuthenticationProvider()
         
-        criOrchestrator = MockCRIOrchestrator()
+        mockCRIOrchestrator = MockCRIOrchestrator()
         sut = HomeViewController(analyticsService: mockAnalyticsService,
                                  networkClient: mockNetworkClient,
-                                 criOrchestrator: criOrchestrator)
+                                 criOrchestrator: mockCRIOrchestrator)
     }
     
     override func tearDown() {
         mockAnalyticsService = nil
         mockNetworkClient = nil
-        criOrchestrator = nil
+        mockCRIOrchestrator = nil
         sut = nil
-        
-        AppEnvironment.updateFlags(
-            releaseFlags: [:],
-            featureFlags: [:]
-        )
         
         super.tearDown()
     }
 }
 
 extension HomeViewControllerTests {
+    func test_header_Image() {
+        XCTAssertTrue(try sut.headerImage.isAccessibilityElement)
+    }
+    
     func test_page() {
         sut.beginAppearanceTransition(true, animated: false)
         sut.endAppearanceTransition()
         XCTAssertEqual(sut.navigationTitle.stringKey, "app_homeTitle")
     }
     
-    func testStream() async throws {
-        var event: CardStatus?
-        
-        sut.idCheckCardUpdateStream.continuation.yield(.hide)
-
-        for await status in sut.idCheckCardUpdateStream.stream {
-            event = status
-            break
-        }
-
-        waitForTruth(event == .hide, timeout: 3)
+    func test_insertIDCheck() throws {
+        XCTAssertEqual(sut.numberOfSections(in: try sut.tableView), 2)
+        mockCRIOrchestrator.hostingViewController.view.isHidden = false
+        mockCRIOrchestrator.streamContinuation?.yield(.show)
+        let tableView = try sut.tableView
+        waitForTruth(
+            self.sut.numberOfSections(in: tableView) == 3,
+            timeout: 5
+        )
+    }
+    
+    func test_deleteIDCheck() throws {
+        mockCRIOrchestrator.idCheckJourney = true
+        XCTAssertEqual(sut.numberOfSections(in: try sut.tableView), 3)
+        mockCRIOrchestrator.hostingViewController.view.isHidden = true
+        mockCRIOrchestrator.streamContinuation?.yield(.hide)
+        let tableView = try sut.tableView
+        waitForTruth(
+            self.sut.numberOfSections(in: tableView) == 2,
+            timeout: 5
+        )
+    }
+    
+    func test_numberOfSections() {
+        XCTAssertEqual(sut.numberOfSections(in: try sut.tableView), 2)
     }
     
     func test_numberOfSectionsWithIDCheck() {
-        UINavigationController().setViewControllers([sut], animated: false)
+        mockCRIOrchestrator.idCheckJourney = true
         XCTAssertEqual(sut.numberOfSections(in: try sut.tableView), 3)
     }
     
-    func test_numberOfRowsInSection() {
+    func test_numberOfRowsInSection_IDCheck() {
+        mockCRIOrchestrator.idCheckJourney = true
         XCTAssertEqual(sut.tableView(try sut.tableView, numberOfRowsInSection: 0), 1)
         XCTAssertEqual(sut.tableView(try sut.tableView, numberOfRowsInSection: 1), 1)
         XCTAssertEqual(sut.tableView(try sut.tableView, numberOfRowsInSection: 2), 1)
@@ -73,7 +87,7 @@ extension HomeViewControllerTests {
     func test_welcomeTileCell_viewModel() throws {
         let servicesTile = sut.tableView(
             try sut.tableView,
-            cellForRowAt: IndexPath(row: 0, section: 1)
+            cellForRowAt: IndexPath(row: 0, section: 0)
         ) as? ContentTileCell
         XCTAssertTrue(servicesTile?.viewModel is WelcomeTileViewModel)
     }
@@ -81,13 +95,13 @@ extension HomeViewControllerTests {
     func test_purposeTileCell_viewModel() throws {
         let servicesTile = sut.tableView(
             try sut.tableView,
-            cellForRowAt: IndexPath(row: 0, section: 2)
+            cellForRowAt: IndexPath(row: 0, section: 1)
         ) as? ContentTileCell
         XCTAssertTrue(servicesTile?.viewModel is PurposeTileViewModel)
     }
     
     func test_idCheckTileCell_isDisplayed() throws {
-        UINavigationController().setViewControllers([sut], animated: false)
+        mockCRIOrchestrator.idCheckJourney = true
         let idCell = sut.tableView(
             try sut.tableView,
             cellForRowAt: IndexPath(row: 0, section: 0)
@@ -120,10 +134,6 @@ extension HomeViewControllerTests {
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
         XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level2] as? String, OLTaxonomyValue.home)
         XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level3] as? String, OLTaxonomyValue.undefined)
-    }
-    
-    func test_header_Image() {
-        XCTAssertTrue(try sut.headerImage.isAccessibilityElement)
     }
 }
 


### PR DESCRIPTION
# fix: ensuring card hides when needed

When the ID Check journey completes through a successful or abort flow the ID Check card should be removed from the table view.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
