### PR TITLE
fix: updated to use 3.3.0 of networking as a minimum

### DIFF
--- a/AppIntegrity/Package.swift
+++ b/AppIntegrity/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/govuk-one-login/mobile-ios-networking",
-            from: "3.0.0"
+            from: "3.3.0"
         )
     ],
     targets: [

--- a/MobilePlatformServices/Package.swift
+++ b/MobilePlatformServices/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "MobilePlatformServices", targets: ["MobilePlatformServices"])
     ],
     dependencies: [
-        .package(url: "https://github.com/govuk-one-login/mobile-ios-networking", .upToNextMajor(from: "3.0.0"))
+        .package(url: "https://github.com/govuk-one-login/mobile-ios-networking", .upToNextMajor(from: "3.3.0"))
     ],
     targets: [
         .target(name: "MobilePlatformServices", dependencies: [

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -3816,7 +3816,7 @@
 			repositoryURL = "https://github.com/govuk-one-login/mobile-ios-networking";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 3.0.0;
+				minimumVersion = 3.3.0;
 			};
 		};
 		C8A13CA22AFBD07E00FCBD36 /* XCRemoteSwiftPackageReference "mobile-ios-authentication" */ = {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -185,8 +185,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-networking",
       "state" : {
-        "revision" : "204728a8c16acb05bd70f7a64c37610c3aa75110",
-        "version" : "3.1.3"
+        "revision" : "7b538750e13d7710d7315511d7cabaee9b8da694",
+        "version" : "3.3.0"
       }
     },
     {


### PR DESCRIPTION
# Update minimum networking version

Wallet needs functionality in 3.3.0 for better observability of `Networking` ServerErrors. 3.3.0 added conformance of `CustomNSError` to `ServerError` allowing access to the error code from consumers of Networking that depend on it via dependency inversion.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
