### PR TITLE
fix: fixing taxonomy overriding

### DIFF
--- a/Sources/Analytics/Taxonomy/OLTaxonomy.swift
+++ b/Sources/Analytics/Taxonomy/OLTaxonomy.swift
@@ -7,7 +7,6 @@ enum OLTaxonomyValue {
     static let system = "app system"
     static let login = "login"
     static let home = "home"
-    static let wallet = "wallet"
     static let settings = "settings"
     static let reauth = "re auth"
     static let undefined = "undefined"

--- a/Sources/Screens/Errors/AppUnavailableViewModel.swift
+++ b/Sources/Screens/Errors/AppUnavailableViewModel.swift
@@ -20,8 +20,7 @@ struct AppUnavailableViewModel: GDSCentreAlignedViewModel,
     
     init(analyticsService: OneLoginAnalyticsService) {
         self.analyticsService = analyticsService.addingAdditionalParameters([
-            OLTaxonomyKey.level2: OLTaxonomyValue.system,
-            OLTaxonomyKey.level3: OLTaxonomyValue.undefined
+            OLTaxonomyKey.level2: OLTaxonomyValue.system
         ])
     }
     

--- a/Sources/Screens/Errors/UpdateAppViewModel.swift
+++ b/Sources/Screens/Errors/UpdateAppViewModel.swift
@@ -23,8 +23,7 @@ struct UpdateAppViewModel: GDSCentreAlignedViewModel,
     init(analyticsService: OneLoginAnalyticsService,
          urlOpener: URLOpener = UIApplication.shared) {
         self.analyticsService = analyticsService.addingAdditionalParameters([
-            OLTaxonomyKey.level2: OLTaxonomyValue.system,
-            OLTaxonomyKey.level3: OLTaxonomyValue.undefined
+            OLTaxonomyKey.level2: OLTaxonomyValue.system
         ])
         self.primaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "app_updateAppButton",
                                                                "app_nameString",

--- a/Sources/Screens/Tabs/HomeViewController.swift
+++ b/Sources/Screens/Tabs/HomeViewController.swift
@@ -33,8 +33,7 @@ final class HomeViewController: BaseViewController {
          networkClient: NetworkClient,
          criOrchestrator: CRIOrchestration) {
         self.analyticsService = analyticsService.addingAdditionalParameters([
-            OLTaxonomyKey.level2: OLTaxonomyValue.home,
-            OLTaxonomyKey.level3: OLTaxonomyValue.undefined
+            OLTaxonomyKey.level2: OLTaxonomyValue.home
         ])
         self.networkClient = networkClient
         self.criOrchestrator = criOrchestrator

--- a/Sources/Screens/Tabs/SettingsTabViewModel.swift
+++ b/Sources/Screens/Tabs/SettingsTabViewModel.swift
@@ -41,8 +41,7 @@ struct SettingsTabViewModel: TabbedViewModel {
          openSignOutPage: @escaping () -> Void,
          openDeveloperMenu: @escaping () -> Void) {
         self.analyticsService = analyticsService.addingAdditionalParameters([
-            OLTaxonomyKey.level2: OLTaxonomyValue.settings,
-            OLTaxonomyKey.level3: OLTaxonomyValue.undefined
+            OLTaxonomyKey.level2: OLTaxonomyValue.settings
         ])
         self.userProvider = userProvider
         self.urlOpener = urlOpener

--- a/Sources/Tabs/HomeCoordinator.swift
+++ b/Sources/Tabs/HomeCoordinator.swift
@@ -16,17 +16,12 @@ final class HomeCoordinator: NSObject,
     let root = UINavigationController()
     weak var parentCoordinator: ParentCoordinator?
     
-    private var idCheckAnalyticsService: OneLoginAnalyticsService
     private var analyticsService: OneLoginAnalyticsService
     private let networkClient: NetworkClient
     
     init(analyticsService: OneLoginAnalyticsService,
          networkClient: NetworkClient) {
-        self.idCheckAnalyticsService = analyticsService
-        self.analyticsService = analyticsService.addingAdditionalParameters([
-            OLTaxonomyKey.level2: OLTaxonomyValue.home,
-            OLTaxonomyKey.level3: OLTaxonomyValue.undefined
-        ])
+        self.analyticsService = analyticsService
         self.networkClient = networkClient
     }
     
@@ -34,7 +29,7 @@ final class HomeCoordinator: NSObject,
         root.tabBarItem = UITabBarItem(title: GDSLocalisedString(stringLiteral: "app_homeTitle").value,
                                        image: UIImage(systemName: "house"),
                                        tag: 0)
-        let criOrchestrator = CRIOrchestrator(analyticsService: idCheckAnalyticsService,
+        let criOrchestrator = CRIOrchestrator(analyticsService: analyticsService,
                                               networkClient: networkClient,
                                               criURLs: OneLoginCRIURLs())
         let hc = HomeViewController(analyticsService: analyticsService,

--- a/Sources/Tabs/HomeCoordinator.swift
+++ b/Sources/Tabs/HomeCoordinator.swift
@@ -16,11 +16,13 @@ final class HomeCoordinator: NSObject,
     let root = UINavigationController()
     weak var parentCoordinator: ParentCoordinator?
     
+    private var idCheckAnalyticsService: OneLoginAnalyticsService
     private var analyticsService: OneLoginAnalyticsService
     private let networkClient: NetworkClient
     
     init(analyticsService: OneLoginAnalyticsService,
          networkClient: NetworkClient) {
+        self.idCheckAnalyticsService = analyticsService
         self.analyticsService = analyticsService.addingAdditionalParameters([
             OLTaxonomyKey.level2: OLTaxonomyValue.home,
             OLTaxonomyKey.level3: OLTaxonomyValue.undefined
@@ -32,7 +34,7 @@ final class HomeCoordinator: NSObject,
         root.tabBarItem = UITabBarItem(title: GDSLocalisedString(stringLiteral: "app_homeTitle").value,
                                        image: UIImage(systemName: "house"),
                                        tag: 0)
-        let criOrchestrator = CRIOrchestrator(analyticsService: analyticsService,
+        let criOrchestrator = CRIOrchestrator(analyticsService: idCheckAnalyticsService,
                                               networkClient: networkClient,
                                               criURLs: OneLoginCRIURLs())
         let hc = HomeViewController(analyticsService: analyticsService,

--- a/Sources/Tabs/SettingsCoordinator.swift
+++ b/Sources/Tabs/SettingsCoordinator.swift
@@ -27,8 +27,7 @@ final class SettingsCoordinator: NSObject,
          networkClient: NetworkClient,
          urlOpener: URLOpener) {
         self.analyticsService = analyticsService.addingAdditionalParameters([
-            OLTaxonomyKey.level2: OLTaxonomyValue.system,
-            OLTaxonomyKey.level3: OLTaxonomyValue.undefined
+            OLTaxonomyKey.level2: OLTaxonomyValue.system
         ])
         self.analyticsPreferenceStore = analyticsPreferenceStore
         self.sessionManager = sessionManager

--- a/Sources/Tabs/WalletCoordinator.swift
+++ b/Sources/Tabs/WalletCoordinator.swift
@@ -24,8 +24,7 @@ final class WalletCoordinator: NSObject,
          networkClient: NetworkClient & WalletNetworkClient,
          sessionManager: SessionManager) {
         self.analyticsService = analyticsService.addingAdditionalParameters([
-            OLTaxonomyKey.level2: OLTaxonomyValue.wallet,
-            OLTaxonomyKey.level3: OLTaxonomyValue.undefined
+            OLTaxonomyKey.level2: OLTaxonomyValue.wallet
         ])
         self.networkClient = networkClient
         self.sessionManager = sessionManager

--- a/Sources/Tabs/WalletCoordinator.swift
+++ b/Sources/Tabs/WalletCoordinator.swift
@@ -23,9 +23,7 @@ final class WalletCoordinator: NSObject,
     init(analyticsService: OneLoginAnalyticsService,
          networkClient: NetworkClient & WalletNetworkClient,
          sessionManager: SessionManager) {
-        self.analyticsService = analyticsService.addingAdditionalParameters([
-            OLTaxonomyKey.level2: OLTaxonomyValue.wallet
-        ])
+        self.analyticsService = analyticsService
         self.networkClient = networkClient
         self.sessionManager = sessionManager
     }

--- a/Tests/UnitTests/Resources/OLStringTests.swift
+++ b/Tests/UnitTests/Resources/OLStringTests.swift
@@ -12,5 +12,6 @@ final class OLStringTests: XCTestCase {
 
         // Universal Link Component
         XCTAssertEqual(OLString.redirect, "redirect")
+        XCTAssertEqual(OLString.wallet, "wallet")
     }
 }

--- a/Tests/UnitTests/Resources/OLStringTests.swift
+++ b/Tests/UnitTests/Resources/OLStringTests.swift
@@ -12,6 +12,5 @@ final class OLStringTests: XCTestCase {
 
         // Universal Link Component
         XCTAssertEqual(OLString.redirect, "redirect")
-        XCTAssertEqual(OLString.wallet, "wallet")
     }
 }

--- a/Tests/UnitTests/Screens/Errors/AppUnavailableViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Errors/AppUnavailableViewModelTests.swift
@@ -45,6 +45,6 @@ extension AppUnavailableViewModelTests {
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
         XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level2] as? String, OLTaxonomyValue.system)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level3] as? String, OLTaxonomyValue.undefined)
+        XCTAssertNil(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level3] as? String)
     }
 }

--- a/Tests/UnitTests/Screens/Tabs/HomeViewControllerTests.swift
+++ b/Tests/UnitTests/Screens/Tabs/HomeViewControllerTests.swift
@@ -133,7 +133,7 @@ extension HomeViewControllerTests {
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
         XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level2] as? String, OLTaxonomyValue.home)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level3] as? String, OLTaxonomyValue.undefined)
