### PR TITLE
refactor: use GAnalyticsV2 type

### DIFF
--- a/LocalAuthenticationWrapper/Sources/LocalAuthenticationWrapper/LocalAuthenticationWrapper.swift
+++ b/LocalAuthenticationWrapper/Sources/LocalAuthenticationWrapper/LocalAuthenticationWrapper.swift
@@ -30,21 +30,18 @@ public struct LocalAuthenticationWrapper: LocalAuthManaging {
             guard try canOnlyUseBiometrics else {
                 return try canUseAnyLocalAuth ? .passcode : .none
             }
-            
-            return try deviceBiometricsType
+            return deviceBiometricsType
         }
     }
     
     public var deviceBiometricsType: LocalAuthType {
-        get throws {
-            switch localAuthContext.biometryType {
-            case .touchID:
-                return .touchID
-            case .faceID:
-                return .faceID
-            default:
-                return .none
-            }
+        switch localAuthContext.biometryType {
+        case .touchID:
+            return .touchID
+        case .faceID:
+            return .faceID
+        default:
+            return .none
         }
     }
     

--- a/LocalAuthenticationWrapper/Sources/LocalAuthenticationWrapper/Protocols/LocalAuthManaging.swift
+++ b/LocalAuthenticationWrapper/Sources/LocalAuthenticationWrapper/Protocols/LocalAuthManaging.swift
@@ -1,6 +1,6 @@
 public protocol LocalAuthManaging {
     var type: LocalAuthType { get throws }
-    var deviceBiometricsType: LocalAuthType { get throws }
+    var deviceBiometricsType: LocalAuthType { get }
     var canUseAnyLocalAuth: Bool { get throws }
     
     func checkLevelSupported(_ requiredLevel: RequiredLocalAuthLevel) throws -> Bool

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -3827,8 +3827,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/govuk-one-login/mobile-ios-logging.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.0.0;
+				branch = feature/ganalyticsv2;
+				kind = branch;
 			};
 		};
 		C8A13CAE2AFBD0F100FCBD36 /* XCRemoteSwiftPackageReference "mobile-ios-coordination" */ = {

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -3827,8 +3827,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/govuk-one-login/mobile-ios-logging.git";
 			requirement = {
-				branch = feature/ganalyticsv2;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 4.0.0;
 			};
 		};
 		C8A13CAE2AFBD0F100FCBD36 /* XCRemoteSwiftPackageReference "mobile-ios-coordination" */ = {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -168,7 +168,7 @@
       "location" : "https://github.com/govuk-one-login/mobile-ios-logging.git",
       "state" : {
         "branch" : "feature/ganalyticsv2",
-        "revision" : "79e7506c96bd8322b3d3c3fdbf75b2004c5953a0"
+        "revision" : "50cc15dbc42189d7932da05957dd7a6210a6ec73"
       }
     },
     {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -167,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-logging.git",
       "state" : {
-        "branch" : "feature/ganalyticsv2",
-        "revision" : "50cc15dbc42189d7932da05957dd7a6210a6ec73"
+        "revision" : "e60ef8c92d8c073b504fb873f74d9fa90d7aa28f",
+        "version" : "4.2.0"
       }
     },
     {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -167,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-logging.git",
       "state" : {
-        "revision" : "e593364750ea10cc2564f7783749b1093d9c5d43",
-        "version" : "4.1.3"
+        "branch" : "feature/ganalyticsv2",
+        "revision" : "c602628d78d4afaacffe79a25a2ae6a052c20ebb"
       }
     },
     {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -168,7 +168,7 @@
       "location" : "https://github.com/govuk-one-login/mobile-ios-logging.git",
       "state" : {
         "branch" : "feature/ganalyticsv2",
-        "revision" : "c602628d78d4afaacffe79a25a2ae6a052c20ebb"
+        "revision" : "79e7506c96bd8322b3d3c3fdbf75b2004c5953a0"
       }
     },
     {

--- a/Sources/Application/AppDelegate.swift
+++ b/Sources/Application/AppDelegate.swift
@@ -8,7 +8,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         FirebaseAppIntegrityService.configure()
-        GAnalytics().configure()
+        GAnalyticsV2.configure()
         return true
     }
     

