### PR TITLE
feat: show non recoverable error after 3rd server error

### DIFF
--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -111,10 +111,10 @@ final class LoginCoordinator: NSObject,
                 showUnrecoverableErrorScreen(error)
             } catch let error as LoginErrorV2 where error.reason == .authorizationUnknownError,
                     let error as LoginErrorV2 where error.reason == .tokenUnknownError,
-                    let error as LoginErrorV2 where error.reason == .generalServerError,
                     let error as LoginErrorV2 where error.reason == .safariOpenError {
                 showRecoverableErrorScreen(error)
-            } catch let error as LoginErrorV2 where error.reason == .authorizationServerError {
+            } catch let error as LoginErrorV2 where error.reason == .authorizationServerError,
+                    let error as LoginErrorV2 where error.reason == .generalServerError {
                 self.serverErrorCounter += 1
                 if serverErrorCounter < 3 {
                     showRecoverableErrorScreen(error)

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -21,6 +21,7 @@ final class LoginCoordinator: NSObject,
     private let networkMonitor: NetworkMonitoring
     private let authService: AuthenticationService
     private var isExpiredUser: Bool
+    private var serverErrorCounter: Int = 0
     
     private var loginTask: Task<Void, Never>? {
         didSet {
@@ -108,12 +109,18 @@ final class LoginCoordinator: NSObject,
                     let error as LoginErrorV2 where error.reason == .tokenUnsupportedGrantType,
                     let error as LoginErrorV2 where error.reason == .tokenClientError {
                 showUnrecoverableErrorScreen(error)
-            } catch let error as LoginErrorV2 where error.reason == .authorizationServerError,
-                    let error as LoginErrorV2 where error.reason == .authorizationUnknownError,
+            } catch let error as LoginErrorV2 where error.reason == .authorizationUnknownError,
                     let error as LoginErrorV2 where error.reason == .tokenUnknownError,
                     let error as LoginErrorV2 where error.reason == .generalServerError,
                     let error as LoginErrorV2 where error.reason == .safariOpenError {
                 showRecoverableErrorScreen(error)
+            } catch let error as LoginErrorV2 where error.reason == .authorizationServerError {
+                self.serverErrorCounter += 1
+                if serverErrorCounter < 3 {
+                    showRecoverableErrorScreen(error)
+                } else {
+                    showUnrecoverableErrorScreen(error)
+                }
             } catch let error as JWTVerifierError {
                 showRecoverableErrorScreen(error)
             } catch {
@@ -128,6 +135,7 @@ final class LoginCoordinator: NSObject,
             launchEnrolmentCoordinator()
             return
         }
+        self.serverErrorCounter = 0
         finish()
     }
     

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -383,6 +383,17 @@ extension LoginCoordinatorTests {
         let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
         // THEN the visible view controller's view model should be the UnableToLoginErrorViewModel
         XCTAssertTrue(vc.viewModel is RecoverableLoginErrorViewModel)
+        
+        sut.launchAuthenticationService()
+        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
+        let vc2 = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        XCTAssertTrue(vc2.viewModel is RecoverableLoginErrorViewModel)
+        
+        // 3rd server error should show non-recoverable error screen
+        sut.launchAuthenticationService()
+        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
+        let vc3 = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        XCTAssertTrue(vc3.viewModel is UnrecoverableLoginErrorViewModel)
     }
     
     @MainActor

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -334,6 +334,16 @@ extension LoginCoordinatorTests {
         let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
         // THEN the visible view controller's view model should be the RecoverableLoginErrorViewModel
         XCTAssertTrue(vc.viewModel is RecoverableLoginErrorViewModel)
+        sut.launchAuthenticationService()
+        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
+        let vc2 = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        XCTAssertTrue(vc2.viewModel is RecoverableLoginErrorViewModel)
+        
+        // 3rd server error should show non-recoverable error screen
+        sut.launchAuthenticationService()
+        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
+        let vc3 = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        XCTAssertTrue(vc3.viewModel is UnrecoverableLoginErrorViewModel)
     }
     
     @MainActor


### PR DESCRIPTION
# DCMAW-13429: Show non-recoverable error after 3rd server error on login

## Demo
https://github.com/user-attachments/assets/8e99cf0b-2b58-4775-a971-0216fc02aa8e




# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