+        XCTAssertNil(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level3] as? String)
     }
 }
 

--- a/Tests/UnitTests/Screens/Tabs/SettingsTabViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Tabs/SettingsTabViewModelTests.swift
@@ -58,7 +58,7 @@ extension SettingsTabViewModelTests {
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
         XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level2] as? String, OLTaxonomyValue.settings)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level3] as? String, OLTaxonomyValue.undefined)
+        XCTAssertNil(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level3] as? String)
     }
     
     func test_openSignOutPage() {

--- a/Tests/UnitTests/Screens/Tabs/SettingsViewControllerTests.swift
+++ b/Tests/UnitTests/Screens/Tabs/SettingsViewControllerTests.swift
@@ -120,7 +120,7 @@ extension SettingsViewControllerTests {
         XCTAssertEqual(mockAnalyticsService.screensVisited, [screen.name])
         XCTAssertEqual(mockAnalyticsService.screenParamsLogged, screen.parameters)
         XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level2] as? String, OLTaxonomyValue.settings)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level3] as? String, OLTaxonomyValue.undefined)
+        XCTAssertNil(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level3] as? String)
     }
     
     func test_updateAnalytics_accepted() {
@@ -162,7 +162,7 @@ extension SettingsViewControllerTests {
         XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged, event.parameters)
         XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level2] as? String, OLTaxonomyValue.settings)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level3] as? String, OLTaxonomyValue.undefined)
