### PR TITLE
chore: bump GitHub-actions group

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
           role-skip-session-tagging: true
 
       - name: Store Secrets from AWS SecretManager
-        uses: aws-actions/aws-secretsmanager-get-secrets@5e19ff380d035695bdd56bbad320ca535c9063f2 # pin@v2.0.9
+        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # pin@v2.0.10
         with:
           secret-ids: |
             di-ipv-dca-mob-ios/github-actions-v2


### PR DESCRIPTION
Bumps the github-actions group with 1 update: [aws-actions/aws-secretsmanager-get-secrets](https://github.com/aws-actions/aws-secretsmanager-get-secrets).


Updates `aws-actions/aws-secretsmanager-get-secrets` from 2.0.9 to 2.0.10
- [Release notes](https://github.com/aws-actions/aws-secretsmanager-get-secrets/releases)
- [Commits](https://github.com/aws-actions/aws-secretsmanager-get-secrets/compare/5e19ff380d035695bdd56bbad320ca535c9063f2...a9a7eb4e2f2871d30dc5b892576fde60a2ecc802)

---
updated-dependencies:
- dependency-name: aws-actions/aws-secretsmanager-get-secrets dependency-version: 2.0.10 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: github-actions ...
- 
# Checklist

## Before raising your pull request:
- [ ] Commit messages that conform to conventional commit messages
- [ ] Ran the app locally ensuring it builds 
- [ ] Ran the tests locally ensuring they pass on Build
- [ ] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
