### PR TITLE
feat: do not announce branded items on the splash page

### DIFF
--- a/Sources/Resources/cy-GB.lproj/Localizable.strings
+++ b/Sources/Resources/cy-GB.lproj/Localizable.strings
@@ -26,7 +26,7 @@
 
 "app_externalApp" = "Yn agor yn yr App Store";
 
-"app_loadingHint" = "Llwytho GOV.UK One Login";
+"app_loadingLabel" = "Llwytho GOV.UK One Login";
 
 
 // MARK: Local Auth prompt (Face ID)

--- a/Sources/Resources/cy-GB.lproj/Localizable.strings
+++ b/Sources/Resources/cy-GB.lproj/Localizable.strings
@@ -19,6 +19,8 @@
 
 "app_exitButton" = "Gadael";
 
+"app_nameString" = "GOV.UK One Login";
+
 
 // MARK: Accessibility - voiceover additions
 
@@ -26,7 +28,7 @@
 
 "app_externalApp" = "Yn agor yn yr App Store";
 
-"app_loadingLabel" = "Llwytho GOV.UK One Login";
+"app_loadingLabel" = "Llwytho %@";
 
 
 // MARK: Local Auth prompt (Face ID)

--- a/Sources/Resources/cy-GB.lproj/Localizable.strings
+++ b/Sources/Resources/cy-GB.lproj/Localizable.strings
@@ -19,11 +19,14 @@
 
 "app_exitButton" = "Gadael";
 
+
 // MARK: Accessibility - voiceover additions
 
 "app_externalBrowser" = "Agor mewn porwr gwe";
 
 "app_externalApp" = "Yn agor yn yr App Store";
+
+"app_loadingHint" = "Llwytho GOV.UK One Login";
 
 
 // MARK: Local Auth prompt (Face ID)

--- a/Sources/Resources/cy-GB.lproj/Localizable.strings
+++ b/Sources/Resources/cy-GB.lproj/Localizable.strings
@@ -40,8 +40,6 @@
 
 
 // MARK: Sign in screen
-"app_signInTitle" = "GOV.UK One Login";
-
 "app_signInBody" = "Profwch eich hunaniaeth i gael mynediad at wasanaethau'r llywodraeth.\n\nBydd angen i chi fewngofnodi gyda'ch manylion GOV.UK One Login.";
 
 "app_signInButton" = "Mewngofnodi";

--- a/Sources/Resources/en.lproj/Localizable.strings
+++ b/Sources/Resources/en.lproj/Localizable.strings
@@ -40,8 +40,6 @@
 
 
 // MARK: Sign in screen
-"app_signInTitle" = "GOV.UK One Login";
-
 "app_signInBody" = "Prove your identity to access government services.\n\nYou’ll need to sign in with your GOV.UK One Login details.";
 
 "app_signInButton" = "Sign in";

--- a/Sources/Resources/en.lproj/Localizable.strings
+++ b/Sources/Resources/en.lproj/Localizable.strings
@@ -19,6 +19,8 @@
 
 "app_exitButton" = "Exit";
 
+"app_nameString" = "GOV.UK One Login";
+
 
 // MARK: Accessibility - voiceover additions
 
@@ -26,7 +28,7 @@
 
 "app_externalApp" = "Opens in App Store";
 
-"app_loadingLabel" = "Loading GOV.UK One Login";
+"app_loadingLabel" = "Loading %@";
 
 
 // MARK: Local Auth prompt (Face ID)

--- a/Sources/Resources/en.lproj/Localizable.strings
+++ b/Sources/Resources/en.lproj/Localizable.strings
@@ -26,6 +26,8 @@
 
 "app_externalApp" = "Opens in App Store";
 
+"app_loadingHint" = "Loading GOV.UK One Login";
+
 
 // MARK: Local Auth prompt (Face ID)
 "app_faceId_subtitle" = "Enter iPhone passcode";

--- a/Sources/Resources/en.lproj/Localizable.strings
+++ b/Sources/Resources/en.lproj/Localizable.strings
@@ -26,7 +26,7 @@
 
 "app_externalApp" = "Opens in App Store";
 
-"app_loadingHint" = "Loading GOV.UK One Login";
+"app_loadingLabel" = "Loading GOV.UK One Login";
 
 
 // MARK: Local Auth prompt (Face ID)

