### PR TITLE
feat: rework app integrity errors

### DIFF
--- a/AppIntegrity/Sources/AppIntegrity/FirebaseAppIntegrityService.swift
+++ b/AppIntegrity/Sources/AppIntegrity/FirebaseAppIntegrityService.swift
@@ -2,7 +2,7 @@ import FirebaseAppCheck
 import FirebaseCore
 import Networking
 
-public struct AppIntegrityError: Error, LocalizedError {
+public struct AppIntegrityError: Error, LocalizedError, Equatable {
     public enum AppIntegrityErrorType {
         case unknown
         case network
@@ -15,15 +15,14 @@ public struct AppIntegrityError: Error, LocalizedError {
     }
     
     public let errorType: AppIntegrityErrorType
-    let underlyingReason: String
-    public var errorDescription: String? { underlyingReason }
+    public var errorDescription: String?
     
-    init(
+    public init(
         _ errorType: AppIntegrityErrorType,
         underlyingReason: String
     ) {
         self.errorType = errorType
-        self.underlyingReason = underlyingReason
+        self.errorDescription = underlyingReason
     }
 }
 

--- a/AppIntegrity/Sources/AppIntegrity/FirebaseAppIntegrityService.swift
+++ b/AppIntegrity/Sources/AppIntegrity/FirebaseAppIntegrityService.swift
@@ -3,7 +3,7 @@ import FirebaseCore
 import Networking
 
 public struct AppIntegrityError: Error, LocalizedError, Equatable {
-    public enum AppIntegrityErrorType {
+    public enum AppIntegrityErrorType: String {
         case unknown
         case network
         case invalidConfiguration
@@ -16,7 +16,8 @@ public struct AppIntegrityError: Error, LocalizedError, Equatable {
     }
     
     public let errorType: AppIntegrityErrorType
-    public var errorDescription: String?
+    public let errorDescription: String?
+    public let failureReason: String?
     
     public init(
         _ errorType: AppIntegrityErrorType,
@@ -24,6 +25,7 @@ public struct AppIntegrityError: Error, LocalizedError, Equatable {
     ) {
         self.errorType = errorType
         self.errorDescription = underlyingReason
+        self.failureReason = errorType.rawValue
     }
 }
 

--- a/AppIntegrity/Sources/AppIntegrity/FirebaseAppIntegrityService.swift
+++ b/AppIntegrity/Sources/AppIntegrity/FirebaseAppIntegrityService.swift
@@ -12,6 +12,7 @@ public struct AppIntegrityError: Error, LocalizedError, Equatable {
         case generic
         case invalidPublicKey
         case invalidToken
+        case serverError
     }
     
     public let errorType: AppIntegrityErrorType
@@ -98,7 +99,11 @@ public final class FirebaseAppIntegrityService: AppIntegrityProvider {
                 throw AppIntegrityError(.invalidPublicKey, underlyingReason: error.localizedDescription)
             } catch let error as ServerError where
                         error.errorCode == 401 {
+                // potential for a server error or invalid app check token from mobile backend
                 throw AppIntegrityError(.invalidToken, underlyingReason: error.localizedDescription)
+            } catch let error as ServerError where
+                        error.errorCode == 500 {
+                throw AppIntegrityError(.serverError, underlyingReason: error.localizedDescription)
             }
         }
     }

--- a/AppIntegrity/Tests/AppIntegrity/FirebaseAppIntegrityServiceTests.swift
+++ b/AppIntegrity/Tests/AppIntegrity/FirebaseAppIntegrityServiceTests.swift
@@ -59,7 +59,12 @@ struct FirebaseAppIntegrityServiceTests {
             (Data(), HTTPURLResponse(statusCode: 401))
         }
 
-        await #expect(throws: AppIntegrityError.invalidToken) {
+        await #expect(
+            throws: AppIntegrityError(
+                .invalidToken,
+                underlyingReason: "The operation couldn’t be completed. (Networking.ServerError error 1.)"
+            )
+        ) {
             try await sut.integrityAssertions
         }
     }
@@ -72,7 +77,12 @@ struct FirebaseAppIntegrityServiceTests {
             (Data(), HTTPURLResponse(statusCode: 400))
         }
 
-        await #expect(throws: AppIntegrityError.invalidPublicKey) {
+        await #expect(
+            throws: AppIntegrityError(
+                .invalidPublicKey,
+                underlyingReason: "The operation couldn’t be completed. (Networking.ServerError error 1.)"
+            )
+        ) {
             try await sut.integrityAssertions
         }
     }

