### PR TITLE
fix: ReadID landscape bug

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		1EB56D6D2B7CDE6D00BD548E /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 1EB56D6F2B7CDE6D00BD548E /* Localizable.strings */; };
 		1EB667A32B59910D008D8199 /* NetworkMonitoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EB667A12B596A1B008D8199 /* NetworkMonitoring.swift */; };
 		1EDA358C2B29FAAD0062FA46 /* LoginModalSecondScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EDA358B2B29FAAD0062FA46 /* LoginModalSecondScreen.swift */; };
+		1EE2B7E72E1295B400C9D267 /* CustomTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EE2B7E62E1295A700C9D267 /* CustomTabBarController.swift */; };
 		219602022A976305008F3427 /* TabManagerCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219602012A976305008F3427 /* TabManagerCoordinatorTests.swift */; };
 		21E04DFC2AE6BC5B004C6660 /* MockAnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E04DFB2AE6BC5B004C6660 /* MockAnalyticsService.swift */; };
 		21FA1C4D2AE183D20052136E /* MockLoginSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FA1C4B2AE183A50052136E /* MockLoginSession.swift */; };
@@ -94,9 +95,9 @@
 		C32436D12DCB906900CC3FCC /* PurposeTileViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C32436D02DCB906000CC3FCC /* PurposeTileViewModelTests.swift */; };
 		C34BD12A2DDF229100D379C8 /* LocalAuthBiometricsErrorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34BD1292DDF227E00D379C8 /* LocalAuthBiometricsErrorViewModelTests.swift */; };
 		C388D2612DC8E928007C9902 /* HomeView.xib in Resources */ = {isa = PBXBuildFile; fileRef = C388D2602DC8E928007C9902 /* HomeView.xib */; };
-		C3CDBC8D2DDE7648005A5C36 /* LocalAuthBiometricsErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3CDBC8C2DDE7634005A5C36 /* LocalAuthBiometricsErrorViewModel.swift */; };
 		C3A2D72F2DF1B58D00F8D617 /* SignOutSuccessfulViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A2D72E2DF1B58500F8D617 /* SignOutSuccessfulViewModel.swift */; };
 		C3A2D7312DF1B66500F8D617 /* SignOutSuccessfulViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A2D7302DF1B65A00F8D617 /* SignOutSuccessfulViewModelTests.swift */; };
+		C3CDBC8D2DDE7648005A5C36 /* LocalAuthBiometricsErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3CDBC8C2DDE7634005A5C36 /* LocalAuthBiometricsErrorViewModel.swift */; };
 		C8098B972AEFF1AB001517A0 /* LoginSessionConfiguration+OneLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8098B962AEFF1AB001517A0 /* LoginSessionConfiguration+OneLogin.swift */; };
 		C8098B992AEFF287001517A0 /* AnalyticsService+GDS.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8098B982AEFF287001517A0 /* AnalyticsService+GDS.swift */; };
 		C80B871A2B029E230087C6D5 /* LoginUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80B87192B029E230087C6D5 /* LoginUITests.swift */; };
