### PR TITLE
feat: no local auth set-up - error screen

### DIFF
--- a/LocalAuthenticationWrapper/Sources/LocalAuthenticationWrapper/LocalAuthenticationWrapper.swift
+++ b/LocalAuthenticationWrapper/Sources/LocalAuthenticationWrapper/LocalAuthenticationWrapper.swift
@@ -31,6 +31,12 @@ public struct LocalAuthenticationWrapper: LocalAuthManaging {
                 return try canUseAnyLocalAuth ? .passcode : .none
             }
             
+            return try deviceBiometricsType
+        }
+    }
+    
+    public var deviceBiometricsType: LocalAuthType {
+        get throws {
             switch localAuthContext.biometryType {
             case .touchID:
                 return .touchID
@@ -105,13 +111,10 @@ public struct LocalAuthenticationWrapper: LocalAuthManaging {
         return localAuthPromptStore.previouslyPasscodePrompted
     }
     
-    public func recordPasscode() {
-        localAuthPromptStore.recordPasscodePrompt()
-    }
-    
     public func promptForPermission() async throws -> Bool {
-        guard try (type == .faceID || type == .touchID) &&
-                !localAuthPromptStore.previouslyPrompted else {
+        guard try type != .none  &&
+                !localAuthPromptStore.previouslyPrompted &&
+                !localAuthPromptStore.previouslyPasscodePrompted else {
             return true
         }
         // Enrolment is required if biometry type is FaceID

--- a/LocalAuthenticationWrapper/Sources/LocalAuthenticationWrapper/LocalAuthenticationWrapper.swift
+++ b/LocalAuthenticationWrapper/Sources/LocalAuthenticationWrapper/LocalAuthenticationWrapper.swift
@@ -103,18 +103,13 @@ public struct LocalAuthenticationWrapper: LocalAuthManaging {
         return supportedLevel >= requiredLevel.tier
     }
     
-    public func isEnrolled() -> Bool {
+    public func hasBeenPrompted() -> Bool {
         return localAuthPromptStore.previouslyPrompted
-    }
-    
-    public func isEnrolledPasscode() -> Bool {
-        return localAuthPromptStore.previouslyPasscodePrompted
     }
     
     public func promptForPermission() async throws -> Bool {
         guard try type != .none  &&
-                !localAuthPromptStore.previouslyPrompted &&
-                !localAuthPromptStore.previouslyPasscodePrompted else {
+                !localAuthPromptStore.previouslyPrompted else {
             return true
         }
         // Enrolment is required if biometry type is FaceID
@@ -127,12 +122,7 @@ public struct LocalAuthenticationWrapper: LocalAuthManaging {
                     localizedReason: localAuthStrings.subtitle
                 )
             
-            let currentType = try type
-            if currentType == .passcode {
-                localAuthPromptStore.recordPasscodePrompt()
-            } else {
-                localAuthPromptStore.recordPrompt()
-            }
+            localAuthPromptStore.recordPrompt()
             return localAuthResult
         } catch let error as NSError {
             switch error.code {

--- a/LocalAuthenticationWrapper/Sources/LocalAuthenticationWrapper/Protocols/LocalAuthManaging.swift
+++ b/LocalAuthenticationWrapper/Sources/LocalAuthenticationWrapper/Protocols/LocalAuthManaging.swift
@@ -5,6 +5,5 @@ public protocol LocalAuthManaging {
     
     func checkLevelSupported(_ requiredLevel: RequiredLocalAuthLevel) throws -> Bool
     func promptForPermission() async throws -> Bool
-    func isEnrolled() -> Bool
-    func isEnrolledPasscode() -> Bool
+    func hasBeenPrompted() -> Bool
 }

--- a/LocalAuthenticationWrapper/Sources/LocalAuthenticationWrapper/Protocols/LocalAuthManaging.swift
+++ b/LocalAuthenticationWrapper/Sources/LocalAuthenticationWrapper/Protocols/LocalAuthManaging.swift
@@ -1,10 +1,10 @@
 public protocol LocalAuthManaging {
     var type: LocalAuthType { get throws }
+    var deviceBiometricsType: LocalAuthType { get throws }
     var canUseAnyLocalAuth: Bool { get throws }
     
     func checkLevelSupported(_ requiredLevel: RequiredLocalAuthLevel) throws -> Bool
     func promptForPermission() async throws -> Bool
     func isEnrolled() -> Bool
     func isEnrolledPasscode() -> Bool
-    func recordPasscode()
 }

--- a/LocalAuthenticationWrapper/Sources/LocalAuthenticationWrapper/Protocols/LocalAuthPromptRecorder.swift
+++ b/LocalAuthenticationWrapper/Sources/LocalAuthenticationWrapper/Protocols/LocalAuthPromptRecorder.swift
@@ -2,9 +2,7 @@ import Foundation
 
 protocol LocalAuthPromptRecorder {
     var previouslyPrompted: Bool { get }
-    var previouslyPasscodePrompted: Bool { get }
     func recordPrompt()
-    func recordPasscodePrompt()
 }
 
 extension UserDefaults: LocalAuthPromptRecorder {
@@ -14,13 +12,5 @@ extension UserDefaults: LocalAuthPromptRecorder {
     
     func recordPrompt() {
         set(true, forKey: "localAuthPrompted")
-    }
-    
-    var previouslyPasscodePrompted: Bool {
-        bool(forKey: "localAuthPasscodePrompted")
-    }
-    
-    func recordPasscodePrompt() {
-        set(true, forKey: "localAuthPasscodePrompted")
     }
 }

--- a/LocalAuthenticationWrapper/Tests/LocalAuthenticationWrapperTests/LocalAuthPromptRecorderTests.swift
+++ b/LocalAuthenticationWrapper/Tests/LocalAuthenticationWrapperTests/LocalAuthPromptRecorderTests.swift
@@ -25,15 +25,4 @@ class LocalAuthPromptRecorderTests {
         sut.recordPrompt()
         #expect(sut.previouslyPrompted)
     }
-    
-    @Test("Check previously prompted is not true by default")
-    func notPreviouslyPromptedPasscode() {
-        #expect(!sut.previouslyPasscodePrompted)
-    }
-    
-    @Test("Check previously prompted is true if set")
-    func previouslyPromptedPasscode() {
-        sut.recordPasscodePrompt()
-        #expect(sut.previouslyPasscodePrompted)
-    }
 }

--- a/LocalAuthenticationWrapper/Tests/LocalAuthenticationWrapperTests/Mocks/MockLocalAuthPromptRecorder.swift
+++ b/LocalAuthenticationWrapper/Tests/LocalAuthenticationWrapperTests/Mocks/MockLocalAuthPromptRecorder.swift
@@ -2,13 +2,8 @@
 
 final class MockLocalAuthPromptRecorder: LocalAuthPromptRecorder {
     var previouslyPrompted: Bool = false
-    var previouslyPasscodePrompted: Bool = false
     
     func recordPrompt() {
         previouslyPrompted = true
-    }
-    
-    func recordPasscodePrompt() {
-        previouslyPasscodePrompted = true
     }
 }

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-id-check-ios-sdk.git",
       "state" : {
-        "revision" : "e836678500f233aa9bd4e7a8f4a0201cefc56ea1",
-        "version" : "8.1.1"
+        "revision" : "e7c7a8a1a680dfc9ba7740b229e3b35238dec155",
+        "version" : "8.3.4"
       }
     },
     {
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-authentication.git",
       "state" : {
-        "revision" : "9c058d369d98023d7dd191b53c6576aa1e4cdf37",
-        "version" : "2.2.1"
+        "revision" : "deb92df19f1ac9640a03ef4bf0a9121847be357e",
+        "version" : "2.2.2"
       }
     },
     {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-common.git",
       "state" : {
-        "revision" : "f622e95c0a11f66be8f314e4c60b1a41e2756d05",
-        "version" : "2.13.3"
+        "revision" : "acff9adcfe52cee82f991585878cc77d9e7b097c",
+        "version" : "2.14.1"
       }
     },
     {
@@ -203,8 +203,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-wallet-ios.git",
       "state" : {
-        "revision" : "d4788883d8f27781c8f91e4dc323f939bc7f819d",
-        "version" : "13.2.0"
+        "revision" : "86bdb0170292e7414c23aad63d9909063e501bf4",
+        "version" : "13.3.2"
       }
     },
     {

--- a/Sources/Screens/Errors/LocalAuthErrorScreens/LocalAuthSettingsErrorViewModel.swift
+++ b/Sources/Screens/Errors/LocalAuthErrorScreens/LocalAuthSettingsErrorViewModel.swift
@@ -10,14 +10,17 @@ struct LocalAuthSettingsErrorViewModel: GDSErrorViewModelV3, BaseViewModel {
     let buttonViewModels: [ButtonViewModel]
     let image: ErrorScreenImage = .error
     let localAuthType: LocalAuthType
+    let completion: (() -> Void)?
     
     let rightBarButtonTitle: GDSLocalisedString? = "app_cancelButton"
     let backButtonIsHidden: Bool = true
 
     init(urlOpener: URLOpener = UIApplication.shared,
          analyticsService: OneLoginAnalyticsService,
-         localAuthType: LocalAuthType) {
+         localAuthType: LocalAuthType,
+         completion: (() -> Void)? = nil) {
         self.localAuthType = localAuthType
+        self.completion = completion
         
         self.analyticsService = analyticsService.addingAdditionalParameters([
             OLTaxonomyKey.level2: OLTaxonomyValue.onboarding
@@ -30,6 +33,7 @@ struct LocalAuthSettingsErrorViewModel: GDSErrorViewModelV3, BaseViewModel {
                                              return
                                          }
                                          urlOpener.open(url: url)
+                                         completion?()
                                      }
         ]
         
@@ -59,6 +63,7 @@ struct LocalAuthSettingsErrorViewModel: GDSErrorViewModelV3, BaseViewModel {
     }
     
     func didDismiss() {
+        completion?()
         let event = IconEvent(textKey: "back - system")
         analyticsService.logEvent(event)
     }

--- a/Sources/Screens/Errors/LocalAuthErrorScreens/LocalAuthSettingsErrorViewModel.swift
+++ b/Sources/Screens/Errors/LocalAuthErrorScreens/LocalAuthSettingsErrorViewModel.swift
@@ -29,7 +29,7 @@ struct LocalAuthSettingsErrorViewModel: GDSErrorViewModelV3, BaseViewModel {
         self.buttonViewModels = [
             AnalyticsButtonViewModel(titleKey: "app_localAuthManagerErrorGoToSettingsButton",
                                      analyticsService: analyticsService) {
-                                         guard let url = URL(string: UIApplication.openSettingsURLString) else {
+                                         guard let url = URL(string: "App-Prefs:PASSCODE") ?? URL(string: UIApplication.openSettingsURLString) else {
                                              return
                                          }
                                          urlOpener.open(url: url)

--- a/Sources/Screens/Errors/LocalAuthErrorScreens/LocalAuthSettingsErrorViewModel.swift
+++ b/Sources/Screens/Errors/LocalAuthErrorScreens/LocalAuthSettingsErrorViewModel.swift
@@ -29,7 +29,7 @@ struct LocalAuthSettingsErrorViewModel: GDSErrorViewModelV3, BaseViewModel {
         self.buttonViewModels = [
             AnalyticsButtonViewModel(titleKey: "app_localAuthManagerErrorGoToSettingsButton",
                                      analyticsService: analyticsService) {
-                                         guard let url = URL(string: "App-Prefs:PASSCODE") ?? URL(string: UIApplication.openSettingsURLString) else {
+                                         guard let url = URL(string: "App-Prefs:PASSCODE") else {
                                              return
                                          }
                                          urlOpener.open(url: url)

--- a/Sources/Tabs/HomeCoordinator.swift
+++ b/Sources/Tabs/HomeCoordinator.swift
@@ -41,5 +41,7 @@ final class HomeCoordinator: NSObject,
     func didBecomeSelected() {
         let event = IconEvent(textKey: "app_homeTitle")
         analyticsService.logEvent(event)
+        let tabCoordinator = (parentCoordinator as? TabManagerCoordinator)
+        tabCoordinator?.updateSelectedTabIndex()
     }
 }

--- a/Sources/Tabs/SettingsCoordinator.swift
+++ b/Sources/Tabs/SettingsCoordinator.swift
@@ -53,6 +53,8 @@ final class SettingsCoordinator: NSObject,
     func didBecomeSelected() {
         let event = IconEvent(textKey: "app_settingsTitle")
         analyticsService.logEvent(event)
+        let tabCoordinator = (parentCoordinator as? TabManagerCoordinator)
+        tabCoordinator?.updateSelectedTabIndex()
     }
     
     func openSignOutPage() {

--- a/Sources/Tabs/TabManagerCoordinator.swift
+++ b/Sources/Tabs/TabManagerCoordinator.swift
@@ -27,6 +27,8 @@ final class TabManagerCoordinator: NSObject,
     
     lazy var delegate: TabCoordinatorDelegate? = TabCoordinatorDelegate(coordinator: self)
     
+    var selectedTabIndex: Int?
+    
     private var walletCoordinator: WalletCoordinator? {
         childCoordinators.firstInstanceOf(WalletCoordinator.self)
     }
@@ -91,6 +93,14 @@ final class TabManagerCoordinator: NSObject,
                                      networkClient: networkClient,
                                      urlOpener: UIApplication.shared)
         addTab(pc)
+    }
+    
+    func updateSelectedTabIndex() {
+        selectedTabIndex = root.selectedIndex
+    }
+    
+    func isTabAlreadySelected() -> Bool {
+        return selectedTabIndex == root.selectedIndex
     }
 }
 

--- a/Sources/Tabs/WalletCoordinator.swift
+++ b/Sources/Tabs/WalletCoordinator.swift
@@ -54,9 +54,14 @@ final class WalletCoordinator: NSObject,
     }
     
     func didBecomeSelected() {
-        WalletSDK.walletTabSelected()
+        let tabCoordinator = parentCoordinator as? TabManagerCoordinator
+        let isWalletAlreadySelected = tabCoordinator?.isTabAlreadySelected()
+       
+        WalletSDK.walletTabSelected(isTabAlreadySelected: isWalletAlreadySelected ?? false)
+        
         let event = IconEvent(textKey: "app_walletTitle")
         analyticsService.logEvent(event)
+        tabCoordinator?.updateSelectedTabIndex()
     }
     
     func handleUniversalLink(_ url: URL) {

--- a/Sources/Utilities/LocalAuthServiceWallet.swift
+++ b/Sources/Utilities/LocalAuthServiceWallet.swift
@@ -10,7 +10,7 @@ final class LocalAuthServiceWallet: WalletLocalAuthService {
     private var analyticsService: OneLoginAnalyticsService
     private let sessionManager: SessionManager
     private let walletCoodinator: WalletCoordinator
-    var biometricsNavigationController = UINavigationController()
+    private(set) var biometricsNavigationController = UINavigationController()
     
     private var localAuthManager: EnrolmentManager
     

--- a/Sources/Utilities/LocalAuthServiceWallet.swift
+++ b/Sources/Utilities/LocalAuthServiceWallet.swift
@@ -62,12 +62,22 @@ final class LocalAuthServiceWallet: WalletLocalAuthService {
                 walletCoodinator.root.present(biometricsNavigationController ?? UINavigationController(),
                                               animated: true)
             case .passcode:
-                localAuthManager.saveSession(isWalletEnrolment: true) { [unowned self] in
-                    localAuthentication.recordPasscode()
+                localAuthManager.saveSession(isWalletEnrolment: true) {
                     completion()
                 }
             case .none:
-                completion()
+                var settingsErrorScreen: GDSErrorScreen?
+                let viewModel = LocalAuthSettingsErrorViewModel(analyticsService: analyticsService, localAuthType: try localAuthentication.deviceBiometricsType) { 
+                    settingsErrorScreen?.dismiss(animated: true)
+                    completion()
+                }
+                settingsErrorScreen = GDSErrorScreen(viewModel: viewModel)
+                
+                biometricsNavigationController = UINavigationController(rootViewController: settingsErrorScreen ?? GDSErrorScreen(viewModel: viewModel))
+                biometricsNavigationController?.modalPresentationStyle = .pageSheet
+                biometricsNavigationController?.presentationController?.delegate = walletCoodinator
+                walletCoodinator.root.present(biometricsNavigationController ?? UINavigationController(),
+                                              animated: true)
             }
         } catch {
             preconditionFailure()

--- a/Sources/Utilities/LocalAuthServiceWallet.swift
+++ b/Sources/Utilities/LocalAuthServiceWallet.swift
@@ -89,11 +89,16 @@ final class LocalAuthServiceWallet: WalletLocalAuthService {
             return false
         }
         
-        switch minimumAuth {
-        case .biometrics:
-            return localAuthentication.isEnrolled()
-        default:
-            return localAuthentication.isEnrolled() || localAuthentication.isEnrolledPasscode()
+        do {
+            let type = try localAuthentication.type
+            switch minimumAuth {
+            case .biometrics:
+                return (type == .touchID || type == .faceID) && localAuthentication.hasBeenPrompted()
+            default:
+                return (type == .touchID || type == .faceID || type == .passcode) && localAuthentication.hasBeenPrompted()
+            }
+        } catch {
+            preconditionFailure()
         }
     }
     

--- a/Sources/Utilities/LocalAuthServiceWallet.swift
+++ b/Sources/Utilities/LocalAuthServiceWallet.swift
@@ -67,7 +67,7 @@ final class LocalAuthServiceWallet: WalletLocalAuthService {
                 }
             case .none:
                 var settingsErrorScreen: GDSErrorScreen?
-                let viewModel = LocalAuthSettingsErrorViewModel(analyticsService: analyticsService, localAuthType: try localAuthentication.deviceBiometricsType) { 
+                let viewModel = LocalAuthSettingsErrorViewModel(analyticsService: analyticsService, localAuthType: try localAuthentication.deviceBiometricsType) {
                     settingsErrorScreen?.dismiss(animated: true)
                     completion()
                 }

--- a/Tests/UnitTests/Mocks/Sessions+Services/Analytics/LocalAuth/MockLocalAuthManager.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Analytics/LocalAuth/MockLocalAuthManager.swift
@@ -11,8 +11,7 @@ final class MockLocalAuthManager: LocalAuthManaging, LocalAuthenticationContextS
     var localAuthIsEnabledOnTheDevice = false
     var errorFromEnrolLocalAuth: Error?
     var userDidConsentToFaceID = true
-    var isPasscodeEnrolled = false
-    var isBiometricsEnrolled = false
+    var userPromptedForLocalAuth = false
     
     var didCallEnrolFaceIDIfAvailable = false
     
@@ -24,6 +23,10 @@ final class MockLocalAuthManager: LocalAuthManaging, LocalAuthenticationContextS
         return true
     }
     
+    func hasBeenPrompted() -> Bool {
+        return userPromptedForLocalAuth
+    }
+    
     func promptForPermission() async throws -> Bool {
         defer {
             didCallEnrolFaceIDIfAvailable = true
@@ -33,13 +36,5 @@ final class MockLocalAuthManager: LocalAuthManaging, LocalAuthenticationContextS
             throw errorFromEnrolLocalAuth
         }
         return userDidConsentToFaceID
-    }
-    
-    func isEnrolled() -> Bool {
-        return isBiometricsEnrolled
-    }
-    
-    func isEnrolledPasscode() -> Bool {
-        return isPasscodeEnrolled
     }
 }

--- a/Tests/UnitTests/Mocks/Sessions+Services/Analytics/LocalAuth/MockLocalAuthManager.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Analytics/LocalAuth/MockLocalAuthManager.swift
@@ -4,6 +4,7 @@ import SecureStore
 
 final class MockLocalAuthManager: LocalAuthManaging, LocalAuthenticationContextStrings {
     var type: LocalAuthType = .touchID
+    var deviceBiometricsType: LocalAuthType = .touchID
     
     var oneLoginStrings: LocalAuthenticationLocalizedStrings?
     
@@ -40,9 +41,5 @@ final class MockLocalAuthManager: LocalAuthManaging, LocalAuthenticationContextS
     
     func isEnrolledPasscode() -> Bool {
         return isPasscodeEnrolled
-    }
-    
-    func recordPasscode() {
-        isPasscodeEnrolled = true
     }
 }

--- a/Tests/UnitTests/Tabs/TabManagerCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/TabManagerCoordinatorTests.swift
@@ -146,7 +146,7 @@ extension TabManagerCoordinatorTests {
         )
         sut.start()
         
-        //start with home selected
+        // start with home tab selected
         sut.root.selectedIndex = 0
         sut.updateSelectedTabIndex()
         XCTAssertEqual(sut.selectedTabIndex, 0)

--- a/Tests/UnitTests/Tabs/TabManagerCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/TabManagerCoordinatorTests.swift
@@ -136,4 +136,23 @@ extension TabManagerCoordinatorTests {
         XCTAssertTrue(sut.childCoordinators.contains(where: { $0 is WalletCoordinator }))
         XCTAssertTrue(sut.root.selectedIndex == 1)
     }
+    
+    @MainActor
+    func test_tabSwitching() throws {
+        // GIVEN the wallet feature flag is on
+        AppEnvironment.updateFlags(
+            releaseFlags: [FeatureFlagsName.enableWalletVisibleToAll.rawValue: true],
+            featureFlags: [:]
+        )
+        sut.start()
+        
+        //start with home selected
+        sut.root.selectedIndex = 0
+        sut.updateSelectedTabIndex()
+        XCTAssertEqual(sut.selectedTabIndex, 0)
+        XCTAssertTrue(sut.isTabAlreadySelected())
+        
+        sut.root.selectedIndex = 1
+        XCTAssertFalse(sut.isTabAlreadySelected())
+    }
 }

--- a/Tests/UnitTests/Utilities/LocalAuthServiceWalletTests.swift
+++ b/Tests/UnitTests/Utilities/LocalAuthServiceWalletTests.swift
@@ -111,21 +111,29 @@ extension LocalAuthServiceWalletTests {
                 self.isEnrolled = true
             }
         )
-
+        
+        let vc = try XCTUnwrap(sut.biometricsNavigationController?.topViewController as? GDSErrorScreen)
+        
+        XCTAssertTrue(vc.viewModel is LocalAuthSettingsErrorViewModel)
+        
+        let secondErrorScreen = try XCTUnwrap(vc.viewModel)
+        
+        secondErrorScreen.buttonViewModels[0].action()
+        
         XCTAssertTrue(isEnrolled)
     }
     
     func test_isEnrolled() {
         mockLocalAuthManager.isBiometricsEnrolled = false
         XCTAssertFalse(mockLocalAuthManager.isEnrolledPasscode())
-        mockLocalAuthManager.recordPasscode()
+        mockLocalAuthManager.isPasscodeEnrolled = true
         
         XCTAssertFalse(sut.isEnrolled(LocalAuth.biometrics))
         XCTAssertTrue(sut.isEnrolled(LocalAuth.passcode))
         XCTAssertTrue(sut.isEnrolled(LocalAuth.none))
     }
     
-    func test_primaryButtonAction() throws {
+    func test_primaryButtonActionWithBiometrics() throws {
         mockLocalAuthManager.type = .faceID
         
         XCTAssertFalse(isEnrolled)
@@ -144,7 +152,7 @@ extension LocalAuthServiceWalletTests {
         XCTAssertTrue(isEnrolled)
     }
     
-    func test_secondaryButtonAction() throws {
+    func test_secondaryButtonActionWithBiometrics() throws {
         mockLocalAuthManager.type = .faceID
         
         XCTAssertFalse(isEnrolled)

--- a/Tests/UnitTests/Utilities/LocalAuthServiceWalletTests.swift
+++ b/Tests/UnitTests/Utilities/LocalAuthServiceWalletTests.swift
@@ -82,7 +82,9 @@ extension LocalAuthServiceWalletTests {
             completion: {}
         )
         
-        XCTAssertNotNil(sut.biometricsEnrolmentScreen)
+        let vc = try XCTUnwrap(sut.biometricsNavigationController.topViewController as? GDSInformationViewController)
+        
+        XCTAssertTrue(vc.viewModel is BiometricsEnrolmentViewModel)
     }
     
     func test_enrolLocalAuthPasscode() async throws {
@@ -112,7 +114,7 @@ extension LocalAuthServiceWalletTests {
             }
         )
         
-        let vc = try XCTUnwrap(sut.biometricsNavigationController?.topViewController as? GDSErrorScreen)
+        let vc = try XCTUnwrap(sut.biometricsNavigationController.topViewController as? GDSErrorScreen)
         
         XCTAssertTrue(vc.viewModel is LocalAuthSettingsErrorViewModel)
         
@@ -124,9 +126,10 @@ extension LocalAuthServiceWalletTests {
     }
     
     func test_isEnrolled() {
-        mockLocalAuthManager.isBiometricsEnrolled = false
-        XCTAssertFalse(mockLocalAuthManager.isEnrolledPasscode())
-        mockLocalAuthManager.isPasscodeEnrolled = true
+        mockLocalAuthManager.type = .passcode
+        mockLocalAuthManager.userPromptedForLocalAuth = false
+        XCTAssertFalse(mockLocalAuthManager.hasBeenPrompted())
+        mockLocalAuthManager.userPromptedForLocalAuth = true
         
         XCTAssertFalse(sut.isEnrolled(LocalAuth.biometrics))
         XCTAssertTrue(sut.isEnrolled(LocalAuth.passcode))
@@ -145,9 +148,11 @@ extension LocalAuthServiceWalletTests {
             }
         )
         
-        let screen = try XCTUnwrap(sut.biometricsEnrolmentScreen?.viewModel as? GDSCentreAlignedViewModelWithPrimaryButton & GDSCentreAlignedViewModelWithSecondaryButton)
+        let vc = try XCTUnwrap(sut.biometricsNavigationController.topViewController as? GDSInformationViewController)
         
-        screen.primaryButtonViewModel.action()
+        let viewModel = try XCTUnwrap(vc.viewModel as? GDSCentreAlignedViewModelWithPrimaryButton & GDSCentreAlignedViewModelWithSecondaryButton)
+        
+        viewModel.primaryButtonViewModel.action()
         
         XCTAssertTrue(isEnrolled)
     }
@@ -164,15 +169,17 @@ extension LocalAuthServiceWalletTests {
             }
         )
         
-        let screen = try XCTUnwrap(sut.biometricsEnrolmentScreen?.viewModel as? GDSCentreAlignedViewModelWithPrimaryButton & GDSCentreAlignedViewModelWithSecondaryButton)
+        let vc = try XCTUnwrap(sut.biometricsNavigationController.topViewController as? GDSInformationViewController)
         
-        screen.secondaryButtonViewModel.action()
+        let viewModel = try XCTUnwrap(vc.viewModel as? GDSCentreAlignedViewModelWithPrimaryButton & GDSCentreAlignedViewModelWithSecondaryButton)
         
-        let vc = try XCTUnwrap(sut.biometricsNavigationController?.topViewController as? GDSErrorScreen)
+        viewModel.secondaryButtonViewModel.action()
         
-        XCTAssertTrue(vc.viewModel is LocalAuthBiometricsErrorViewModel)
+        let vc2 = try XCTUnwrap(sut.biometricsNavigationController.topViewController as? GDSErrorScreen)
         
-        let secondErrorScreen = try XCTUnwrap(vc.viewModel)
+        XCTAssertTrue(vc2.viewModel is LocalAuthBiometricsErrorViewModel)
+        
+        let secondErrorScreen = try XCTUnwrap(vc2.viewModel)
         
         secondErrorScreen.buttonViewModels[0].action()
         


### PR DESCRIPTION
# DCMAW-12981 no local auth set-up - error screen

Also included:
- fixed isEnrolled implementation to return correct value
- updated settings page url to navigate user to passcode screen rather than our app settings
- tracking of selected tab so we don't re-call the tab selected methods if user presses on already selected tab
- refactoring of existing implementation to remove optionals and unnecessary variables

## No local auth - enable passcode in settings
https://github.com/user-attachments/assets/09b346bf-1fbe-4508-98fd-ccacac31781d


# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