--- a/AppIntegrity/Tests/AppIntegrity/FirebaseAppIntegrityServiceTests.swift
+++ b/AppIntegrity/Tests/AppIntegrity/FirebaseAppIntegrityServiceTests.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable:next type_body_length
 @testable import AppIntegrity
 import FirebaseAppCheck
 import FirebaseCore

--- a/AppIntegrity/Tests/AppIntegrity/FirebaseAppIntegrityServiceTests.swift
+++ b/AppIntegrity/Tests/AppIntegrity/FirebaseAppIntegrityServiceTests.swift
@@ -1,4 +1,4 @@
-// swiftlint:disable:next type_body_length
+// swiftlint:disable type_body_length
 @testable import AppIntegrity
 import FirebaseAppCheck
 import FirebaseCore
@@ -313,3 +313,4 @@ struct FirebaseAppIntegrityServiceTests {
         #expect(response.expiryDate < Date().addingTimeInterval(expiresIn))
     }
 }
+// swiftlint:disable type_body_length

--- a/AppIntegrity/Tests/AppIntegrity/FirebaseAppIntegrityServiceTests.swift
+++ b/AppIntegrity/Tests/AppIntegrity/FirebaseAppIntegrityServiceTests.swift
@@ -150,6 +150,24 @@ struct FirebaseAppIntegrityServiceTests {
     }
     
     @Test("""
+          Check that 500 throws txma server error
+          """)
+    func testAssertIntegrity500() async throws {
+        MockURLProtocol.handler = {
+            (Data(), HTTPURLResponse(statusCode: 500))
+        }
+
+        await #expect(
+            throws: AppIntegrityError(
+                .serverError,
+                underlyingReason: "The operation couldn’t be completed. (Networking.ServerError error 1.)"
+            )
+        ) {
+            try await sut.integrityAssertions
+        }
+    }
+    
+    @Test("""
           Check that 401 throws invalid token error
           """)
     func testAssertIntegrity401() async throws {

--- a/AppIntegrity/Tests/AppIntegrity/FirebaseAppIntegrityServiceTests.swift
+++ b/AppIntegrity/Tests/AppIntegrity/FirebaseAppIntegrityServiceTests.swift
@@ -313,4 +313,3 @@ struct FirebaseAppIntegrityServiceTests {
         #expect(response.expiryDate < Date().addingTimeInterval(expiresIn))
     }
 }
-// swiftlint:enable type_body_length

--- a/AppIntegrity/Tests/AppIntegrity/FirebaseAppIntegrityServiceTests.swift
+++ b/AppIntegrity/Tests/AppIntegrity/FirebaseAppIntegrityServiceTests.swift
@@ -313,3 +313,4 @@ struct FirebaseAppIntegrityServiceTests {
         #expect(response.expiryDate < Date().addingTimeInterval(expiresIn))
     }
 }
+// swiftlint:enable type_body_length

--- a/AppIntegrity/Tests/AppIntegrity/FirebaseAppIntegrityServiceTests.swift
+++ b/AppIntegrity/Tests/AppIntegrity/FirebaseAppIntegrityServiceTests.swift
@@ -313,4 +313,4 @@ struct FirebaseAppIntegrityServiceTests {
         #expect(response.expiryDate < Date().addingTimeInterval(expiresIn))
     }
 }
-// swiftlint:disable type_body_length
+// swiftlint:enable type_body_length

--- a/AppIntegrity/Tests/AppIntegrity/Mocks/MockAppCheckVendor.swift
+++ b/AppIntegrity/Tests/AppIntegrity/Mocks/MockAppCheckVendor.swift
@@ -3,6 +3,7 @@ import FirebaseAppCheck
 
 final class MockAppCheckVendor: AppCheckVendor {
     private(set) static var wasConfigured: (any AppCheckProviderFactory)?
+    var errorFromLimitedUseToken: Error?
 
     static func setAppCheckProviderFactory(_ factory: (any AppCheckProviderFactory)?) {
         self.wasConfigured = factory
@@ -16,6 +17,9 @@ final class MockAppCheckVendor: AppCheckVendor {
     }
     
     func limitedUseToken() async throws -> AppCheckToken {
-        AppCheckToken(token: "abc", expirationDate: .distantFuture)
+        if let errorFromLimitedUseToken {
+            throw errorFromLimitedUseToken
+        }
+        return AppCheckToken(token: "abc", expirationDate: .distantFuture)
     }
 }

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -45,7 +45,7 @@
 		41E1A9132BE1278F0034B6C7 /* MockNetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41E1A9122BE1278F0034B6C7 /* MockNetworkMonitor.swift */; };
 		41E1A9152BE128610034B6C7 /* MockURLOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41E1A9142BE128610034B6C7 /* MockURLOpener.swift */; };
 		41FF35AC2B21F1AA00419DB3 /* GenericErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41FF35AB2B21F1AA00419DB3 /* GenericErrorViewModel.swift */; };