@@ -307,6 +308,7 @@
 		1EB56D702B7CDE6F00BD548E /* cy-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "cy-GB"; path = "cy-GB.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		1EB667A12B596A1B008D8199 /* NetworkMonitoring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitoring.swift; sourceTree = "<group>"; };
 		1EDA358B2B29FAAD0062FA46 /* LoginModalSecondScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginModalSecondScreen.swift; sourceTree = "<group>"; };
+		1EE2B7E62E1295A700C9D267 /* CustomTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTabBarController.swift; sourceTree = "<group>"; };
 		219601E72A976302008F3427 /* OneLogin.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OneLogin.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		219601FD2A976305008F3427 /* OneLoginUnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OneLoginUnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		219602012A976305008F3427 /* TabManagerCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -385,16 +387,16 @@
 		ABFE5EF62DBA7BE50093E86E /* LocalAuthErrorListViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAuthErrorListViewTests.swift; sourceTree = "<group>"; };
 		C32436CE2DCB6E6500CC3FCC /* PurposeTileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurposeTileViewModel.swift; sourceTree = "<group>"; };
 		C32436D02DCB906000CC3FCC /* PurposeTileViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurposeTileViewModelTests.swift; sourceTree = "<group>"; };
-		C34BD1292DDF227E00D379C8 /* LocalAuthBiometricsErrorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAuthBiometricsErrorViewModelTests.swift; sourceTree = "<group>"; };
 		C3381D2D2DFAE1240007B594 /* OneLoginRelease-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "OneLoginRelease-Info.plist"; sourceTree = "<group>"; };
 		C3381D2E2DFAE1380007B594 /* OneLoginBuild-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "OneLoginBuild-Info.plist"; sourceTree = "<group>"; };
 		C3381D2F2DFAE1450007B594 /* OneLoginDebug-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "OneLoginDebug-Info.plist"; sourceTree = "<group>"; };
 		C3381D302DFAE14E0007B594 /* OneLoginStaging-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "OneLoginStaging-Info.plist"; sourceTree = "<group>"; };
 		C3381D312DFAE1580007B594 /* OneLoginIntegration-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "OneLoginIntegration-Info.plist"; sourceTree = "<group>"; };
+		C34BD1292DDF227E00D379C8 /* LocalAuthBiometricsErrorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAuthBiometricsErrorViewModelTests.swift; sourceTree = "<group>"; };
 		C388D2602DC8E928007C9902 /* HomeView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = HomeView.xib; sourceTree = "<group>"; };
-		C3CDBC8C2DDE7634005A5C36 /* LocalAuthBiometricsErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAuthBiometricsErrorViewModel.swift; sourceTree = "<group>"; };
 		C3A2D72E2DF1B58500F8D617 /* SignOutSuccessfulViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignOutSuccessfulViewModel.swift; sourceTree = "<group>"; };
 		C3A2D7302DF1B65A00F8D617 /* SignOutSuccessfulViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignOutSuccessfulViewModelTests.swift; sourceTree = "<group>"; };
+		C3CDBC8C2DDE7634005A5C36 /* LocalAuthBiometricsErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAuthBiometricsErrorViewModel.swift; sourceTree = "<group>"; };
 		C8098B962AEFF1AB001517A0 /* LoginSessionConfiguration+OneLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoginSessionConfiguration+OneLogin.swift"; sourceTree = "<group>"; };
 		C8098B982AEFF287001517A0 /* AnalyticsService+GDS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnalyticsService+GDS.swift"; sourceTree = "<group>"; };
 		C80B87192B029E230087C6D5 /* LoginUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginUITests.swift; sourceTree = "<group>"; };
@@ -863,6 +865,7 @@
 		7CD66F7C2C90708F008513F4 /* Qualification */ = {
 			isa = PBXGroup;
 			children = (
+				1EE2B7E62E1295A700C9D267 /* CustomTabBarController.swift */,
 				C8DC472A2CF01B660022A24A /* AppAttestation */,
 				7CD66F7D2C9070A6008513F4 /* State */,
 				C823CA0F2C85D97D000BDD5D /* QualifyingCoordinator.swift */,
@@ -2170,6 +2173,7 @@
 				AB24C1132DB94A5F0080141C /* LocalAuthSettingsErrorViewModel.swift in Sources */,
 				C8B825C32B98C34A00336146 /* LoginCoordinator.swift in Sources */,
 				C8BEC2942BFFA8C800C9775A /* LoginLoadingViewModel.swift in Sources */,
+				1EE2B7E72E1295B400C9D267 /* CustomTabBarController.swift in Sources */,
 				C8098B972AEFF1AB001517A0 /* LoginSessionConfiguration+OneLogin.swift in Sources */,
 				D0BE24472BEBD2E400759529 /* MockJWKSResponse.swift in Sources */,
 				41C5E32F2B45A36E00212A12 /* NetworkConnectionErrorViewModel.swift in Sources */,
@@ -2250,7 +2254,7 @@
 				D08B0B5C2BD8046200769CEA /* HomeCoordinatorTests.swift in Sources */,
 				413C58762BF261D300171C06 /* HomeViewControllerTests.swift in Sources */,
 				D0BE24452BEBCB5000759529 /* JWTVerifierTests.swift in Sources */,
-                C34BD12A2DDF229100D379C8 /* LocalAuthBiometricsErrorViewModelTests.swift in Sources */,
+				C34BD12A2DDF229100D379C8 /* LocalAuthBiometricsErrorViewModelTests.swift in Sources */,
 				ABFE5EF72DBA7BEC0093E86E /* LocalAuthErrorListViewTests.swift in Sources */,
 				C8486FE72C60E66400DE514C /* LocalAuthServiceWalletTests.swift in Sources */,
 				ABFE5EF52DBA66500093E86E /* LocalAuthSettingsErrorViewModelTests.swift in Sources */,
@@ -3779,8 +3783,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/govuk-one-login/mobile-id-check-ios-sdk.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 8.1.1;
+				branch = "fix/dcmaw-13381-readid-landscape";
+				kind = branch;
 			};
 		};
 		AB7B56222D6CD9A100193241 /* XCRemoteSwiftPackageReference "mobile-wallet-ios" */ = {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-id-check-ios-sdk.git",
       "state" : {
-        "revision" : "e7c7a8a1a680dfc9ba7740b229e3b35238dec155",
-        "version" : "8.3.4"
+        "branch" : "fix/dcmaw-13381-readid-landscape",
+        "revision" : "e9ab51fc86b76a94666671b4b5a6bcfc0b1c8505"
       }
     },
     {

--- a/Sources/Qualification/CustomTabBarController.swift
+++ b/Sources/Qualification/CustomTabBarController.swift
@@ -1,0 +1,58 @@
+import CRIOrchestrator
+import UIKit
+
+// This code resolves the IDCheck landscape bug, where interface rotation preferences are overridden by UITabBarController.
+// CustomTabBarController ensures the correct navigation controller handles rotation.
+class CustomTabBarController: UITabBarController {
+    override open var shouldAutorotate: Bool {
+        get {
+            if let vc = self.selectedViewController?.presentedViewController, vc is IDCheckNavigationController {
+                return vc.shouldAutorotate
+            } else {
+                return super.shouldAutorotate
+            }
+        }
+        set {
+            // Empty implementation
+        }
+    }
+    
+    override open var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
+        get {
+            if let vc = self.selectedViewController?.presentedViewController, vc is IDCheckNavigationController {
+                return vc.preferredInterfaceOrientationForPresentation
+            } else {
+                return super.preferredInterfaceOrientationForPresentation
+            }
+        }
+        set {
+            // Empty implementation
+        }
+    }
+    
+    override open var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        get {
+            if let vc = self.selectedViewController?.presentedViewController, vc is IDCheckNavigationController {
+                return vc.supportedInterfaceOrientations
+            } else {
+                return super.supportedInterfaceOrientations
+            }
+        }
+        set {
+            // Empty implementation
+        }
+    }
+    
+    override open var preferredStatusBarStyle: UIStatusBarStyle {
+        get {
+            if let vc = self.selectedViewController?.presentedViewController, vc is IDCheckNavigationController {
+                return vc.preferredStatusBarStyle
+            } else {
+                return super.preferredStatusBarStyle
+            }
+        }
+        set {
+            // Empty implementation
+        }
+    }
+}

