### PR TITLE
fix: remove refresh and delete from secure store manager

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -3751,7 +3751,7 @@
 			repositoryURL = "https://github.com/govuk-one-login/mobile-wallet-ios.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 10.0.0;
+				minimumVersion = 11.0.0;
 			};
 		};
 		AB90DC7A2D8831E000070B0F /* XCRemoteSwiftPackageReference "mobile-ios-common" */ = {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -194,8 +194,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-ui",
       "state" : {
-        "revision" : "4cbfec2ce4fbc769b7c14c13afa98f1b59512351",
-        "version" : "0.2.1"
+        "revision" : "9d3946ead0fd76133e227e0a7dd3921bcd63b1bb",
+        "version" : "0.4.1"
       }
     },
     {
@@ -203,8 +203,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-wallet-ios.git",
       "state" : {
-        "revision" : "0024d18453391ae67499cc85272b97666a5364be",
-        "version" : "10.30.0"
+        "revision" : "d8788e58a21ef9195224b12deae0ebf7a64f81bd",
+        "version" : "11.0.0"
       }
     },
     {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-id-check-ios-sdk.git",
       "state" : {
-        "revision" : "e836678500f233aa9bd4e7a8f4a0201cefc56ea1",
-        "version" : "8.1.1"
+        "revision" : "688770f3b6670f8f9bad605ecb01bf5016f63bfb",
+        "version" : "8.3.1"
       }
     },
     {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-id-check-ios-sdk.git",
       "state" : {
-        "revision" : "688770f3b6670f8f9bad605ecb01bf5016f63bfb",
-        "version" : "8.3.1"
+        "revision" : "e836678500f233aa9bd4e7a8f4a0201cefc56ea1",
+        "version" : "8.1.1"
       }
     },
     {

--- a/Sources/Application/SceneDelegate.swift
+++ b/Sources/Application/SceneDelegate.swift
@@ -23,7 +23,6 @@ final class SceneDelegate: UIResponder,
             
             manager.registerSessionBoundData(
                 [
-                    secureStoreManager,
                     WalletSessionData(),
                     WalletAvailabilityService(),
                     analyticsPreferenceStore,

--- a/Sources/Extensions/UserDefaults+AppIntegrity.swift
+++ b/Sources/Extensions/UserDefaults+AppIntegrity.swift
@@ -42,3 +42,12 @@ extension UserDefaults: @retroactive AttestationStorage {
         )
     }
 }
+
+extension UserDefaults: SessionBoundData {
+    func delete() throws {
+        removeObject(forKey: OLString.returningUser)
+        removeObject(forKey: OLString.accessTokenExpiry)
+        removeObject(forKey: OLString.persistentSessionID)
+        removeObject(forKey: OLString.storedTokens)
+    }
+}

--- a/Sources/Login/EnrolmentCoordinator.swift
+++ b/Sources/Login/EnrolmentCoordinator.swift
@@ -62,4 +62,8 @@ final class EnrolmentCoordinator: NSObject,
             preconditionFailure()
         }
     }
+    
+    func enableEnrolmentButton() {
+        (root.viewControllers.last as? GDSInformationViewController)?.resetPrimaryButton()
+    }
 }

--- a/Sources/Screens/Enrolment/BiometricsEnrolmentViewModel.swift
+++ b/Sources/Screens/Enrolment/BiometricsEnrolmentViewModel.swift
@@ -39,6 +39,7 @@ struct BiometricsEnrolmentViewModel: GDSCentreAlignedViewModel,
         self.image = isFaceID ? "faceid" : "touchid"
         self.primaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "app_enableBiometricsButton",
                                                                biometricsTypeString,
+                                                               shouldLoadOnTap: true,
                                                                analyticsService: analyticsService) {
             primaryButtonAction()
         }

--- a/Sources/Utilities/OneLoginEnrolmentManager.swift
+++ b/Sources/Utilities/OneLoginEnrolmentManager.swift
@@ -42,7 +42,8 @@ struct OneLoginEnrolmentManager {
                     analyticsService.logCrash(error)
                 }
             } catch LocalAuthenticationWrapperError.cancelled {
-                return
+                (coordinator as? EnrolmentCoordinator)?
+                    .enableEnrolmentButton()
             } catch {
                 analyticsService.logCrash(error)
             }

--- a/Sources/Utilities/Storage/DefaultsStorable.swift
+++ b/Sources/Utilities/Storage/DefaultsStorable.swift
@@ -7,11 +7,3 @@ protocol DefaultsStorable {
 }
 
 extension UserDefaults: DefaultsStorable { }