-		41FF35AF2B222CAC00419DB3 /* AuthenticationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B3207A2B063CA100FECDF0 /* AuthenticationServiceTests.swift */; };
+		41FF35AF2B222CAC00419DB3 /* WebAuthenticationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B3207A2B063CA100FECDF0 /* WebAuthenticationServiceTests.swift */; };
 		7C47BE162C7883B800DCE5D2 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C47BE152C7883B800DCE5D2 /* User.swift */; };
 		7C47BE182C7883DB00DCE5D2 /* IDTokenUserRepresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C47BE172C7883DB00DCE5D2 /* IDTokenUserRepresentation.swift */; };
 		7C59BFA42C986E6800F1C37A /* Array+OneLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C59BFA32C986E6800F1C37A /* Array+OneLogin.swift */; };
@@ -486,7 +486,7 @@
 		C8B05F442B7AA7B3009D4283 /* LocalizedEnglishStringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizedEnglishStringTests.swift; sourceTree = "<group>"; };
 		C8B05F462B7AA816009D4283 /* LocalizedWelshStringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizedWelshStringTests.swift; sourceTree = "<group>"; };
 		C8B320782B062F9100FECDF0 /* WebAuthenticationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebAuthenticationService.swift; sourceTree = "<group>"; };
-		C8B3207A2B063CA100FECDF0 /* AuthenticationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationServiceTests.swift; sourceTree = "<group>"; };
+		C8B3207A2B063CA100FECDF0 /* WebAuthenticationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebAuthenticationServiceTests.swift; sourceTree = "<group>"; };
 		C8B5EFC42B0E53EE004EA4D4 /* XCTestCase+TestExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+TestExtensions.swift"; sourceTree = "<group>"; };
 		C8B825C22B98C34A00336146 /* LoginCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginCoordinator.swift; sourceTree = "<group>"; };
 		C8BACAF22B4DCC2D00530419 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
@@ -1176,7 +1176,7 @@
 		C8520C2C2AE2C546006790C1 /* Login */ = {
 			isa = PBXGroup;
 			children = (
-				C8B3207A2B063CA100FECDF0 /* AuthenticationServiceTests.swift */,
+				C8B3207A2B063CA100FECDF0 /* WebAuthenticationServiceTests.swift */,
 				C81ECB1F2B71768500AFC3A6 /* EnrolmentCoordinatorTests.swift */,
 				C8454A8E2B99D1BC000F9ED0 /* LoginCoordinatorTests.swift */,
 				C8C3439C2B921E3C00E92FB9 /* OnboardingCoordinatorTests.swift */,
@@ -2261,7 +2261,7 @@
 				C84E8F622CFF1DF500639098 /* AppIntegrityJWTTests.swift in Sources */,
 				7CB5BD902C948C7900ABAE4C /* AppQualifyingServiceTests.swift in Sources */,
 				C8BFE5EB2CB5818B00FA9A35 /* AppUnavailableViewModelTests.swift in Sources */,
-				41FF35AF2B222CAC00419DB3 /* AuthenticationServiceTests.swift in Sources */,
+				41FF35AF2B222CAC00419DB3 /* WebAuthenticationServiceTests.swift in Sources */,
 				41C8E42F2B72920F0063B8A3 /* BiometricsEnrolmentViewModelTests.swift in Sources */,
 				C8D678222C540297000AA26C /* DataDeletedWarningViewModelTests.swift in Sources */,
 				C86E223E2BE108140085453F /* DeveloperMenuViewControllerTests.swift in Sources */,

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -129,9 +129,15 @@ final class LoginCoordinator: NSObject,
                 showNetworkConnectionErrorScreen { [unowned self] in
                     returnFromErrorScreen()
                 }
-            } catch let error as AppIntegrityError where error.errorType == .generic,
-                    let error as AppIntegrityError where error.errorType == .notSupported,
-                    let error as AppIntegrityError where error.errorType == .keychainAccess {
+            } catch let error as AppIntegrityError where error.errorType == .unknown,
+                    let error as AppIntegrityError where error.errorType == .generic,
+                    let error as AppIntegrityError where error.errorType == .invalidToken,
+                    let error as AppIntegrityError where error.errorType == .serverError {
+                showRecoverableErrorScreen(error)
+            } catch let error as AppIntegrityError where error.errorType == .notSupported,
+                    let error as AppIntegrityError where error.errorType == .keychainAccess,
+                    let error as AppIntegrityError where error.errorType == .invalidConfiguration,
+                    let error as AppIntegrityError where error.errorType == .invalidPublicKey {
                 showUnrecoverableErrorScreen(error)
             } catch {
                 showGenericErrorScreen(error)

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -1,3 +1,4 @@
+import AppIntegrity
 import Authentication
 import Coordination
 import GDSAnalytics
@@ -123,6 +124,14 @@ final class LoginCoordinator: NSObject,
                 }
             } catch let error as JWTVerifierError {
                 showRecoverableErrorScreen(error)
+            } catch let error as AppIntegrityError where error.errorType == .network,
+                    let error as AppIntegrityError where error.errorType == .generic {
+                showNetworkConnectionErrorScreen { [unowned self] in
+                    returnFromErrorScreen()
+                }
+            } catch let error as AppIntegrityError where error.errorType == .notSupported,
+                    let error as AppIntegrityError where error.errorType == .keychainAccess {
+                showUnrecoverableErrorScreen(error)
             } catch {
                 showGenericErrorScreen(error)
             }

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -124,12 +124,12 @@ final class LoginCoordinator: NSObject,
                 }
             } catch let error as JWTVerifierError {
                 showRecoverableErrorScreen(error)
-            } catch let error as AppIntegrityError where error.errorType == .network,
-                    let error as AppIntegrityError where error.errorType == .generic {
+            } catch let error as AppIntegrityError where error.errorType == .network {
                 showNetworkConnectionErrorScreen { [unowned self] in
                     returnFromErrorScreen()
                 }
-            } catch let error as AppIntegrityError where error.errorType == .notSupported,
+            } catch let error as AppIntegrityError where error.errorType == .generic,
+                    let error as AppIntegrityError where error.errorType == .notSupported,
                     let error as AppIntegrityError where error.errorType == .keychainAccess {
                 showUnrecoverableErrorScreen(error)
             } catch {

--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -81,6 +81,7 @@ final class LoginCoordinator: NSObject,
         launchAuthenticationService()
     }
     
