### PR TITLE
fix: remove saved_doc_type from analytics parameters

### DIFF
--- a/Sources/Extensions/Dictionary+OneLogin.swift
+++ b/Sources/Extensions/Dictionary+OneLogin.swift
@@ -2,7 +2,6 @@ import Foundation
 
 extension Dictionary where Key == String, Value == Any {
     static let oneLoginDefaults = [
-        "saved_doc_type": "undefined",
         "primary_publishing_organisation": "government digital service - digital identity",
         "organisation": "<OT1056>",
         "taxonomy_level1": "one login mobile application",


### PR DESCRIPTION
# fix: remove saved_doc_type from analytics parameters

Removing parameter set for `saved_doc_type`.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
~- [ ] Written Unit and Integration tests if needed~

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
