### PR TITLE
fix: select right version

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -135,7 +135,7 @@ platform :ios do
         readonly: true
       )
 
-      version = get_version_number(xcodeproj: project_name)
+      version = get_version_number(xcodeproj: project_name, configuration: options[:configuration])
 
       build_number = latest_testflight_build_number(
         app_identifier: app_identifier,


### PR DESCRIPTION
# update fastlane 

Now that there is different info.plist files for each environment get_version_number on fastlane requires input for an environment configuration. This change makes sure that the configuration is passed automatically without manual input. 

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
