### PR TITLE
feat: update app analytics

### DIFF
--- a/Sources/Screens/Errors/UpdateAppViewModel.swift
+++ b/Sources/Screens/Errors/UpdateAppViewModel.swift
@@ -26,10 +26,15 @@ struct UpdateAppViewModel: GDSCentreAlignedViewModel,
             OLTaxonomyKey.level2: OLTaxonomyValue.system,
             OLTaxonomyKey.level3: OLTaxonomyValue.undefined
         ])
+        let event = LinkEvent(textKey: "app_updateAppButton",
+                              variableKeys: "app_nameString",
+                              linkDomain: AppEnvironment.appStoreURL.absoluteString,
+                              external: .true)
         self.primaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "app_updateAppButton",
                                                                "app_nameString",
-                                                               accessibilityHint: GDSLocalisedString(stringKey: "app_externalApp"),
-                                                               analyticsService: analyticsService) {
+                                                               analyticsService: analyticsService,
+                                                               analyticsEvent: event,
+                                                               accessibilityHint: GDSLocalisedString(stringKey: "app_externalApp")) {
             urlOpener.open(url: AppEnvironment.appStoreURL)
         }
     }

--- a/Sources/Screens/Errors/UpdateAppViewModel.swift
+++ b/Sources/Screens/Errors/UpdateAppViewModel.swift
@@ -28,14 +28,14 @@ struct UpdateAppViewModel: GDSCentreAlignedViewModel,
         ])
         let event = LinkEvent(textKey: "app_updateAppButton",
                               variableKeys: "app_nameString",
-                              linkDomain: AppEnvironment.appStoreURL.absoluteString,
+                              linkDomain: AppEnvironment.appStore.absoluteString,
                               external: .true)
         self.primaryButtonViewModel = AnalyticsButtonViewModel(titleKey: "app_updateAppButton",
                                                                "app_nameString",
                                                                analyticsService: analyticsService,
                                                                analyticsEvent: event,
                                                                accessibilityHint: GDSLocalisedString(stringKey: "app_externalApp")) {
-            urlOpener.open(url: AppEnvironment.appStoreURL)
+            urlOpener.open(url: AppEnvironment.appStore)
         }
     }
     

--- a/Tests/UnitTests/Screens/Errors/UpdateAppViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Errors/UpdateAppViewModelTests.swift
@@ -55,6 +55,5 @@ extension UpdateAppViewModelTests {
         XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged, event.parameters)
         XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level2] as? String, OLTaxonomyValue.system)
-        XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level3] as? String, OLTaxonomyValue.undefined)
     }
 }

--- a/Tests/UnitTests/Screens/Errors/UpdateAppViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Errors/UpdateAppViewModelTests.swift
@@ -47,5 +47,14 @@ extension UpdateAppViewModelTests {
         XCTAssertFalse(urlOpener.didOpenURL)
         sut.primaryButtonViewModel.action()
         XCTAssertTrue(urlOpener.didOpenURL)
+        
+        let event = LinkEvent(textKey: "app_updateAppButton",
+                              variableKeys: "app_nameString",
+                              linkDomain: AppEnvironment.appStoreURL.absoluteString,
+                              external: .true)
+        XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
+        XCTAssertEqual(mockAnalyticsService.eventsParamsLogged, event.parameters)
+        XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level2] as? String, OLTaxonomyValue.system)
+        XCTAssertEqual(mockAnalyticsService.additionalParameters[OLTaxonomyKey.level3] as? String, OLTaxonomyValue.undefined)
     }
 }

--- a/Tests/UnitTests/Screens/Errors/UpdateAppViewModelTests.swift
+++ b/Tests/UnitTests/Screens/Errors/UpdateAppViewModelTests.swift
@@ -50,7 +50,7 @@ extension UpdateAppViewModelTests {
         
         let event = LinkEvent(textKey: "app_updateAppButton",
                               variableKeys: "app_nameString",
-                              linkDomain: AppEnvironment.appStoreURL.absoluteString,
+                              linkDomain: AppEnvironment.appStore.absoluteString,
                               external: .true)
         XCTAssertEqual(mockAnalyticsService.eventsLogged, [event.name.name])
         XCTAssertEqual(mockAnalyticsService.eventsParamsLogged, event.parameters)


### PR DESCRIPTION
# DCMAW-9612: Implement GA4 schema on the 'You need to update your app' page

This PR aims to add the `trackEventLink` analytics to the Update App button. All other analytics events for this screen have already been implemented.

This PR also updates the URL used for the primary button. It now opens the actual app listing within the app store instead of the app store homepage.

### QA Evidence

<img width="736" alt="Screenshot 2025-06-11 at 12 24 45" src="https://github.com/user-attachments/assets/b7c03da5-37d7-41b9-b3d3-a48a46902ff5" />


https://github.com/user-attachments/assets/fe2c905c-9bd1-4e5e-9b24-a7e1eeeb17c7


# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
~- [ ] Created a `draft` pull request if it is not yet ready for review~

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
~- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.~
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~ 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