+    // swiftlint:disable:next function_body_length
     func launchAuthenticationService() {
         loginTask = Task {
             do {

--- a/Sources/Login/WebAuthenticationService.swift
+++ b/Sources/Login/WebAuthenticationService.swift
@@ -32,7 +32,7 @@ final class WebAuthenticationService: AuthenticationService {
         } catch let error as LoginErrorV2 where error.reason == .authorizationAccessDenied {
             try await sessionManager.clearAllSessionData()
             throw error
-        } catch let error as AppIntegrityError where error.errorType != .network {
+        } catch let error as AppIntegrityError {
             analyticsService.logCrash(error)
             throw error
         } catch let error as SecureStoreError {

--- a/Sources/Login/WebAuthenticationService.swift
+++ b/Sources/Login/WebAuthenticationService.swift
@@ -1,3 +1,4 @@
+import AppIntegrity
 import Authentication
 import GDSAnalytics
 import Logging
@@ -30,6 +31,9 @@ final class WebAuthenticationService: AuthenticationService {
             throw error
         } catch let error as LoginErrorV2 where error.reason == .authorizationAccessDenied {
             try await sessionManager.clearAllSessionData()
+            throw error
+        } catch let error as AppIntegrityError where error.errorType != .network {
+            analyticsService.logCrash(error)
             throw error
         } catch let error as SecureStoreError {
             analyticsService.logCrash(error)

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -622,4 +622,3 @@ extension LoginCoordinatorTests {
         XCTAssertTrue(sut.childCoordinators[0] is EnrolmentCoordinator)
     }
  }
-// swiftlint:enable file_length

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -1,4 +1,4 @@
-// swiftlint:disable:next file_length
+// swiftlint:disable file_length
 import AppIntegrity
 import Authentication
 import GDSCommon
@@ -622,3 +622,4 @@ extension LoginCoordinatorTests {
         XCTAssertTrue(sut.childCoordinators[0] is EnrolmentCoordinator)
     }
  }
+// swiftlint:enable file_length

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -1,4 +1,4 @@
-// swiftlint:disable file_length
+// swiftlint:disable:next file_length
 import AppIntegrity
 import Authentication
 import GDSCommon
@@ -622,4 +622,3 @@ extension LoginCoordinatorTests {
         XCTAssertTrue(sut.childCoordinators[0] is EnrolmentCoordinator)
     }
  }
-// swiftlint:enable file_length

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -1,4 +1,5 @@
 // swiftlint:disable file_length
+import AppIntegrity
 import Authentication
 import GDSCommon
 @testable import OneLogin
@@ -169,7 +170,7 @@ extension LoginCoordinatorTests {
     
     @MainActor
     func test_launchAuthenticationService_authInvalidRequest() throws {
-        // GIVEN the authentication session returns a invalidRequest error
+        // GIVEN the authentication session returns an invalidRequest error
         mockSessionManager.errorFromStartSession = LoginErrorV2(reason: .authorizationInvalidRequest)
         // WHEN the LoginCoordinator's launchAuthenticationService method is called
         sut.launchAuthenticationService()
@@ -182,7 +183,7 @@ extension LoginCoordinatorTests {
     
     @MainActor
     func test_launchAuthenticationService_authUnauthorizedClient() throws {
-        // GIVEN the authentication session returns a invalidRequest error
+        // GIVEN the authentication session returns an invalidRequest error
         mockSessionManager.errorFromStartSession = LoginErrorV2(reason: .authorizationUnauthorizedClient)
         // WHEN the LoginCoordinator's launchAuthenticationService method is called
         sut.launchAuthenticationService()
@@ -195,7 +196,7 @@ extension LoginCoordinatorTests {
     
     @MainActor
     func test_launchAuthenticationService_unsupportedResponse() throws {
-        // GIVEN the authentication session returns a invalidRequest error
+        // GIVEN the authentication session returns an invalidRequest error
         mockSessionManager.errorFromStartSession = LoginErrorV2(reason: .authorizationUnsupportedResponseType)
         // WHEN the LoginCoordinator's launchAuthenticationService method is called
         sut.launchAuthenticationService()
@@ -208,7 +209,7 @@ extension LoginCoordinatorTests {
     
     @MainActor
     func test_launchAuthenticationService_authInvalidScope() throws {
-        // GIVEN the authentication session returns a invalidRequest error
+        // GIVEN the authentication session returns an invalidRequest error
         mockSessionManager.errorFromStartSession = LoginErrorV2(reason: .authorizationInvalidScope)
         // WHEN the LoginCoordinator's launchAuthenticationService method is called
         sut.launchAuthenticationService()
@@ -221,7 +222,7 @@ extension LoginCoordinatorTests {
     
     @MainActor
     func test_launchAuthenticationService_temporarilyUnavailable() throws {
-        // GIVEN the authentication session returns a invalidRequest error
+        // GIVEN the authentication session returns an invalidRequest error
         mockSessionManager.errorFromStartSession = LoginErrorV2(reason: .authorizationTemporarilyUnavailable)
         // WHEN the LoginCoordinator's launchAuthenticationService method is called
         sut.launchAuthenticationService()
@@ -234,7 +235,7 @@ extension LoginCoordinatorTests {
     
     @MainActor
     func test_launchAuthenticationService_tokenInvalidRequest() throws {
-        // GIVEN the authentication session returns a invalidRequest error
+        // GIVEN the authentication session returns an invalidRequest error
         mockSessionManager.errorFromStartSession = LoginErrorV2(reason: .tokenInvalidRequest)
         // WHEN the LoginCoordinator's launchAuthenticationService method is called
         sut.launchAuthenticationService()
@@ -247,7 +248,7 @@ extension LoginCoordinatorTests {
     
     @MainActor
     func test_launchAuthenticationService_tokenUnauthorizedClient() throws {
-        // GIVEN the authentication session returns a invalidRequest error
+        // GIVEN the authentication session returns an invalidRequest error
         mockSessionManager.errorFromStartSession = LoginErrorV2(reason: .tokenUnauthorizedClient)
         // WHEN the LoginCoordinator's launchAuthenticationService method is called
         sut.launchAuthenticationService()
@@ -260,7 +261,7 @@ extension LoginCoordinatorTests {
     
     @MainActor
     func test_launchAuthenticationService_tokenInvalidScope() throws {
-        // GIVEN the authentication session returns a invalidRequest error
+        // GIVEN the authentication session returns an invalidRequest error
         mockSessionManager.errorFromStartSession = LoginErrorV2(reason: .tokenInvalidScope)
         // WHEN the LoginCoordinator's launchAuthenticationService method is called
         sut.launchAuthenticationService()
@@ -273,7 +274,7 @@ extension LoginCoordinatorTests {
     
     @MainActor
     func test_launchAuthenticationService_invalidClient() throws {
-        // GIVEN the authentication session returns a invalidRequest error
+        // GIVEN the authentication session returns an invalidRequest error
         mockSessionManager.errorFromStartSession = LoginErrorV2(reason: .tokenInvalidClient)
         // WHEN the LoginCoordinator's launchAuthenticationService method is called
         sut.launchAuthenticationService()
@@ -286,7 +287,7 @@ extension LoginCoordinatorTests {
     
     @MainActor
     func test_launchAuthenticationService_invalidGrant() throws {
-        // GIVEN the authentication session returns a invalidRequest error
+        // GIVEN the authentication session returns an invalidRequest error
         mockSessionManager.errorFromStartSession = LoginErrorV2(reason: .tokenInvalidGrant)
         // WHEN the LoginCoordinator's launchAuthenticationService method is called
         sut.launchAuthenticationService()
@@ -299,7 +300,7 @@ extension LoginCoordinatorTests {
     
     @MainActor
     func test_launchAuthenticationService_unsupportedGrant() throws {
-        // GIVEN the authentication session returns a invalidRequest error
+        // GIVEN the authentication session returns an invalidRequest error
         mockSessionManager.errorFromStartSession = LoginErrorV2(reason: .tokenUnsupportedGrantType)
         // WHEN the LoginCoordinator's launchAuthenticationService method is called
         sut.launchAuthenticationService()
@@ -312,7 +313,7 @@ extension LoginCoordinatorTests {
     
     @MainActor
     func test_launchAuthenticationService_clientError() throws {
-        // GIVEN the authentication session returns a invalidRequest error
+        // GIVEN the authentication session returns an invalidRequest error
         mockSessionManager.errorFromStartSession = LoginErrorV2(reason: .tokenClientError)
         // WHEN the LoginCoordinator's launchAuthenticationService method is called
         sut.launchAuthenticationService()
@@ -325,7 +326,7 @@ extension LoginCoordinatorTests {
     
     @MainActor
     func test_launchAuthenticationService_authServerError() throws {
-        // GIVEN the authentication session returns a invalidRequest error
+        // GIVEN the authentication session returns an invalidRequest error
         mockSessionManager.errorFromStartSession = LoginErrorV2(reason: .authorizationServerError)
         // WHEN the LoginCoordinator's launchAuthenticationService method is called
         sut.launchAuthenticationService()
@@ -348,7 +349,7 @@ extension LoginCoordinatorTests {
     
     @MainActor
     func test_launchAuthenticationService_authUnknownError() throws {
-        // GIVEN the authentication session returns a invalidRequest error
+        // GIVEN the authentication session returns an invalidRequest error
         mockSessionManager.errorFromStartSession = LoginErrorV2(reason: .authorizationUnknownError)
         // WHEN the LoginCoordinator's launchAuthenticationService method is called
         sut.launchAuthenticationService()
@@ -411,7 +412,7 @@ extension LoginCoordinatorTests {
     
     @MainActor
     func test_launchAuthenticationService_jwtFetchError() throws {
-        // GIVEN the authentication session returns a unableToFetchJWKs error
+        // GIVEN the authentication session returns an unableToFetchJWKs error
         mockSessionManager.errorFromStartSession = JWTVerifierError.unableToFetchJWKs
         // WHEN the LoginCoordinator's launchAuthenticationService method is called
         sut.launchAuthenticationService()
@@ -424,7 +425,7 @@ extension LoginCoordinatorTests {
     
     @MainActor
     func test_launchAuthenticationService_jwtVerifyError() throws {
-        // GIVEN the authentication session returns a invalidJWTFormat error
+        // GIVEN the authentication session returns an invalidJWTFormat error
         mockSessionManager.errorFromStartSession = JWTVerifierError.invalidJWTFormat
         // WHEN the LoginCoordinator's launchAuthenticationService method is called
         sut.launchAuthenticationService()
@@ -433,6 +434,58 @@ extension LoginCoordinatorTests {
         let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
         // THEN the visible view controller's view model should be the UnableToLoginErrorViewModel
         XCTAssertTrue(vc.viewModel is RecoverableLoginErrorViewModel)
+    }
+    
+    @MainActor
+    func test_launchAuthenticationService_appIntegrityNetworkError() throws {
+        // GIVEN the authentication session returns an app integrity network error
+        mockSessionManager.errorFromStartSession = AppIntegrityError(.network, underlyingReason: "test reason")
+        // WHEN the LoginCoordinator's launchAuthenticationService method is called
+        sut.launchAuthenticationService()
+        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
+        // THEN the visible view controller should be the GDSErrorScreen
+        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        // THEN the visible view controller's view model should be the NetworkConnectionErrorViewModel
+        XCTAssertTrue(vc.viewModel is NetworkConnectionErrorViewModel)
+    }
+    
+    @MainActor
+    func test_launchAuthenticationService_appIntegrityGenericError() throws {
+        // GIVEN the authentication session returns an app integrity generic error
+        mockSessionManager.errorFromStartSession = AppIntegrityError(.generic, underlyingReason: "test reason")
+        // WHEN the LoginCoordinator's launchAuthenticationService method is called
+        sut.launchAuthenticationService()
+        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
+        // THEN the visible view controller should be the GDSErrorScreen
+        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        // THEN the visible view controller's view model should be the UnrecoverableLoginErrorViewModel
+        XCTAssertTrue(vc.viewModel is UnrecoverableLoginErrorViewModel)
+    }
+    
+    @MainActor
+    func test_launchAuthenticationService_appIntegrityNotSupportedError() throws {
+        // GIVEN the authentication session returns an app integrity not supported error
+        mockSessionManager.errorFromStartSession = AppIntegrityError(.notSupported, underlyingReason: "test reason")
+        // WHEN the LoginCoordinator's launchAuthenticationService method is called
+        sut.launchAuthenticationService()
+        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
+        // THEN the visible view controller should be the GDSErrorScreen
+        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        // THEN the visible view controller's view model should be the UnrecoverableLoginErrorViewModel
+        XCTAssertTrue(vc.viewModel is UnrecoverableLoginErrorViewModel)
+    }
+    
+    @MainActor
+    func test_launchAuthenticationService_appIntegrityKeychainAccessError() throws {
+        // GIVEN the authentication session returns an app integrity keychain access error
+        mockSessionManager.errorFromStartSession = AppIntegrityError(.notSupported, underlyingReason: "test reason")
+        // WHEN the LoginCoordinator's launchAuthenticationService method is called
+        sut.launchAuthenticationService()
+        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
+        // THEN the visible view controller should be the GDSErrorScreen
+        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        // THEN the visible view controller's view model should be the UnrecoverableLoginErrorViewModel
+        XCTAssertTrue(vc.viewModel is UnrecoverableLoginErrorViewModel)
     }
     
     @MainActor

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -450,6 +450,19 @@ extension LoginCoordinatorTests {
     }
     
     @MainActor
+    func test_launchAuthenticationService_appIntegrityUnknownError() throws {
+        // GIVEN the authentication session returns an app integrity unknown error
+        mockSessionManager.errorFromStartSession = AppIntegrityError(.unknown, underlyingReason: "test reason")
+        // WHEN the LoginCoordinator's launchAuthenticationService method is called
+        sut.launchAuthenticationService()
+        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
+        // THEN the visible view controller should be the GDSErrorScreen
+        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        // THEN the visible view controller's view model should be the UnrecoverableLoginErrorViewModel
+        XCTAssertTrue(vc.viewModel is RecoverableLoginErrorViewModel)
+    }
+    
+    @MainActor
     func test_launchAuthenticationService_appIntegrityGenericError() throws {
         // GIVEN the authentication session returns an app integrity generic error
         mockSessionManager.errorFromStartSession = AppIntegrityError(.generic, underlyingReason: "test reason")
@@ -459,7 +472,33 @@ extension LoginCoordinatorTests {
         // THEN the visible view controller should be the GDSErrorScreen
         let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
         // THEN the visible view controller's view model should be the UnrecoverableLoginErrorViewModel
-        XCTAssertTrue(vc.viewModel is UnrecoverableLoginErrorViewModel)
+        XCTAssertTrue(vc.viewModel is RecoverableLoginErrorViewModel)
+    }
+    
+    @MainActor
+    func test_launchAuthenticationService_appIntegrityInvalidTokenError() throws {
+        // GIVEN the authentication session returns an app integrity invalid token error
+        mockSessionManager.errorFromStartSession = AppIntegrityError(.invalidToken, underlyingReason: "test reason")
+        // WHEN the LoginCoordinator's launchAuthenticationService method is called
+        sut.launchAuthenticationService()
+        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
+        // THEN the visible view controller should be the GDSErrorScreen
+        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        // THEN the visible view controller's view model should be the UnrecoverableLoginErrorViewModel
+        XCTAssertTrue(vc.viewModel is RecoverableLoginErrorViewModel)
+    }
+    
+    @MainActor
+    func test_launchAuthenticationService_appIntegrityServerError() throws {
+        // GIVEN the authentication session returns an app integrity server error
+        mockSessionManager.errorFromStartSession = AppIntegrityError(.serverError, underlyingReason: "test reason")
+        // WHEN the LoginCoordinator's launchAuthenticationService method is called
+        sut.launchAuthenticationService()
+        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
+        // THEN the visible view controller should be the GDSErrorScreen
+        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        // THEN the visible view controller's view model should be the UnrecoverableLoginErrorViewModel
+        XCTAssertTrue(vc.viewModel is RecoverableLoginErrorViewModel)
     }
     
     @MainActor
@@ -478,7 +517,33 @@ extension LoginCoordinatorTests {
     @MainActor
     func test_launchAuthenticationService_appIntegrityKeychainAccessError() throws {
         // GIVEN the authentication session returns an app integrity keychain access error
-        mockSessionManager.errorFromStartSession = AppIntegrityError(.notSupported, underlyingReason: "test reason")
+        mockSessionManager.errorFromStartSession = AppIntegrityError(.keychainAccess, underlyingReason: "test reason")
+        // WHEN the LoginCoordinator's launchAuthenticationService method is called
+        sut.launchAuthenticationService()
+        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
+        // THEN the visible view controller should be the GDSErrorScreen
+        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        // THEN the visible view controller's view model should be the UnrecoverableLoginErrorViewModel
+        XCTAssertTrue(vc.viewModel is UnrecoverableLoginErrorViewModel)
+    }
+    
+    @MainActor
+    func test_launchAuthenticationService_appIntegrityInvalidConfigurationError() throws {
+        // GIVEN the authentication session returns an app integrity invalid configuration error
+        mockSessionManager.errorFromStartSession = AppIntegrityError(.invalidConfiguration, underlyingReason: "test reason")
+        // WHEN the LoginCoordinator's launchAuthenticationService method is called
+        sut.launchAuthenticationService()
+        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
+        // THEN the visible view controller should be the GDSErrorScreen
+        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        // THEN the visible view controller's view model should be the UnrecoverableLoginErrorViewModel
+        XCTAssertTrue(vc.viewModel is UnrecoverableLoginErrorViewModel)
+    }
+    
+    @MainActor
+    func test_launchAuthenticationService_appIntegrityInvalidPublicKeyError() throws {
+        // GIVEN the authentication session returns an app integrity invalid public key error
+        mockSessionManager.errorFromStartSession = AppIntegrityError(.invalidPublicKey, underlyingReason: "test reason")
         // WHEN the LoginCoordinator's launchAuthenticationService method is called
         sut.launchAuthenticationService()
         waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)


### PR DESCRIPTION
# feat: rework app integrity errors

Working on AppIntegrityError type in the AppIntegrity package to include additional reasoning and maintaining the underlying error from the Firebase App Check `limitedUseToken()` API. Also handling the errors appropriately in the One Login code and displaying appropriate login error screens. The table for the error paths can be found on Confluence [here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3787195450/GOV.UK+One+Login+app+-+Error+handling#App-integrity-check-failures).

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