+        XCTAssertNil(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level3] as? String)
     }
     
     func test_helpCell_eventAnalytics() throws {
@@ -180,7 +180,7 @@ extension SettingsViewControllerTests {
         XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged, event.parameters)
         XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level2] as? String, OLTaxonomyValue.settings)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level3] as? String, OLTaxonomyValue.undefined)
+        XCTAssertNil(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level3] as? String)
     }
     
     func test_contactCell_eventAnalytics() throws {
@@ -198,7 +198,7 @@ extension SettingsViewControllerTests {
         XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged, event.parameters)
         XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level2] as? String, OLTaxonomyValue.settings)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level3] as? String, OLTaxonomyValue.undefined)
+        XCTAssertNil(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level3] as? String)
     }
     
     func test_privacyNoticeCell_eventAnalytics() throws {
@@ -216,7 +216,7 @@ extension SettingsViewControllerTests {
         XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged, event.parameters)
         XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level2] as? String, OLTaxonomyValue.settings)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level3] as? String, OLTaxonomyValue.undefined)
+        XCTAssertNil(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level3] as? String)
     }
     
     func test_accessibilityCell_eventAnalytics() throws {
@@ -232,7 +232,7 @@ extension SettingsViewControllerTests {
         XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged, event.parameters)
         XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level2] as? String, OLTaxonomyValue.settings)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level3] as? String, OLTaxonomyValue.undefined)
