### PR TITLE
refactor: sign out flow

### DIFF
--- a/Sources/Extensions/Notifications/Notification+Session.swift
+++ b/Sources/Extensions/Notifications/Notification+Session.swift
@@ -15,10 +15,6 @@ extension Notification.Name {
         Notification.Name("onelogin:enrolment-complete")
     }
 
-    static var sessionExpired: Self {
-        Notification.Name("onelogin:session-expired")
-    }
-
     static var didLogout: Self {
         Notification.Name("onelogin:logout")
     }

--- a/Sources/Extensions/Notifications/Notification+Session.swift
+++ b/Sources/Extensions/Notifications/Notification+Session.swift
@@ -14,6 +14,10 @@ extension Notification.Name {
     static var enrolmentComplete: Self {
         Notification.Name("onelogin:enrolment-complete")
     }
+    
+    static var sessionExpired: Self {
+        Notification.Name("onelogin:session-expired")
+    }
 
     static var didLogout: Self {
         Notification.Name("onelogin:logout")

--- a/Sources/Qualification/State/AppQualifyingService.swift
+++ b/Sources/Qualification/State/AppQualifyingService.swift
@@ -109,8 +109,8 @@ final class AppQualifyingService: QualifyingService {
                 // As such, no additional action is required.
                 return
             } catch {
+                analyticsService.logCrash(error)
                 do {
-                    analyticsService.logCrash(error)
                     try await sessionManager.clearAllSessionData()
                 } catch {
                     userState = .failed(error)
@@ -128,20 +128,12 @@ extension AppQualifyingService {
                                                name: .enrolmentComplete)
 
         NotificationCenter.default.addObserver(self,
-                                               selector: #selector(sessionDidExpire),
-                                               name: .sessionExpired)
-
-        NotificationCenter.default.addObserver(self,
                                                selector: #selector(userDidLogout),
                                                name: .didLogout)
     }
 
     @objc private func enrolmentComplete() {
         userState = .loggedIn
-    }
-
-    @objc private func sessionDidExpire() {
-        userState = .expired
     }
 
     @objc private func userDidLogout() {

--- a/Sources/Qualification/State/AppQualifyingService.swift
+++ b/Sources/Qualification/State/AppQualifyingService.swift
@@ -126,6 +126,10 @@ extension AppQualifyingService {
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(enrolmentComplete),
                                                name: .enrolmentComplete)
+        
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(sessionDidExpire),
+                                               name: .sessionExpired)
 
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(userDidLogout),
@@ -134,6 +138,10 @@ extension AppQualifyingService {
 
     @objc private func enrolmentComplete() {
         userState = .loggedIn
+    }
+    
+    @objc private func sessionDidExpire() {
+        userState = .expired
     }
 
     @objc private func userDidLogout() {

--- a/Sources/Tabs/SettingsCoordinator.swift
+++ b/Sources/Tabs/SettingsCoordinator.swift
@@ -102,6 +102,7 @@ final class SettingsCoordinator: NSObject,
                 let signOutSuccessful = GDSInformationViewController(viewModel: viewModel)
                 signOutSuccessful.modalPresentationStyle = .fullScreen
                 root.present(signOutSuccessful, animated: false)
+                root.popToRootViewController(animated: true)
             } catch {
                 let viewModel = SignOutErrorViewModel(analyticsService: analyticsService,
                                                       error: error)

--- a/Sources/Tabs/TabManagerCoordinator.swift
+++ b/Sources/Tabs/TabManagerCoordinator.swift
@@ -44,7 +44,6 @@ final class TabManagerCoordinator: NSObject,
     
     func start() {
         addTabs()
-        subscribe()
     }
     
     func handleUniversalLink(_ url: URL) {
@@ -103,35 +102,8 @@ final class TabManagerCoordinator: NSObject,
 extension TabManagerCoordinator: ParentCoordinator {
     func performChildCleanup(child: ChildCoordinator) {
         if child is SettingsCoordinator {
-            Task {
-                do {
-                    let isWalletAccessed = WalletAvailabilityService.hasAccessedBefore
-                    try await sessionManager.clearAllSessionData(restartLoginFlow: false)
-                    
-                    let viewModel = SignOutSuccessfulViewModel(analyticsService: analyticsService,
-                                                               withWallet: isWalletAccessed) {
-                        NotificationCenter.default.post(name: .didLogout)
-                    }
-                    let signOutSuccessful = GDSInformationViewController(viewModel: viewModel)
-                    signOutSuccessful.modalPresentationStyle = .fullScreen
-                    root.present(signOutSuccessful, animated: false)
-                } catch {
-                    let viewModel = SignOutErrorViewModel(analyticsService: analyticsService,
-                                                          error: error)
-                    let signOutErrorScreen = GDSErrorScreen(viewModel: viewModel)
-                    root.present(signOutErrorScreen, animated: true)
-                }
-            }
+            NotificationCenter.default.post(name: .didLogout)
+            finish()
         }
-    }
-    
-    private func subscribe() {
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(userDidLogout),
-                                               name: .didLogout)
-    }
-    
-    @objc private func userDidLogout() {
-        finish()
     }
 }

--- a/Sources/Utilities/Storage/Session/PersistentSessionManager.swift
+++ b/Sources/Utilities/Storage/Session/PersistentSessionManager.swift
@@ -157,21 +157,13 @@ final class PersistentSessionManager: SessionManager {
     }
     
     func resumeSession() throws {
-        guard expiryDate != nil else {
-            throw PersistentSessionError.noSessionExists
-        }
-        
-        guard isSessionValid else {
-            throw TokenError.expired
-        }
-        
         guard hasNotRemovedLocalAuth else {
             throw PersistentSessionError.userRemovedLocalAuth
         }
         
         let keys = try storeKeyService.fetch()
         if let idToken = keys.idToken {
-            try user.send(IDTokenUserRepresentation(idToken: idToken))
+            user.send(try IDTokenUserRepresentation(idToken: idToken))
         } else {
             user.send(nil)
         }

--- a/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
+++ b/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
@@ -252,7 +252,16 @@ extension AppQualifyingServiceTests {
         NotificationCenter.default.post(name: .enrolmentComplete)
         waitForTruth(self.userState == .loggedIn, timeout: 5)
     }
+    
+    func test_sessionExpiry_changesUserState() {
+        appInformationProvider.errorFromFetchAppInfo = AppInfoError.invalidResponse
+        sut.delegate = self
+        sut.initiate()
 
+        NotificationCenter.default.post(name: .sessionExpired)
+        waitForTruth(self.userState == .expired, timeout: 5)
+    }
+    
     func test_logOut_changesUserState() {
         appInformationProvider.errorFromFetchAppInfo = AppInfoError.invalidResponse
         sut.delegate = self

--- a/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
+++ b/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
@@ -253,15 +253,6 @@ extension AppQualifyingServiceTests {
         waitForTruth(self.userState == .loggedIn, timeout: 5)
     }
 
-    func test_sessionExpiry_changesUserState() {
-        appInformationProvider.errorFromFetchAppInfo = AppInfoError.invalidResponse
-        sut.delegate = self
-        sut.initiate()
-
-        NotificationCenter.default.post(name: .sessionExpired)
-        waitForTruth(self.userState == .expired, timeout: 5)
-    }
-
     func test_logOut_changesUserState() {
         appInformationProvider.errorFromFetchAppInfo = AppInfoError.invalidResponse
         sut.delegate = self

--- a/Tests/UnitTests/Tabs/SettingsCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/SettingsCoordinatorTests.swift
@@ -116,7 +116,7 @@ final class SettingsCoordinatorTests: XCTestCase {
         // WHEN the user signs out
         let signOutButton: UIButton = try XCTUnwrap(presentedVC.topViewController?.view[child: "instructions-button"])
         signOutButton.sendActions(for: .touchUpInside)
-        // THEN the presented sign out successful screen is shown
+        // THEN the presented sign out error screen is shown
         waitForTruth((self.sut.root.presentedViewController as? GDSErrorScreen)?.viewModel is SignOutErrorViewModel,
                      timeout: 20)
     }

--- a/Tests/UnitTests/Tabs/SettingsCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/SettingsCoordinatorTests.swift
@@ -100,8 +100,9 @@ final class SettingsCoordinatorTests: XCTestCase {
         // WHEN the user signs out
         let signOutButton: UIButton = try XCTUnwrap(presentedVC.topViewController?.view[child: "instructions-button"])
         signOutButton.sendActions(for: .touchUpInside)
-        // THEN the presented view controller should be dismissed
-        waitForTruth(self.sut.root.presentedViewController == nil, timeout: 20)
+        // THEN the presented sign out successful screen is shown
+        waitForTruth((self.sut.root.presentedViewController as? GDSInformationViewController)?.viewModel is SignOutSuccessfulViewModel,
+                     timeout: 20)
     }
     
     func test_showDeveloperMenu() throws {

--- a/Tests/UnitTests/Tabs/SettingsCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/SettingsCoordinatorTests.swift
@@ -105,6 +105,22 @@ final class SettingsCoordinatorTests: XCTestCase {
                      timeout: 20)
     }
     
+    func test_tapSignOut_errors() throws {
+        // GIVEN an error is returned from clearAllSessionData
+        mockSessionManager.errorFromClearAllSessionData = MockWalletError.cantDelete
+        // GIVEN the user is on the signout page
+        sut.start()
+        // WHEN the openSignOutPage method is called
+        sut.openSignOutPage()
+        let presentedVC = try XCTUnwrap(sut.root.presentedViewController as? UINavigationController)
+        // WHEN the user signs out
+        let signOutButton: UIButton = try XCTUnwrap(presentedVC.topViewController?.view[child: "instructions-button"])
+        signOutButton.sendActions(for: .touchUpInside)
+        // THEN the presented sign out successful screen is shown
+        waitForTruth((self.sut.root.presentedViewController as? GDSErrorScreen)?.viewModel is SignOutErrorViewModel,
+                     timeout: 20)
+    }
+    
     func test_showDeveloperMenu() throws {
         sut.start()
         // WHEN the showDeveloperMenu method is called

--- a/Tests/UnitTests/Tabs/TabManagerCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/TabManagerCoordinatorTests.swift
@@ -75,47 +75,6 @@ extension TabManagerCoordinatorTests {
     }
     
     @MainActor
-    func test_performChildCleanup_fromSettingsCoordinator_succeeds() async throws {
-        let exp = XCTNSNotificationExpectation(
-            name: .didLogout,
-            object: nil,
-            notificationCenter: NotificationCenter.default
-        )
-        // GIVEN the app has an existing session
-        let settingsCoordinator = SettingsCoordinator(analyticsService: mockAnalyticsService,
-                                                      sessionManager: mockSessionManager,
-                                                      networkClient: NetworkClient(),
-                                                      urlOpener: MockURLOpener())
-        // WHEN the TabManagerCoordinator's performChildCleanup method is called from SettingsCoordinator (on user sign out)
-        sut.performChildCleanup(child: settingsCoordinator)
-        // THEN a logout notification is sent
-        await fulfillment(of: [exp], timeout: 5)
-        // THEN the session should be cleared
-        XCTAssertTrue(mockSessionManager.didCallClearAllSessionData)
-    }
-    
-    @MainActor
-    func test_performChildCleanup_fromSettingsCoordinator_errors() throws {
-        let window = UIWindow()
-        window.rootViewController = tabBarController
-        window.makeKeyAndVisible()
-        // GIVEN the app has an existing session
-        mockSessionManager.errorFromClearAllSessionData = MockWalletError.cantDelete
-        let settingsCoordinator = SettingsCoordinator(analyticsService: mockAnalyticsService,
-                                                      sessionManager: mockSessionManager,
-                                                      networkClient: NetworkClient(),
-                                                      urlOpener: MockURLOpener())
-        // WHEN the TabManagerCoordinator's performChildCleanup method is called from SettingsCoordinator (on user sign out)
-        // but there was an error in signing out
-        sut.performChildCleanup(child: settingsCoordinator)
-        // THEN the sign out error screen should be presented
-        waitForTruth(self.sut.root.presentedViewController is GDSErrorScreen, timeout: 5)
-        XCTAssertTrue((sut.root.presentedViewController as? GDSErrorScreen)?.viewModel is SignOutErrorViewModel)
-        // THEN the session should not be cleared
-        XCTAssertFalse(mockSessionManager.didCallEndCurrentSession)
-    }
-    
-    @MainActor
     func test_handleUniversalLink() throws {
         // GIVEN the wallet feature flag is on
         AppEnvironment.updateFlags(

--- a/Tests/UnitTests/Utilities/Session/PersistentSessionManagerTests.swift
+++ b/Tests/UnitTests/Utilities/Session/PersistentSessionManagerTests.swift
@@ -317,23 +317,6 @@ extension PersistentSessionManagerTests {
         XCTAssertEqual(mockEncryptedStore.savedItems, [:])
     }
     
-    func test_isSessionValid_throwsError() throws {
-        // GIVEN I have an expired session
-        mockUnprotectedStore.savedData = [
-            OLString.returningUser: true,
-            OLString.accessTokenExpiry: Date.distantPast
-        ]
-        mockEncryptedStore.savedItems = [
-            OLString.persistentSessionID: UUID().uuidString
-        ]
-        
-        // WHEN I try to resume a session
-        XCTAssertThrowsError(try sut.resumeSession()) { error in
-            // THEN an error is thrown
-            XCTAssertEqual(error as? TokenError, .expired)
-        }
-    }
-    
     func test_hasNotRemovedLocalAuth_throwsError_whenPasscodeRemoved() throws {
         // GIVEN I am a returning user with an active session
         let date = Date.distantFuture


### PR DESCRIPTION
# refactor: sign out flow

Moving the sign out functionality to the SettingCoordinator and removing redundant code from the `resumeSession()` API.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
~- [ ] Met all of the acceptance criteria specified in the user story on Jira~
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
