### PR TITLE
fix: local auth bug

### DIFF
--- a/Sources/Login/EnrolmentCoordinator.swift
+++ b/Sources/Login/EnrolmentCoordinator.swift
@@ -37,6 +37,11 @@ final class EnrolmentCoordinator: NSObject,
         self.sessionManager = sessionManager
         self.localAuthContext = localAuthContext
         self.enrolmentJourney = enrolmentJourney
+        self.sessionManager.isEnrolling = true
+    }
+
+    deinit {
+        sessionManager.isEnrolling = false
     }
     
     func start() {

--- a/Sources/Qualification/State/AppQualifyingService.swift
+++ b/Sources/Qualification/State/AppQualifyingService.swift
@@ -89,19 +89,14 @@ final class AppQualifyingService: QualifyingService {
             return
         }
         
-        if sessionManager.isOneTimeUser {
+        switch sessionManager.sessionState {
+        case .expired:
+            userState = .expired
+        case .enrolling, .nonePresent:
+            userState = .notLoggedIn
+        case .oneTime:
             userState = .loggedIn
-        } else {
-            guard sessionManager.expiryDate != nil else {
-                userState = .notLoggedIn
-                return
-            }
-            
-            guard sessionManager.isSessionValid else {
-                userState = .expired
-                return
-            }
-            
+        case .saved:
             do {
                 try await MainActor.run {
                     try sessionManager.resumeSession()

--- a/Sources/Utilities/Storage/Session/PersistentSessionManager.swift
+++ b/Sources/Utilities/Storage/Session/PersistentSessionManager.swift
@@ -133,10 +133,6 @@ final class PersistentSessionManager: SessionManager {
     }
     
     func saveSession() throws {
-        defer {
-            isEnrolling = false
-        }
-        
         guard let tokenResponse else {
             assertionFailure("Could not save session as token response was not set")
             return

--- a/Sources/Utilities/Storage/Session/PersistentSessionManager.swift
+++ b/Sources/Utilities/Storage/Session/PersistentSessionManager.swift
@@ -7,11 +7,13 @@ final class PersistentSessionManager: SessionManager {
     private let secureStoreManager: SecureStoreManager
     private let storeKeyService: TokenStore
     private let unprotectedStore: DefaultsStorable
+    
     let localAuthentication: LocalAuthManaging
-    
     let tokenProvider: TokenHolder
-    private var tokenResponse: TokenResponse?
     
+    var isEnrolling: Bool = false
+    
+    private var tokenResponse: TokenResponse?
     private var sessionBoundData = [SessionBoundData]()
     
     let user = CurrentValueSubject<(any User)?, Never>(nil)
@@ -35,16 +37,37 @@ final class PersistentSessionManager: SessionManager {
         self.tokenProvider = TokenHolder()
     }
     
-    private var persistentID: String? {
-        try? secureStoreManager.encryptedStore.readItem(itemName: OLString.persistentSessionID)
+    var sessionState: SessionState {
+        if isValidEnrolment {
+            return .enrolling
+        } else if isOneTimeUser {
+            return .oneTime
+        } else {
+            guard expiryDate != nil else {
+                return .nonePresent
+            }
+            
+            guard isSessionValid else {
+                return .expired
+            }
+            
+            return .saved
+        }
+    }
+    
+    private var isValidEnrolment: Bool {
+        guard let tokenResponse else {
+            return false
+        }
+        return isEnrolling && tokenResponse.expiryDate > .now
+    }
+    
+    private var isOneTimeUser: Bool {
+        tokenProvider.subjectToken != nil && !isReturningUser
     }
     
     var expiryDate: Date? {
         unprotectedStore.value(forKey: OLString.accessTokenExpiry) as? Date
-    }
-    
-    var sessionExists: Bool {
-        tokenProvider.subjectToken != nil
     }
     
     var isSessionValid: Bool {
@@ -59,8 +82,8 @@ final class PersistentSessionManager: SessionManager {
         ?? false
     }
     
-    var isOneTimeUser: Bool {
-        sessionExists && !isReturningUser
+    private var persistentID: String? {
+        try? secureStoreManager.encryptedStore.readItem(itemName: OLString.persistentSessionID)
     }
     
     private var hasNotRemovedLocalAuth: Bool {
@@ -110,6 +133,10 @@ final class PersistentSessionManager: SessionManager {
     }
     
     func saveSession() throws {
+        defer {
+            isEnrolling = false
+        }
+        
         guard let tokenResponse else {
             assertionFailure("Could not save session as token response was not set")
             return

--- a/Sources/Utilities/Storage/Session/SessionManager.swift
+++ b/Sources/Utilities/Storage/Session/SessionManager.swift
@@ -7,13 +7,20 @@ enum UserState {
     case notAuthenticated
 }
 
-protocol SessionManager: UserProvider {
-    var expiryDate: Date? { get }
+enum SessionState {
+    case nonePresent
+    case enrolling
+    case oneTime
+    case saved
+    case expired
+}
+
+protocol SessionManager: AnyObject, UserProvider {
+    var sessionState: SessionState { get }
     
-    var sessionExists: Bool { get }
-    var isSessionValid: Bool { get }
+    var expiryDate: Date? { get }
     var isReturningUser: Bool { get }
-    var isOneTimeUser: Bool { get }
+    var isEnrolling: Bool { get set }
 
     var tokenProvider: TokenHolder { get }
 

--- a/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockSessionManager.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockSessionManager.swift
@@ -5,10 +5,10 @@ import LocalAuthenticationWrapper
 @testable import OneLogin
 
 final class MockSessionManager: SessionManager {
+    var sessionState: SessionState
+
     var expiryDate: Date?
-    var sessionExists: Bool
-    var isSessionValid: Bool
-    var isOneTimeUser: Bool
+    var isEnrolling: Bool
     var isReturningUser: Bool
 
     var user = CurrentValueSubject<(any OneLogin.User)?, Never>(nil)
@@ -29,17 +29,15 @@ final class MockSessionManager: SessionManager {
     var localAuthentication: LocalAuthManaging = MockLocalAuthManager()
 
     init(expiryDate: Date? = nil,
-         sessionExists: Bool = false,
-         isSessionValid: Bool = false,
+         isEnrolling: Bool = false,
          isReturningUser: Bool = false,
-         isOneTimeUser: Bool = false,
+         sessionState: SessionState = .nonePresent,
          tokenProvider: TokenHolder = TokenHolder()) {
         self.expiryDate = expiryDate
-        self.sessionExists = sessionExists
-        self.isSessionValid = isSessionValid
+        self.isEnrolling = isEnrolling
         self.isReturningUser = isReturningUser
         self.tokenProvider = tokenProvider
-        self.isOneTimeUser = isOneTimeUser
+        self.sessionState = sessionState
     }
 
     func startSession(
@@ -93,6 +91,5 @@ final class MockSessionManager: SessionManager {
         user.send(MockUser())
         isReturningUser = returningUser
         expiryDate = expired ? .distantPast : .distantFuture
-        isSessionValid = !expired
     }
 }

--- a/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
+++ b/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
@@ -141,7 +141,7 @@ extension AppQualifyingServiceTests {
 // MARK: - User State Evaluation
 extension AppQualifyingServiceTests {
     func test_oneTimeUser_userConfirmed() {
-        sessionManager.isOneTimeUser = true
+        sessionManager.sessionState = .oneTime
         sut.delegate = self
         sut.initiate()
 
@@ -167,6 +167,7 @@ extension AppQualifyingServiceTests {
     
     func test_sessionInvalid_userExpired() {
         sessionManager.expiryDate = .distantFuture
+        sessionManager.sessionState = .expired
         sut.delegate = self
         sut.initiate()
         
@@ -180,7 +181,7 @@ extension AppQualifyingServiceTests {
     
     func test_resumeSession_userConfirmed() {
         sessionManager.expiryDate = .distantFuture
-        sessionManager.isSessionValid = true
+        sessionManager.sessionState = .saved
         sut.delegate = self
         sut.initiate()
         
@@ -194,7 +195,7 @@ extension AppQualifyingServiceTests {
     
     func test_resumeSession_userCancelledBiometrics_error() {
         sessionManager.expiryDate = .distantFuture
-        sessionManager.isSessionValid = true
+        sessionManager.sessionState = .saved
         sessionManager.errorFromResumeSession = SecureStoreError.biometricsCancelled
         sut.delegate = self
         sut.initiate()
@@ -209,7 +210,7 @@ extension AppQualifyingServiceTests {
     
     func test_resumeSession_nonCantDecryptData_error() {
         sessionManager.expiryDate = .distantFuture
-        sessionManager.isSessionValid = true
+        sessionManager.sessionState = .saved
         sessionManager.errorFromResumeSession = SecureStoreError.unableToRetrieveFromUserDefaults
         sut.delegate = self
         sut.initiate()
@@ -226,7 +227,7 @@ extension AppQualifyingServiceTests {
     
     func test_resumeSession_nonCantDecryptData_error_clearSessionData_error() {
         sessionManager.expiryDate = .distantFuture
-        sessionManager.isSessionValid = true
+        sessionManager.sessionState = .saved
         sessionManager.errorFromResumeSession = SecureStoreError.unableToRetrieveFromUserDefaults
         sessionManager.errorFromClearAllSessionData = MockWalletError.cantDelete
         sut.delegate = self

--- a/Tests/UnitTests/Utilities/Session/PersistentSessionManagerTests.swift
+++ b/Tests/UnitTests/Utilities/Session/PersistentSessionManagerTests.swift
@@ -56,7 +56,6 @@ final class PersistentSessionManagerTests: XCTestCase {
 extension PersistentSessionManagerTests {
     func test_initialState() {
         XCTAssertNil(sut.expiryDate)
-        XCTAssertFalse(sut.sessionExists)
         XCTAssertFalse(sut.isSessionValid)
         XCTAssertFalse(sut.isReturningUser)
     }

--- a/Tests/UnitTests/Utilities/Session/PersistentSessionManagerTests.swift
+++ b/Tests/UnitTests/Utilities/Session/PersistentSessionManagerTests.swift
@@ -58,6 +58,8 @@ extension PersistentSessionManagerTests {
         XCTAssertNil(sut.expiryDate)
         XCTAssertFalse(sut.isSessionValid)
         XCTAssertFalse(sut.isReturningUser)
+        XCTAssertFalse(sut.isEnrolling)
+        XCTAssertEqual(sut.sessionState, .nonePresent)
     }
     
     func test_sessionExpiryDate() {
@@ -72,8 +74,9 @@ extension PersistentSessionManagerTests {
         // GIVEN the unprotected store contains a session expiry date in the future
         let date = Date.distantFuture
         mockUnprotectedStore.set(date, forKey: OLString.accessTokenExpiry)
-        // THEN the session is not valid
+        // THEN the session is valid
         XCTAssertTrue(sut.isSessionValid)
+        XCTAssertEqual(sut.sessionState, .saved)
     }
     
     func test_sessionIsInvalidWhenExpired() {
@@ -82,6 +85,7 @@ extension PersistentSessionManagerTests {
         mockUnprotectedStore.set(date, forKey: OLString.accessTokenExpiry)
         // THEN the session is not valid
         XCTAssertFalse(sut.isSessionValid)
+        XCTAssertEqual(sut.sessionState, .expired)
     }
     
     func test_isReturningUserPullsFromStore() {
@@ -118,6 +122,7 @@ extension PersistentSessionManagerTests {
         // AND no persistent session ID is provided
         let configuration = try XCTUnwrap(loginSession.sessionConfiguration)
         XCTAssertNil(configuration.persistentSessionId)
+        XCTAssertEqual(sut.sessionState, .oneTime)
     }
     
     @MainActor


### PR DESCRIPTION
# DCMAW-12757: Local Auth bug fix

During local auth enrolment, if the user sends the app to the background, the app assumes they've selected the 'Skip' option. This PR aims to fix this by resuming the enrolment flow when the app is brought back to the foreground.

### QA Evidence

https://github.com/user-attachments/assets/432f8b42-3f63-45b0-8269-c68d3047c351


# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
~- [ ] Created a `draft` pull request if it is not yet ready for review~

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
~- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.~
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~ 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