+        XCTAssertNil(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level3] as? String)
     }
     
     func test_signOut_eventAnalytics() throws {
@@ -246,7 +246,7 @@ extension SettingsViewControllerTests {
         XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged, event.parameters)
         XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level2] as? String, OLTaxonomyValue.settings)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level3] as? String, OLTaxonomyValue.undefined)
+        XCTAssertNil(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level3] as? String)
     }
 }
 

--- a/Tests/UnitTests/Tabs/HomeCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/HomeCoordinatorTests.swift
@@ -45,7 +45,7 @@ final class HomeCoordinatorTests: XCTestCase {
         XCTAssertEqual(mockAnalyticsService.eventsLogged.count, 1)
         XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged, event.parameters)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level2] as? String, OLTaxonomyValue.home)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level3] as? String, OLTaxonomyValue.undefined)
+        XCTAssertNil(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level2] as? String)
+        XCTAssertNil(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level3] as? String)
     }
 }

--- a/Tests/UnitTests/Tabs/SettingsCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/SettingsCoordinatorTests.swift
@@ -66,7 +66,7 @@ final class SettingsCoordinatorTests: XCTestCase {
         XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged, event.parameters)
         XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level2] as? String, OLTaxonomyValue.system)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level3] as? String, OLTaxonomyValue.undefined)
+        XCTAssertNil(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level3] as? String)
     }
     
     func test_openSignOutPageWithWallet() throws {

--- a/Tests/UnitTests/Tabs/WalletCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/WalletCoordinatorTests.swift
@@ -48,7 +48,7 @@ extension WalletCoordinatorTests {
         XCTAssertEqual(mockAnalyticsService.eventsLogged.count, 1)
         XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged, event.parameters)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level2] as? String, OLTaxonomyValue.wallet)
+        XCTAssertNil(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level2] as? String)
         XCTAssertNil(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level3] as? String)
     }
 }

--- a/Tests/UnitTests/Tabs/WalletCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/WalletCoordinatorTests.swift
@@ -49,6 +49,6 @@ extension WalletCoordinatorTests {
         XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged, event.parameters)
         XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level2] as? String, OLTaxonomyValue.wallet)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level3] as? String, OLTaxonomyValue.undefined)
+        XCTAssertNil(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level3] as? String)
     }
 }


### PR DESCRIPTION
# fix: fixing taxonomy overriding

https://govukverify.atlassian.net/browse/DCMAW-13813

@dylanjames-dd we are seeing that both CRI and IDCheck level 2 and 3 taxonomies are not sending to analytics. This looks like it is due to these values being set in the HomeCoordinator, and by design these can not be overridden. I have a change in this PR similar to how we did in V1 app to keep the IDCheck analytics service separate so that we can send both the home taxonomies and not let that affect the IDCheck analytics.

Alternatively, we could tidy it up if we were able to not have to send the home taxonomies in the HomeCoordinator, but keen to see what you think and if we should loop in analytics team for that decision if we wanted to.

<img width="1216" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/aba19960-09b9-4ce2-8b09-2ada2492389d" />
<img width="1217" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/97a6594d-4258-4c72-bab4-aa10744fc664" />
<img width="1213" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/b2ff5a73-1465-444a-987f-d992db491241" />
<img width="1233" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/fbf2207c-4990-43fe-a797-c8888972371e" />
<img width="1226" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/672341b9-5839-4f35-85ee-a38211a4084b" />
<img width="1203" alt="want to continue with your passport" src="https://github.com/user-attachments/assets/e7a3199c-2a68-444e-90a0-622f2608d9b6" />
<img width="1208" alt="Pasted Graphic 6" src="https://github.com/user-attachments/assets/1cf4df73-130a-4403-8b0d-0381ba7b2ecc" />
<img width="1265" alt="Pasted Graphic 7" src="https://github.com/user-attachments/assets/2209a517-cc2f-401e-bb9a-605051583b36" />
<img width="1213" alt="Pasted Graphic 8" src="https://github.com/user-attachments/assets/5dcfae73-1bc5-4c88-8a12-f09d11700b2b" />
<img width="1202" alt="Pasted Graphic 9" src="https://github.com/user-attachments/assets/ab03ee4d-b634-4c3c-8ecd-7baee1ab15de" />


# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