--- a/Sources/Application/SceneDelegate.swift
+++ b/Sources/Application/SceneDelegate.swift
@@ -12,7 +12,7 @@ final class SceneDelegate: UIResponder,
     
     lazy var analyticsService: OneLoginAnalyticsService = {
         let analyticsService = GAnalyticsV2().addingAdditionalParameters(.oneLoginDefaults)
-        analyticsService.configure()
+        analyticsService.activate()
         return analyticsService
     }()
     private lazy var analyticsPreferenceStore = UserDefaultsPreferenceStore()

--- a/Sources/Application/SceneDelegate.swift
+++ b/Sources/Application/SceneDelegate.swift
@@ -10,7 +10,11 @@ final class SceneDelegate: UIResponder,
                            SceneLifecycle {
     private var rootCoordinator: QualifyingCoordinator?
     
-    lazy var analyticsService: OneLoginAnalyticsService = GAnalytics().addingAdditionalParameters(.oneLoginDefaults)
+    lazy var analyticsService: OneLoginAnalyticsService = {
+        let analyticsService = GAnalyticsV2().addingAdditionalParameters(.oneLoginDefaults)
+        analyticsService.configure()
+        return analyticsService
+    }()
     private lazy var analyticsPreferenceStore = UserDefaultsPreferenceStore()
     private lazy var appQualifyingService = AppQualifyingService(analyticsService: analyticsService,
                                                                  sessionManager: sessionManager)

--- a/Sources/Application/SceneDelegate.swift
+++ b/Sources/Application/SceneDelegate.swift
@@ -10,12 +10,13 @@ final class SceneDelegate: UIResponder,
                            SceneLifecycle {
     private var rootCoordinator: QualifyingCoordinator?
     
+    private lazy var analyticsPreferenceStore = UserDefaultsPreferenceStore()
     lazy var analyticsService: OneLoginAnalyticsService = {
-        let analyticsService = GAnalyticsV2().addingAdditionalParameters(.oneLoginDefaults)
+        let analyticsService = GAnalyticsV2(analyticsPreferenceStore: analyticsPreferenceStore)
+            .addingAdditionalParameters(.oneLoginDefaults)
         analyticsService.activate()
         return analyticsService
     }()
-    private lazy var analyticsPreferenceStore = UserDefaultsPreferenceStore()
     private lazy var appQualifyingService = AppQualifyingService(analyticsService: analyticsService,
                                                                  sessionManager: sessionManager)
     private lazy var networkClient = NetworkClient()
@@ -52,7 +53,6 @@ final class SceneDelegate: UIResponder,
             appWindow: UIWindow(windowScene: windowScene),
             appQualifyingService: appQualifyingService,
             analyticsService: analyticsService,
-            analyticsPreferenceStore: analyticsPreferenceStore,
             sessionManager: sessionManager,
             networkClient: networkClient
         )

--- a/Sources/Extensions/CustomTypes/AnalyticsService+GDS.swift
+++ b/Sources/Extensions/CustomTypes/AnalyticsService+GDS.swift
@@ -26,7 +26,7 @@ extension ErrorScreenView: @retroactive LoggableScreenV2 where Screen: OneLoginS
 
 extension EventName: @retroactive LoggableEvent { }
 
-extension AnalyticsService {
+extension AnalyticsServiceV2 {
     public func logEvent(_ event: Event) {
         logEvent(event.name,
                  parameters: event.parameters)

--- a/Sources/Extensions/CustomTypes/SecureStorable+OneLogin.swift
+++ b/Sources/Extensions/CustomTypes/SecureStorable+OneLogin.swift
@@ -3,7 +3,7 @@ import SecureStore
 
 extension SecureStorable where Self == SecureStoreService {
     static func accessControlEncryptedStore(
-        localAuthManager: LocalAuthManaging & LocalAuthenticationContextStrings
+        localAuthManager: LocalAuthenticationContextStrings
     ) throws -> SecureStoreService {
         let accessControlConfiguration = SecureStorageConfiguration(
             id: OLString.oneLoginTokens,

--- a/Sources/Extensions/SDKConformances.swift
+++ b/Sources/Extensions/SDKConformances.swift
@@ -10,9 +10,9 @@ extension AuthorizedHTTPLogger: @retroactive WalletTxMALogger { }
 
 extension NetworkClient: @retroactive WalletNetworkClient { }
 
-extension GAnalytics: @retroactive WalletAnalyticsService & IDCheckAnalyticsService { }
+extension GAnalyticsV2: @retroactive WalletAnalyticsService & IDCheckAnalyticsService { }
 
-typealias OneLoginAnalyticsService = AnalyticsService & IDCheckAnalyticsService & WalletAnalyticsService
+typealias OneLoginAnalyticsService = AnalyticsServiceV2 & IDCheckAnalyticsService & WalletAnalyticsService
 
 extension WalletConfig {
     static let oneLoginWalletConfig = WalletConfig(
@@ -20,17 +20,6 @@ extension WalletConfig {
         credentialIssuer: AppEnvironment.walletCredentialIssuer.absoluteString,
         clientID: AppEnvironment.stsClientID
     )
-}
-
-struct OneLoginCRIURLs: CRIURLs {
-    let criBaseURL: URL = AppEnvironment.idCheckAsyncBaseURL
-    let govSupportURL: URL = AppEnvironment.govSupportURL
-    let handoffURL: URL = AppEnvironment.idCheckHandoffURL
-    let baseURL: URL = AppEnvironment.idCheckBaseURL
-    let domainURL: URL = AppEnvironment.idCheckDomainURL
-    let govUKURL: URL = AppEnvironment.govURL
-    let readIDURLString: String = AppEnvironment.readIDURLString
-    let iProovURLString: String = AppEnvironment.iProovURLString
 }
 
 extension WalletEnvironment {
@@ -45,4 +34,15 @@ extension WalletEnvironment {
             self = config
         }
     }
+}
+
+struct OneLoginCRIURLs: CRIURLs {
+    let criBaseURL: URL = AppEnvironment.idCheckAsyncBaseURL
+    let govSupportURL: URL = AppEnvironment.govSupportURL
+    let handoffURL: URL = AppEnvironment.idCheckHandoffURL
+    let baseURL: URL = AppEnvironment.idCheckBaseURL
+    let domainURL: URL = AppEnvironment.idCheckDomainURL
+    let govUKURL: URL = AppEnvironment.govURL
+    let readIDURLString: String = AppEnvironment.readIDURLString
+    let iProovURLString: String = AppEnvironment.iProovURLString
 }

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -17,7 +17,6 @@ final class LoginCoordinator: NSObject,
     var childCoordinators = [ChildCoordinator]()
     
     private let analyticsService: OneLoginAnalyticsService
-    private let analyticsPreferenceStore: AnalyticsPreferenceStore
     private let sessionManager: SessionManager
     private let networkMonitor: NetworkMonitoring
     private let authService: AuthenticationService
@@ -32,7 +31,6 @@ final class LoginCoordinator: NSObject,
     init(appWindow: UIWindow,
          root: UINavigationController,
          analyticsService: OneLoginAnalyticsService,
-         analyticsPreferenceStore: AnalyticsPreferenceStore,
          sessionManager: SessionManager,
          networkMonitor: NetworkMonitoring = NetworkMonitor.shared,
          authService: AuthenticationService,
@@ -40,7 +38,6 @@ final class LoginCoordinator: NSObject,
         self.appWindow = appWindow
         self.root = root
         self.analyticsService = analyticsService
-        self.analyticsPreferenceStore = analyticsPreferenceStore
         self.sessionManager = sessionManager
         self.networkMonitor = networkMonitor
         self.authService = authService
@@ -70,9 +67,6 @@ final class LoginCoordinator: NSObject,
     }
     
     func authenticate() {
-        let numbers = [0]
-        _ = numbers[1]
-        
         guard networkMonitor.isConnected else {
             showNetworkConnectionErrorScreen { [unowned self] in
                 returnFromErrorScreen()
@@ -152,9 +146,9 @@ final class LoginCoordinator: NSObject,
     }
     
     func launchOnboardingCoordinator() {
-        if analyticsPreferenceStore.hasAcceptedAnalytics == nil, root.topViewController is IntroViewController {
-            openChildModally(OnboardingCoordinator(analyticsService: analyticsService,
-                                                   analyticsPreferenceStore: analyticsPreferenceStore,
+        if analyticsService.analyticsPreferenceStore.hasAcceptedAnalytics == nil,
+           root.topViewController is IntroViewController {
+            openChildModally(OnboardingCoordinator(analyticsPreferenceStore: analyticsService.analyticsPreferenceStore,
                                                    urlOpener: UIApplication.shared))
         }
     }

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -70,6 +70,9 @@ final class LoginCoordinator: NSObject,
     }
     
     func authenticate() {
+        let numbers = [0]
+        _ = numbers[1]
+        
         guard networkMonitor.isConnected else {
             showNetworkConnectionErrorScreen { [unowned self] in
                 returnFromErrorScreen()

--- a/Sources/Login/OnboardingCoordinator.swift
+++ b/Sources/Login/OnboardingCoordinator.swift
@@ -8,14 +8,11 @@ final class OnboardingCoordinator: NSObject,
                                    ChildCoordinator {
     let root = UINavigationController()
     weak var parentCoordinator: ParentCoordinator?
-    private var analyticsService: OneLoginAnalyticsService
     private var analyticsPreferenceStore: AnalyticsPreferenceStore
     private let urlOpener: URLOpener
     
-    init(analyticsService: OneLoginAnalyticsService,
-         analyticsPreferenceStore: AnalyticsPreferenceStore,
+    init(analyticsPreferenceStore: AnalyticsPreferenceStore,
          urlOpener: URLOpener) {
-        self.analyticsService = analyticsService
         self.analyticsPreferenceStore = analyticsPreferenceStore
         self.urlOpener = urlOpener
     }

--- a/Sources/Login/OnboardingCoordinator.swift
+++ b/Sources/Login/OnboardingCoordinator.swift
@@ -22,12 +22,10 @@ final class OnboardingCoordinator: NSObject,
     
     func start() {
         let viewModel = AnalyticsPreferenceViewModel { [unowned self] in
-            analyticsService.grantAnalyticsPermission()
             analyticsPreferenceStore.hasAcceptedAnalytics = true
             root.dismiss(animated: true)
             finish()
         } secondaryButtonAction: { [unowned self] in
-            analyticsService.denyAnalyticsPermission()
             analyticsPreferenceStore.hasAcceptedAnalytics = false
             root.dismiss(animated: true)
             finish()

--- a/Sources/Qualification/QualifyingCoordinator.swift
+++ b/Sources/Qualification/QualifyingCoordinator.swift
@@ -25,7 +25,6 @@ final class QualifyingCoordinator: NSObject,
     
     private let appQualifyingService: QualifyingService
     private let analyticsService: OneLoginAnalyticsService
-    private let analyticsPreferenceStore: AnalyticsPreferenceStore
     private let sessionManager: SessionManager
     private let networkClient: NetworkClient
     
@@ -49,13 +48,11 @@ final class QualifyingCoordinator: NSObject,
     init(appWindow: UIWindow,
          appQualifyingService: QualifyingService,
          analyticsService: OneLoginAnalyticsService,
-         analyticsPreferenceStore: AnalyticsPreferenceStore,
          sessionManager: SessionManager,
          networkClient: NetworkClient) {
         self.appWindow = appWindow
         self.appQualifyingService = appQualifyingService
         self.analyticsService = analyticsService
-        self.analyticsPreferenceStore = analyticsPreferenceStore
         self.sessionManager = sessionManager
         self.networkClient = networkClient
         super.init()
@@ -120,7 +117,6 @@ final class QualifyingCoordinator: NSObject,
                 appWindow: appWindow,
                 root: UINavigationController(),
                 analyticsService: analyticsService,
-                analyticsPreferenceStore: analyticsPreferenceStore,
                 sessionManager: sessionManager,
                 authService: WebAuthenticationService(sessionManager: sessionManager,
                                                       session: AppAuthSessionV2(window: appWindow),
@@ -141,7 +137,6 @@ extension QualifyingCoordinator {
             let tabManagerCoordinator = TabManagerCoordinator(
                 root: OrientationLockingTabBarController(),
                 analyticsService: analyticsService,
-                analyticsPreferenceStore: analyticsPreferenceStore,
                 networkClient: networkClient,
                 sessionManager: sessionManager)
             displayChildCoordinator(tabManagerCoordinator)

--- a/Sources/Tabs/SettingsCoordinator.swift
+++ b/Sources/Tabs/SettingsCoordinator.swift
@@ -16,20 +16,17 @@ final class SettingsCoordinator: NSObject,
     weak var parentCoordinator: ParentCoordinator?
     
     private let analyticsService: OneLoginAnalyticsService
-    private let analyticsPreferenceStore: AnalyticsPreferenceStore
     private let sessionManager: SessionManager & UserProvider
     private let networkClient: NetworkClient
     private let urlOpener: URLOpener
     
     init(analyticsService: OneLoginAnalyticsService,
-         analyticsPreferenceStore: AnalyticsPreferenceStore,
          sessionManager: SessionManager & UserProvider,
          networkClient: NetworkClient,
          urlOpener: URLOpener) {
         self.analyticsService = analyticsService.addingAdditionalParameters([
             OLTaxonomyKey.level2: OLTaxonomyValue.system
         ])
-        self.analyticsPreferenceStore = analyticsPreferenceStore
         self.sessionManager = sessionManager
         self.networkClient = networkClient
         self.urlOpener = urlOpener
@@ -46,7 +43,7 @@ final class SettingsCoordinator: NSObject,
                                              openDeveloperMenu: openDeveloperMenu)
         let settingsViewController = SettingsViewController(viewModel: viewModel,
                                                             userProvider: sessionManager,
-                                                            analyticsPreference: analyticsPreferenceStore)
+                                                            analyticsPreference: analyticsService.analyticsPreferenceStore)
         root.setViewControllers([settingsViewController], animated: true)
     }
     

--- a/Sources/Tabs/TabManagerCoordinator.swift
+++ b/Sources/Tabs/TabManagerCoordinator.swift
@@ -21,7 +21,6 @@ final class TabManagerCoordinator: NSObject,
     weak var parentCoordinator: ParentCoordinator?
     var childCoordinators = [ChildCoordinator]()
     private let analyticsService: OneLoginAnalyticsService
-    private let analyticsPreferenceStore: AnalyticsPreferenceStore
     private let networkClient: NetworkClient
     private let sessionManager: SessionManager
     
@@ -35,12 +34,10 @@ final class TabManagerCoordinator: NSObject,
     
     init(root: UITabBarController,
          analyticsService: OneLoginAnalyticsService,
-         analyticsPreferenceStore: AnalyticsPreferenceStore,
          networkClient: NetworkClient,
          sessionManager: SessionManager) {
         self.root = root
         self.analyticsService = analyticsService
-        self.analyticsPreferenceStore = analyticsPreferenceStore
         self.networkClient = networkClient
         self.sessionManager = sessionManager
     }
@@ -88,7 +85,6 @@ final class TabManagerCoordinator: NSObject,
     
     private func addSettingsTab() {
         let pc = SettingsCoordinator(analyticsService: analyticsService,
-                                     analyticsPreferenceStore: analyticsPreferenceStore,
                                      sessionManager: sessionManager,
                                      networkClient: networkClient,
                                      urlOpener: UIApplication.shared)

--- a/Sources/Utilities/LocalAuthServiceWallet.swift
+++ b/Sources/Utilities/LocalAuthServiceWallet.swift
@@ -88,7 +88,7 @@ final class LocalAuthServiceWallet: WalletLocalAuthService {
             return true
         #endif
         
-        return isEnrolledToLocalAuth(minimum)
+        isEnrolledToLocalAuth(minimum)
     }
     
     func isEnrolledToLocalAuth(_ minimum: any WalletLocalAuthType) -> Bool {

--- a/Sources/Utilities/LocalAuthServiceWallet.swift
+++ b/Sources/Utilities/LocalAuthServiceWallet.swift
@@ -66,7 +66,7 @@ final class LocalAuthServiceWallet: WalletLocalAuthService {
                     completion()
                 }
             case .none:
-                let viewModel = LocalAuthSettingsErrorViewModel(analyticsService: analyticsService, localAuthType: try localAuthentication.deviceBiometricsType) { [unowned self] in
+                let viewModel = LocalAuthSettingsErrorViewModel(analyticsService: analyticsService, localAuthType: localAuthentication.deviceBiometricsType) { [unowned self] in
                     biometricsNavigationController.dismiss(animated: true)
                     completion()
                 }

--- a/Tests/UnitTests/Application/SceneLifecycleTests.swift
+++ b/Tests/UnitTests/Application/SceneLifecycleTests.swift
@@ -6,7 +6,6 @@ import XCTest
 @MainActor
 final class SceneLifecycleTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
-    var mockAnalyticsPreferenceStore: MockAnalyticsPreferenceStore!
     var mockSessionManager: MockSessionManager!
     var mockTabManagerCoordinator: TabManagerCoordinator!
     var sut: MockSceneDelegate!
@@ -15,11 +14,9 @@ final class SceneLifecycleTests: XCTestCase {
         super.setUp()
         
         mockAnalyticsService = MockAnalyticsService()
-        mockAnalyticsPreferenceStore = MockAnalyticsPreferenceStore()
         mockSessionManager = MockSessionManager()
         mockTabManagerCoordinator = TabManagerCoordinator(root: UITabBarController(),
                                                           analyticsService: mockAnalyticsService,
-                                                          analyticsPreferenceStore: mockAnalyticsPreferenceStore,
                                                           networkClient: NetworkClient(),
                                                           sessionManager: mockSessionManager)
         sut = MockSceneDelegate(coordinator: mockTabManagerCoordinator,
@@ -28,7 +25,6 @@ final class SceneLifecycleTests: XCTestCase {
     
     override func tearDown() {
         mockAnalyticsService = nil
-        mockAnalyticsPreferenceStore = nil
         mockSessionManager = nil
         mockTabManagerCoordinator = nil
         sut = nil

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -9,7 +9,6 @@ final class LoginCoordinatorTests: XCTestCase {
     var appWindow: UIWindow!
     var navigationController: UINavigationController!
     var mockAnalyticsService: MockAnalyticsService!
-    var mockAnalyticsPreferenceStore: MockAnalyticsPreferenceStore!
     var mockSessionManager: MockSessionManager!
     var mockNetworkMonitor: NetworkMonitoring!
     var mockAuthenticationService: MockAuthenticationService!
@@ -22,7 +21,6 @@ final class LoginCoordinatorTests: XCTestCase {
         appWindow = .init()
         navigationController = .init()
         mockAnalyticsService = MockAnalyticsService()
-        mockAnalyticsPreferenceStore = MockAnalyticsPreferenceStore()
         mockSessionManager = MockSessionManager()
         mockNetworkMonitor = MockNetworkMonitor()
         mockAuthenticationService = MockAuthenticationService(sessionManager: mockSessionManager)
@@ -31,7 +29,6 @@ final class LoginCoordinatorTests: XCTestCase {
         sut = LoginCoordinator(appWindow: appWindow,
                                root: navigationController,
                                analyticsService: mockAnalyticsService,
-                               analyticsPreferenceStore: mockAnalyticsPreferenceStore,
                                sessionManager: mockSessionManager,
                                networkMonitor: mockNetworkMonitor,
                                authService: mockAuthenticationService,
@@ -42,7 +39,6 @@ final class LoginCoordinatorTests: XCTestCase {
         appWindow = nil
         navigationController = nil
         mockAnalyticsService = nil
-        mockAnalyticsPreferenceStore = nil
         mockSessionManager = nil
         mockNetworkMonitor = nil
         sut = nil
@@ -56,7 +52,6 @@ final class LoginCoordinatorTests: XCTestCase {
         sut = LoginCoordinator(appWindow: appWindow,
                                root: navigationController,
                                analyticsService: mockAnalyticsService,
-                               analyticsPreferenceStore: mockAnalyticsPreferenceStore,
                                sessionManager: mockSessionManager,
                                networkMonitor: mockNetworkMonitor,
                                authService: mockAuthenticationService,
@@ -472,7 +467,7 @@ extension LoginCoordinatorTests {
     func test_skip_launchOnboardingCoordinator() {
         sut.start()
         // GIVEN the user has accepted analytics permissions
-        mockAnalyticsPreferenceStore.hasAcceptedAnalytics = true
+        mockAnalyticsService.analyticsPreferenceStore.hasAcceptedAnalytics = true
         // WHEN the launchOnboardingCoordinator method is called
         sut.launchOnboardingCoordinator()
         // THEN the OnboardingCoordinator should not be launched

--- a/Tests/UnitTests/Login/OnboardingCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/OnboardingCoordinatorTests.swift
@@ -4,7 +4,6 @@ import XCTest
 
 @MainActor
 final class OnboardingCoordinatorTests: XCTestCase {
-    var mockAnalyticsService: MockAnalyticsService!
     var mockAnalyticsPreferenceStore: MockAnalyticsPreferenceStore!
     var mockURLOpener: MockURLOpener!
     var sut: OnboardingCoordinator!
@@ -12,16 +11,13 @@ final class OnboardingCoordinatorTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        mockAnalyticsService = MockAnalyticsService()
         mockAnalyticsPreferenceStore = MockAnalyticsPreferenceStore()
         mockURLOpener = MockURLOpener()
-        sut = OnboardingCoordinator(analyticsService: mockAnalyticsService,
-                                    analyticsPreferenceStore: mockAnalyticsPreferenceStore,
+        sut = OnboardingCoordinator(analyticsPreferenceStore: mockAnalyticsPreferenceStore,
                                     urlOpener: mockURLOpener)
     }
     
     override func tearDown() {
-        mockAnalyticsService = nil
         mockAnalyticsPreferenceStore = nil
         mockURLOpener = nil
         sut = nil
@@ -41,7 +37,6 @@ extension OnboardingCoordinatorTests {
         let acceptPermissionsButton: UIButton = try XCTUnwrap(vc.view[child: "modal-info-primary-button"])
         acceptPermissionsButton.sendActions(for: .touchUpInside)
         // THEN the analyticsPreferenceStore's hasAcceptedAnalytics value is updated to true
-        XCTAssertTrue(try XCTUnwrap(mockAnalyticsService.hasAcceptedAnalytics))
         XCTAssertTrue(try XCTUnwrap(mockAnalyticsPreferenceStore.hasAcceptedAnalytics))
     }
 
@@ -55,7 +50,6 @@ extension OnboardingCoordinatorTests {
         let declinePermissionsButton: UIButton = try XCTUnwrap(vc.view[child: "modal-info-secondary-button"])
         declinePermissionsButton.sendActions(for: .touchUpInside)
         // THEN the analyticsPreferenceStore's hasAcceptedAnalytics value is updated to false
-        XCTAssertFalse(try XCTUnwrap(mockAnalyticsService.hasAcceptedAnalytics))
         XCTAssertFalse(try XCTUnwrap(mockAnalyticsPreferenceStore.hasAcceptedAnalytics))
     }
     

--- a/Tests/UnitTests/Mocks/Sessions+Services/Analytics/MockAnalyticsService.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Analytics/MockAnalyticsService.swift
@@ -3,6 +3,8 @@ import Logging
 import XCTest
 
 final class MockAnalyticsService: OneLoginAnalyticsService {
+    var analyticsPreferenceStore: AnalyticsPreferenceStore = MockAnalyticsPreferenceStore()
+    
     var additionalParameters = [String: Any]()
     
     private(set) var screensVisited = [String]()

--- a/Tests/UnitTests/Qualification/QualifyingCoordinatorTests.swift
+++ b/Tests/UnitTests/Qualification/QualifyingCoordinatorTests.swift
@@ -7,7 +7,6 @@ import XCTest
 final class QualifyingCoordinatorTests: XCTestCase {
     private var qualifyingService: MockQualifyingService!
     private var mockAnalyticsService: MockAnalyticsService!
-    private var mockAnalyticsPreferenceStore: MockAnalyticsPreferenceStore!
     private var sessionManager: MockSessionManager!
     private var networkClient: NetworkClient!
     private var window: UIWindow!
@@ -21,14 +20,12 @@ final class QualifyingCoordinatorTests: XCTestCase {
         window = UIWindow()
         sessionManager = MockSessionManager()
         mockAnalyticsService = MockAnalyticsService()
-        mockAnalyticsPreferenceStore = MockAnalyticsPreferenceStore()
         networkClient = NetworkClient()
         networkClient.authorizationProvider = MockAuthenticationProvider()
         qualifyingService = MockQualifyingService()
         sut = QualifyingCoordinator(appWindow: window,
                                     appQualifyingService: qualifyingService,
                                     analyticsService: mockAnalyticsService,
-                                    analyticsPreferenceStore: mockAnalyticsPreferenceStore,
                                     sessionManager: sessionManager,
                                     networkClient: networkClient)
     }

--- a/Tests/UnitTests/Tabs/SettingsCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/SettingsCoordinatorTests.swift
@@ -8,7 +8,6 @@ import XCTest
 @MainActor
 final class SettingsCoordinatorTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
-    var mockAnalyticsPreferenceStore: MockAnalyticsPreferenceStore!
     var mockSessionManager: MockSessionManager!
     var mockNetworkClient: NetworkClient!
     var urlOpener: URLOpener!
@@ -18,13 +17,11 @@ final class SettingsCoordinatorTests: XCTestCase {
         super.setUp()
         
         mockAnalyticsService = MockAnalyticsService()
-        mockAnalyticsPreferenceStore =  MockAnalyticsPreferenceStore()
         mockSessionManager = MockSessionManager()
         mockNetworkClient = NetworkClient()
         mockNetworkClient.authorizationProvider = MockAuthenticationProvider()
         urlOpener = MockURLOpener()
         sut = SettingsCoordinator(analyticsService: mockAnalyticsService,
-                                  analyticsPreferenceStore: mockAnalyticsPreferenceStore,
                                   sessionManager: mockSessionManager,
                                   networkClient: mockNetworkClient,
                                   urlOpener: urlOpener)
@@ -35,7 +32,6 @@ final class SettingsCoordinatorTests: XCTestCase {
     
     override func tearDown() {
         mockAnalyticsService = nil
-        mockAnalyticsPreferenceStore = nil
         mockSessionManager = nil
         mockNetworkClient = nil
         urlOpener = nil

--- a/Tests/UnitTests/Tabs/TabManagerCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/TabManagerCoordinatorTests.swift
@@ -7,7 +7,6 @@ import XCTest
 final class TabManagerCoordinatorTests: XCTestCase {
     var tabBarController: UITabBarController!
     var mockAnalyticsService: MockAnalyticsService!
-    var mockAnalyticsPreferenceStore: MockAnalyticsPreferenceStore!
     var mockSessionManager: MockSessionManager!
     var sut: TabManagerCoordinator!
     
@@ -17,11 +16,9 @@ final class TabManagerCoordinatorTests: XCTestCase {
         
         tabBarController = UITabBarController()
         mockAnalyticsService = MockAnalyticsService()
-        mockAnalyticsPreferenceStore = MockAnalyticsPreferenceStore()
         mockSessionManager = MockSessionManager()
         sut = TabManagerCoordinator(root: tabBarController,
                                     analyticsService: mockAnalyticsService,
-                                    analyticsPreferenceStore: mockAnalyticsPreferenceStore,
                                     networkClient: NetworkClient(),
                                     sessionManager: mockSessionManager)
     }
@@ -29,7 +26,6 @@ final class TabManagerCoordinatorTests: XCTestCase {
     override func tearDown() {
         tabBarController = nil
         mockAnalyticsService = nil
-        mockAnalyticsPreferenceStore = nil
         mockSessionManager = nil
         sut = nil
         
@@ -87,7 +83,6 @@ extension TabManagerCoordinatorTests {
         )
         // GIVEN the app has an existing session
         let settingsCoordinator = SettingsCoordinator(analyticsService: mockAnalyticsService,
-                                                      analyticsPreferenceStore: mockAnalyticsPreferenceStore,
                                                       sessionManager: mockSessionManager,
                                                       networkClient: NetworkClient(),
                                                       urlOpener: MockURLOpener())
@@ -107,7 +102,6 @@ extension TabManagerCoordinatorTests {
         // GIVEN the app has an existing session
         mockSessionManager.errorFromClearAllSessionData = MockWalletError.cantDelete
         let settingsCoordinator = SettingsCoordinator(analyticsService: mockAnalyticsService,
-                                                      analyticsPreferenceStore: mockAnalyticsPreferenceStore,
                                                       sessionManager: mockSessionManager,
                                                       networkClient: NetworkClient(),
                                                       urlOpener: MockURLOpener())


### PR DESCRIPTION
# refactor: use GAnalyticsV2 type

Using the GAnalyticsV2 type which is now part of the Logging package allows us to remove some code around granting/denying analytics and crashlytics permissions as well as removing the passing of the analytics preference store through all of the parent objects.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
