### PR TITLE
fix: remove guard let for optional persistent session id

### DIFF
--- a/Sources/Tabs/WalletCoordinator.swift
+++ b/Sources/Tabs/WalletCoordinator.swift
@@ -39,14 +39,10 @@ final class WalletCoordinator: NSObject,
         root.tabBarItem = UITabBarItem(title: GDSLocalisedString(stringLiteral: "app_tabBarWallet").value,
                                        image: UIImage(systemName: "wallet.pass"),
                                        tag: 1)
-        guard let persistentID = sessionManager.persistentID else {
-            analyticsService.logCrash(SecureStoreError.unableToRetrieveFromUserDefaults)
-            return
-        }
         let walletConfig = WalletConfigV2(
             environment: WalletEnvironment(buildConfiguration: AppEnvironment.buildConfiguration.lowercased()),
             clientID: AppEnvironment.stsClientID,
-            persistentSessionID: persistentID
+            persistentSessionID: sessionManager.persistentID
         )
         let walletServices = WalletServices(
             networkClient: WalletNetworkClientWrapper(networkClient: networkClient,

--- a/Tests/UnitTests/Tabs/WalletCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/WalletCoordinatorTests.swift
@@ -31,8 +31,6 @@ final class WalletCoordinatorTests: XCTestCase {
 
 extension WalletCoordinatorTests {
     func test_tabBarItem() throws {
-        // GIVEN there is a persisten session ID
-        mockSessionManager.persistentID = "123456789"
         // WHEN the WalletCoordinator has started
         sut.start()
         // THEN the bar button item of the root is correctly configured
@@ -42,14 +40,6 @@ extension WalletCoordinatorTests {
         XCTAssertEqual(sut.root.tabBarItem.title, walletTab.title)
         XCTAssertEqual(sut.root.tabBarItem.image, walletTab.image)
         XCTAssertEqual(sut.root.tabBarItem.tag, walletTab.tag)
-    }
-    
-    func test_noPersistenIDError() {
-        // GIVEN there is no persisten session ID
-        mockSessionManager.persistentID = nil
-        // WHEN the WalletCoordinator has started
-        sut.start()
-        XCTAssertEqual(mockAnalyticsService.crashesLogged, [SecureStoreError.unableToRetrieveFromUserDefaults as NSError])
     }
     
     func test_didBecomeSelected() {


### PR DESCRIPTION
# fix: remove guard let for optional persistent session id

Removing a guard let for the optional persistent session id property of the WalletConfigV2.

## Evidence:

https://github.com/user-attachments/assets/8e306610-a074-47d4-9a62-73e988a4dd7a

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
~- [ ] Met all of the acceptance criteria specified in the user story on Jira~
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