--- a/Sources/Screens/Intro/OneLoginIntroViewModel.swift
+++ b/Sources/Screens/Intro/OneLoginIntroViewModel.swift
@@ -5,7 +5,7 @@ import UIKit
 
 struct OneLoginIntroViewModel: IntroViewModel, BaseViewModel {
     let image: UIImage = UIImage(named: "badge") ?? UIImage()
-    let title: GDSLocalisedString = "app_signInTitle"
+    let title: GDSLocalisedString = "app_nameString"
     let body: GDSLocalisedString = "app_signInBody"
     let introButtonViewModel: ButtonViewModel
     let analyticsService: OneLoginAnalyticsService

--- a/Sources/Screens/Unlock/UnlockScreenViewController.swift
+++ b/Sources/Screens/Unlock/UnlockScreenViewController.swift
@@ -45,7 +45,7 @@ class UnlockScreenViewController: BaseViewController {
         didSet {
             loadingLabel.text = "Loading"
             loadingLabel.accessibilityIdentifier = "unlock-screen-loading-label"
-            loadingLabel.accessibilityHint = viewModel.accessibilityLabel.value
+            loadingLabel.accessibilityLabel = viewModel.accessibilityLabel.value
         }
     }
     

--- a/Sources/Screens/Unlock/UnlockScreenViewController.swift
+++ b/Sources/Screens/Unlock/UnlockScreenViewController.swift
@@ -31,10 +31,10 @@ class UnlockScreenViewController: BaseViewController {
     
     @IBOutlet private var oneLoginLogo: UIImageView! {
         didSet {
-            oneLoginLogo.isAccessibilityElement = true
+//            oneLoginLogo.isAccessibilityElement = true
             oneLoginLogo.accessibilityIdentifier = "unlock-screen-one-login-logo"
-            oneLoginLogo.accessibilityTraits = .none
-            oneLoginLogo.accessibilityHint = "GOV.UK One Login logo"
+//            oneLoginLogo.accessibilityTraits = .none
+//            oneLoginLogo.accessibilityHint = "GOV.UK One Login logo"
         }
     }
     

--- a/Sources/Screens/Unlock/UnlockScreenViewController.swift
+++ b/Sources/Screens/Unlock/UnlockScreenViewController.swift
@@ -31,10 +31,7 @@ class UnlockScreenViewController: BaseViewController {
     
     @IBOutlet private var oneLoginLogo: UIImageView! {
         didSet {
-//            oneLoginLogo.isAccessibilityElement = true
             oneLoginLogo.accessibilityIdentifier = "unlock-screen-one-login-logo"
-//            oneLoginLogo.accessibilityTraits = .none
-//            oneLoginLogo.accessibilityHint = "GOV.UK One Login logo"
         }
     }
     
@@ -48,6 +45,7 @@ class UnlockScreenViewController: BaseViewController {
         didSet {
             loadingLabel.text = "Loading"
             loadingLabel.accessibilityIdentifier = "unlock-screen-loading-label"
+            loadingLabel.accessibilityHint = viewModel.accessibilityLabel.value
         }
     }
     

--- a/Sources/Screens/Unlock/UnlockScreenViewModel.swift
+++ b/Sources/Screens/Unlock/UnlockScreenViewModel.swift
@@ -6,7 +6,7 @@ import UIKit
 struct UnlockScreenViewModel: BaseViewModel {
     let analyticsService: OneLoginAnalyticsService
     let primaryButtonViewModel: ButtonViewModel
-    let accessibilityLabel: GDSLocalisedString = GDSLocalisedString(stringKey: "app_loadingLabel")
+    let accessibilityLabel: GDSLocalisedString = GDSLocalisedString(stringKey: "app_loadingLabel", "app_nameString")
     
     let rightBarButtonTitle: GDSLocalisedString? = nil
     let backButtonIsHidden: Bool = true

--- a/Sources/Screens/Unlock/UnlockScreenViewModel.swift
+++ b/Sources/Screens/Unlock/UnlockScreenViewModel.swift
@@ -6,7 +6,7 @@ import UIKit
 struct UnlockScreenViewModel: BaseViewModel {
     let analyticsService: OneLoginAnalyticsService
     let primaryButtonViewModel: ButtonViewModel
-    let accessibilityLabel: GDSLocalisedString = GDSLocalisedString(stringKey: "app_loadingHint")
+    let accessibilityLabel: GDSLocalisedString = GDSLocalisedString(stringKey: "app_loadingLabel")
     
     let rightBarButtonTitle: GDSLocalisedString? = nil
     let backButtonIsHidden: Bool = true

--- a/Sources/Screens/Unlock/UnlockScreenViewModel.swift
+++ b/Sources/Screens/Unlock/UnlockScreenViewModel.swift
@@ -6,6 +6,7 @@ import UIKit
 struct UnlockScreenViewModel: BaseViewModel {
     let analyticsService: OneLoginAnalyticsService
     let primaryButtonViewModel: ButtonViewModel
+    let accessibilityLabel: GDSLocalisedString = GDSLocalisedString(stringKey: "app_loadingHint")
     
     let rightBarButtonTitle: GDSLocalisedString? = nil
     let backButtonIsHidden: Bool = true

--- a/Tests/UnitTests/Resources/LocalizedEnglishStringTests.swift
+++ b/Tests/UnitTests/Resources/LocalizedEnglishStringTests.swift
@@ -24,6 +24,8 @@ final class LocalizedEnglishStringTests: XCTestCase {
                        "Enter passcode")
         XCTAssertEqual("app_exitButton".getEnglishString(),
                        "Exit")
+        XCTAssertEqual("app_nameString".getEnglishString(),
+                       "GOV.UK One Login")
     }
     
     func test_localAuthPrompt_keys() throws {
@@ -34,8 +36,6 @@ final class LocalizedEnglishStringTests: XCTestCase {
     }
     
     func test_signInScreen_keys() throws {
-        XCTAssertEqual("app_signInTitle".getEnglishString(),
-                       "GOV.UK One Login")
         XCTAssertEqual("app_signInBody".getEnglishString(),
                        "Prove your identity to access government services.\n\nYou’ll need to sign in with your GOV.UK One Login details.")
         XCTAssertEqual("app_signInButton".getEnglishString(),
@@ -226,7 +226,7 @@ final class LocalizedEnglishStringTests: XCTestCase {
     func test_accessibilityHintKeys() {
         XCTAssertEqual("app_externalBrowser".getEnglishString(), "Opens in web browser")
         XCTAssertEqual("app_externalApp".getEnglishString(), "Opens in App Store")
-        XCTAssertEqual("app_loadingLabel".getEnglishString(), "Loading GOV.UK One Login")
+        XCTAssertEqual("app_loadingLabel".getEnglishString(), "Loading %@")
     }
     
     func test_localAuthError_keys() throws {

--- a/Tests/UnitTests/Resources/LocalizedEnglishStringTests.swift
+++ b/Tests/UnitTests/Resources/LocalizedEnglishStringTests.swift
@@ -226,6 +226,7 @@ final class LocalizedEnglishStringTests: XCTestCase {
     func test_accessibilityHintKeys() {
         XCTAssertEqual("app_externalBrowser".getEnglishString(), "Opens in web browser")
         XCTAssertEqual("app_externalApp".getEnglishString(), "Opens in App Store")
+        XCTAssertEqual("app_loadingLabel".getEnglishString(), "Loading GOV.UK One Login")
     }
     
     func test_localAuthError_keys() throws {

--- a/Tests/UnitTests/Resources/LocalizedWelshStringTests.swift
+++ b/Tests/UnitTests/Resources/LocalizedWelshStringTests.swift
@@ -24,6 +24,8 @@ final class LocalizedWelshStringTests: XCTestCase {
                        "Rhowch god mynediad")
         XCTAssertEqual("app_exitButton".getWelshString(),
                        "Gadael")
+        XCTAssertEqual("app_nameString".getWelshString(),
+                       "GOV.UK One Login")
     }
     
     func test_localAuthPrompt_keys() throws {
@@ -34,8 +36,6 @@ final class LocalizedWelshStringTests: XCTestCase {
     }
     
     func test_signInScreen_keys() throws {
-        XCTAssertEqual("app_signInTitle".getWelshString(),
-                       "GOV.UK One Login")
         XCTAssertEqual("app_signInBody".getWelshString(),
                        "Profwch eich hunaniaeth i gael mynediad at wasanaethau'r llywodraeth.\n\nBydd angen i chi fewngofnodi gyda'ch manylion GOV.UK One Login.")
         XCTAssertEqual("app_signInButton".getWelshString(),
@@ -226,7 +226,7 @@ final class LocalizedWelshStringTests: XCTestCase {
     func test_accessibilityHintKeys() {
         XCTAssertEqual("app_externalBrowser".getWelshString(), "Agor mewn porwr gwe")
         XCTAssertEqual("app_externalApp".getWelshString(), "Yn agor yn yr App Store")
-        XCTAssertEqual("app_loadingLabel".getWelshString(), "Llwytho GOV.UK One Login")
+        XCTAssertEqual("app_loadingLabel".getWelshString(), "Llwytho %@")
     }
     
     func test_localAuthError_keys() throws {

--- a/Tests/UnitTests/Resources/LocalizedWelshStringTests.swift
+++ b/Tests/UnitTests/Resources/LocalizedWelshStringTests.swift
@@ -226,6 +226,7 @@ final class LocalizedWelshStringTests: XCTestCase {
     func test_accessibilityHintKeys() {
         XCTAssertEqual("app_externalBrowser".getWelshString(), "Agor mewn porwr gwe")
         XCTAssertEqual("app_externalApp".getWelshString(), "Yn agor yn yr App Store")
+        XCTAssertEqual("app_loadingLabel".getWelshString(), "Llwytho GOV.UK One Login")
     }
     
     func test_localAuthError_keys() throws {

--- a/Tests/UnitTests/Screens/Intro/OneLoginIntroViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Intro/OneLoginIntroViewModelTests.swift
@@ -31,7 +31,7 @@ final class OneLoginIntroViewModelTests: XCTestCase {
 extension OneLoginIntroViewModelTests {
     func test_page() {
         XCTAssertEqual(sut.image, UIImage(named: "badge"))
-        XCTAssertEqual(sut.title.stringKey, "app_signInTitle")
+        XCTAssertEqual(sut.title.stringKey, "app_nameString")
         XCTAssertEqual(sut.body.stringKey, "app_signInBody")
         
     }
@@ -56,7 +56,7 @@ extension OneLoginIntroViewModelTests {
         XCTAssertEqual(mockAnalyticsService.screensVisited.count, 1)
         let screen = ScreenView(id: IntroAnalyticsScreenID.welcome.rawValue,
                                 screen: IntroAnalyticsScreen.welcome,
-                                titleKey: "app_signInTitle")
+                                titleKey: "app_nameString")
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
     }

--- a/Tests/UnitTests/Screens/Unlock/UnlockScreenViewControllerTests.swift
+++ b/Tests/UnitTests/Screens/Unlock/UnlockScreenViewControllerTests.swift
@@ -54,11 +54,6 @@ extension UnlockScreenViewControllerTests {
         try sut.unlockButton.sendActions(for: .touchUpInside)
         XCTAssertTrue(didPressButton)
     }
-    
-    func test_logo() {
-        XCTAssertTrue(try sut.oneLoginLogo.isAccessibilityElement)
-        XCTAssertEqual(try sut.oneLoginLogo.accessibilityHint, "GOV.UK One Login logo")
-    }
 }
 
 extension UnlockScreenViewController {

--- a/Tests/UnitTests/Screens/Unlock/UnlockScreenViewControllerTests.swift
+++ b/Tests/UnitTests/Screens/Unlock/UnlockScreenViewControllerTests.swift
@@ -40,7 +40,7 @@ extension UnlockScreenViewControllerTests {
     
     func test_page() throws {
         XCTAssertEqual(try sut.loadingLabel.text, "Loading")
-        XCTAssertEqual(try sut.loadingLabel.accessibilityHint, "Loading GOV.UK One Login")
+        XCTAssertEqual(try sut.loadingLabel.accessibilityLabel, "Loading GOV.UK One Login")
         XCTAssertEqual(try sut.loadingSpinner.style, .medium)
     }
     

--- a/Tests/UnitTests/Screens/Unlock/UnlockScreenViewControllerTests.swift
+++ b/Tests/UnitTests/Screens/Unlock/UnlockScreenViewControllerTests.swift
@@ -40,6 +40,7 @@ extension UnlockScreenViewControllerTests {
     
     func test_page() throws {
         XCTAssertEqual(try sut.loadingLabel.text, "Loading")
+        XCTAssertEqual(try sut.loadingLabel.accessibilityHint, "Loading GOV.UK One Login")
         XCTAssertEqual(try sut.loadingSpinner.style, .medium)
     }
     


### PR DESCRIPTION
# DCMAW-13250: Do not announce branded items on the Splash page

### QA Evidence
- **No announcement for GOV.UK logo**

https://github.com/user-attachments/assets/67b53cd5-3c18-4229-b96a-ff8a49e9e809


- **Added announcement to loading label on splash screen**

_Note - presenting the screen was temporarily changed in order to manually test announcement on loading text. Unsure as to whether the voiceover will ever reach this text on the actual splash screen as this is always overshadowed by local auth prompt._

https://github.com/user-attachments/assets/2db8b71a-f62b-4610-96ce-148126e3e04e


# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