-
-extension UserDefaults: SessionBoundData {
-    func delete() throws {
-        removeObject(forKey: OLString.returningUser)
-        removeObject(forKey: OLString.accessTokenExpiry)
-        removeObject(forKey: OLString.persistentSessionID)
-    }
-}

--- a/Sources/Utilities/Storage/OneLoginSecureStoreManager.swift
+++ b/Sources/Utilities/Storage/OneLoginSecureStoreManager.swift
@@ -5,12 +5,11 @@ protocol SecureStoreManager {
     var accessControlEncryptedStore: SecureStorable { get }
     var encryptedStore: SecureStorable { get }
     var localAuthentication: LocalAuthManaging & LocalAuthenticationContextStrings { get }
-    func refreshStore() throws
 }
 
 final class OneLoginSecureStoreManager: SecureStoreManager {
-    private(set) var accessControlEncryptedStore: SecureStorable
-    private(set) var encryptedStore: SecureStorable
+    let accessControlEncryptedStore: SecureStorable
+    let encryptedStore: SecureStorable
     let localAuthentication: LocalAuthManaging & LocalAuthenticationContextStrings
     
     convenience init(
@@ -35,21 +34,5 @@ final class OneLoginSecureStoreManager: SecureStoreManager {
         self.accessControlEncryptedStore = accessControlEncryptedStore
         self.encryptedStore = encryptedStore
         self.localAuthentication = localAuthentication
-    }
-    
-    func refreshStore() throws {
-        try accessControlEncryptedStore.delete()
-        try encryptedStore.delete()
-        
-        accessControlEncryptedStore = try .accessControlEncryptedStore(
-            localAuthManager: localAuthentication
-        )
-        encryptedStore = .encryptedStore()
-    }
-}
-
-extension OneLoginSecureStoreManager: SessionBoundData {
-    func delete() throws {
-        try refreshStore()
     }
 }

--- a/Sources/Utilities/Storage/Session/PersistentSessionManager.swift
+++ b/Sources/Utilities/Storage/Session/PersistentSessionManager.swift
@@ -115,10 +115,6 @@ final class PersistentSessionManager: SessionManager {
             return
         }
         
-        if !storeKeyService.hasLoginTokens {
-            try secureStoreManager.refreshStore()
-        }
-        
         let tokens = StoredTokens(idToken: tokenResponse.idToken,
                                   accessToken: tokenResponse.accessToken)
         

--- a/Tests/UnitTests/Utilities/OneLoginSecureStoreManagerTests.swift
+++ b/Tests/UnitTests/Utilities/OneLoginSecureStoreManagerTests.swift
@@ -33,15 +33,4 @@ extension OneLoginSecureStoreManagerTests {
         #expect(sut.accessControlEncryptedStore is SecureStoreService)
         #expect(sut.encryptedStore is SecureStoreService)
     }
-    
-    @Test("Ensure delete replaces instances of SecureStorable")
-    func delete() throws {
-        #expect(sut.accessControlEncryptedStore is MockSecureStoreService)
-        #expect(sut.encryptedStore is MockSecureStoreService)
-        try sut.delete()
-        #expect(mockAccessControlEncryptedStore.didCallDeleteStore)
-        #expect(mockEncryptedStore.didCallDeleteStore)
-        #expect(sut.accessControlEncryptedStore is SecureStoreService)
-        #expect(sut.encryptedStore is SecureStoreService)
-    }
 }

--- a/Tests/UnitTests/Utilities/Session/PersistentSessionManagerTests.swift
+++ b/Tests/UnitTests/Utilities/Session/PersistentSessionManagerTests.swift
@@ -236,8 +236,6 @@ extension PersistentSessionManagerTests {
         try await sut.startSession(loginSession, using: MockLoginSessionConfiguration.oneLoginSessionConfiguration)
         // WHEN I attempt to save my session
         try sut.saveSession()
-        // THEN the secure store manager is refreshed
-        XCTAssertTrue(mockSecureStoreManager.didCallRefreshStore)
         // THEN my session data is updated in the store
         XCTAssertEqual(mockEncryptedStore.savedItems, [OLString.persistentSessionID: "1d003342-efd1-4ded-9c11-32e0f15acae6"])
         XCTAssertEqual(mockUnprotectedStore.savedData.count, 2)


### PR DESCRIPTION
# fix: dcmaw-13682 remove refresh and delete from secure store manager

Removing all local auth after logging into the app was causing a crash because we were cycling secure store keys.
This is a hangover from using the secure store access level `currentBiometricsOrPasscode` where we have now moved to `.anyBiometricsOrPasscode` so the keys do not need to be cycled when the user logs out.
This incorporates an update to the Wallet SDK for deleting wallet data, which was also previously causing a crash when deleting keys.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