--- a/Sources/Qualification/QualifyingCoordinator.swift
+++ b/Sources/Qualification/QualifyingCoordinator.swift
@@ -1,5 +1,6 @@
 import Authentication
 import Coordination
+import DocumentCheck
 import GDSCommon
 import Logging
 import Networking
@@ -139,7 +140,7 @@ extension QualifyingCoordinator {
             updateStream.continuation.yield(tabManagerCoordinator)
         } else {
             let tabManagerCoordinator = TabManagerCoordinator(
-                root: UITabBarController(),
+                root: CustomTabBarController(),
                 analyticsService: analyticsService,
                 analyticsPreferenceStore: analyticsPreferenceStore,
                 networkClient: networkClient,
@@ -193,6 +194,50 @@ extension QualifyingCoordinator {
                     tabCoordinator.handleUniversalLink(deeplink)
                     self.deeplink = nil
                 }
+            }
+        }
+    }
+}
+
+public typealias IDCheckNavigationController = ConfirmNavigationController
+
+class CustomTabBarController: UITabBarController {
+    override open var shouldAutorotate: Bool {
+        get {
+            if let vc = self.selectedViewController, vc is IDCheckNavigationController {
+                return vc.shouldAutorotate
+            } else {
+                return super.shouldAutorotate
+            }
+        }
+    }
+    
+    override open var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
+        get {
+            if let vc = self.selectedViewController, vc is IDCheckNavigationController {
+                return vc.preferredInterfaceOrientationForPresentation
+            } else {
+                return super.preferredInterfaceOrientationForPresentation
+            }
+        }
+    }
+    
+    override open var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        get {
+            if let vc = self.selectedViewController, vc is IDCheckNavigationController {
+                return vc.supportedInterfaceOrientations
+            } else {
+                return super.supportedInterfaceOrientations
+            }
+        }
+    }
+    
+    override open var preferredStatusBarStyle: UIStatusBarStyle {
+        get {
+            if let vc = self.selectedViewController, vc is IDCheckNavigationController {
+                return vc.preferredStatusBarStyle
+            } else {
+                return super.preferredStatusBarStyle
             }
         }
     }

--- a/Sources/Qualification/QualifyingCoordinator.swift
+++ b/Sources/Qualification/QualifyingCoordinator.swift
@@ -1,6 +1,5 @@
 import Authentication
 import Coordination
-import DocumentCheck
 import GDSCommon
 import Logging
 import Networking
@@ -195,62 +194,6 @@ extension QualifyingCoordinator {
                     self.deeplink = nil
                 }
             }
-        }
-    }
-}
-
-public typealias IDCheckNavigationController = ConfirmNavigationController
-
-class CustomTabBarController: UITabBarController {
-    override open var shouldAutorotate: Bool {
-        get {
-            if let vc = self.selectedViewController?.presentedViewController, vc is IDCheckNavigationController {
-                return vc.shouldAutorotate
-            } else {
-                return super.shouldAutorotate
-            }
-        }
-        set {
-            // Empty implementation
-        }
-    }
-    
-    override open var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
-        get {
-            if let vc = self.selectedViewController?.presentedViewController, vc is IDCheckNavigationController {
-                return vc.preferredInterfaceOrientationForPresentation
-            } else {
-                return super.preferredInterfaceOrientationForPresentation
-            }
-        }
-        set {
-            // Empty implementation
-        }
-    }
-    
-    override open var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        get {
-            if let vc = self.selectedViewController?.presentedViewController, vc is IDCheckNavigationController {
-                return vc.supportedInterfaceOrientations
-            } else {
-                return super.supportedInterfaceOrientations
-            }
-        }
-        set {
-            // Empty implementation
-        }
-    }
-    
-    override open var preferredStatusBarStyle: UIStatusBarStyle {
-        get {
-            if let vc = self.selectedViewController?.presentedViewController, vc is IDCheckNavigationController {
-                return vc.preferredStatusBarStyle
-            } else {
-                return super.preferredStatusBarStyle
-            }
-        }
-        set {
-            // Empty implementation
         }
     }
 }

--- a/Sources/Qualification/QualifyingCoordinator.swift
+++ b/Sources/Qualification/QualifyingCoordinator.swift
@@ -204,41 +204,53 @@ public typealias IDCheckNavigationController = ConfirmNavigationController
 class CustomTabBarController: UITabBarController {
     override open var shouldAutorotate: Bool {
         get {
-            if let vc = self.selectedViewController, vc is IDCheckNavigationController {
+            if let vc = self.selectedViewController?.presentedViewController, vc is IDCheckNavigationController {
                 return vc.shouldAutorotate
             } else {
                 return super.shouldAutorotate
             }
         }
+        set {
+            // Empty implementation
+        }
     }
     
     override open var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
         get {
-            if let vc = self.selectedViewController, vc is IDCheckNavigationController {
+            if let vc = self.selectedViewController?.presentedViewController, vc is IDCheckNavigationController {
                 return vc.preferredInterfaceOrientationForPresentation
             } else {
                 return super.preferredInterfaceOrientationForPresentation
             }
         }
+        set {
+            // Empty implementation
+        }
     }
     
     override open var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         get {
-            if let vc = self.selectedViewController, vc is IDCheckNavigationController {
+            if let vc = self.selectedViewController?.presentedViewController, vc is IDCheckNavigationController {
                 return vc.supportedInterfaceOrientations
             } else {
                 return super.supportedInterfaceOrientations
             }
         }
+        set {
+            // Empty implementation
+        }
     }
     
     override open var preferredStatusBarStyle: UIStatusBarStyle {
         get {
-            if let vc = self.selectedViewController, vc is IDCheckNavigationController {
+            if let vc = self.selectedViewController?.presentedViewController, vc is IDCheckNavigationController {
                 return vc.preferredStatusBarStyle
             } else {
                 return super.preferredStatusBarStyle
             }
+        }
+        set {
+            // Empty implementation
         }
     }
 }


### PR DESCRIPTION
# fix: ReadID landscape bug

This PR fixes the ReadID landscape bug, where rotation preferences where overridden by UITabBarController. A `CustomTabBarController` has been created which ensures the correct navigation controller handles rotation.

When in landscape mode ReadID no longer rotates

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] ~Checked dynamic type sizes are applied~
    - [ ] ~Checked VoiceOver can navigate your new code~
    - [ ] ~Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
