### PR TITLE
fix: DCMAW-19202 Calling IDCheck every time Home is displayed

### DIFF
--- a/Sources/Login/LoginCoordinator.swift
+++ b/Sources/Login/LoginCoordinator.swift
@@ -162,10 +162,8 @@ final class LoginCoordinator: NSObject,
             root.present(signOutSuccessful, animated: false)
         case (_, .accountIntervention):
             serviceState = .accountIntervention
-            start()
         case (_, .reauthenticationRequired):
             serviceState = .reauthenticationRequired
-            start()
         case (_, _):
             return
         }

--- a/Sources/Screens/Tabs/HomeViewController.swift
+++ b/Sources/Screens/Tabs/HomeViewController.swift
@@ -68,7 +68,6 @@ final class HomeViewController: BaseViewController {
             viewController: self,
             externalStream: idCheckCardUpdateStream
         )
-        criOrchestrator.continueIdentityCheckIfRequired(over: self)
     }
     
     func listenForCardUpdates() {
@@ -91,6 +90,7 @@ final class HomeViewController: BaseViewController {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        criOrchestrator.continueIdentityCheckIfRequired(over: self)
         let screen = ScreenView(id: HomeAnalyticsScreenID.homeScreen.rawValue,
                                 screen: HomeAnalyticsScreen.homeScreen,
                                 titleKey: navigationTitle.stringKey)


### PR DESCRIPTION
# DCMAW-19202 Calling IDCheck every time Home is displayed

Notes
- If home is displayed before putting the app in the background, the call won't be made when it's brought back. 
- If we get an account intervention first, then it will be called while brought into the foreground.


After Account intervention:
- change password on website while logged in on the app

https://github.com/user-attachments/assets/5737e557-fab8-4d4e-868c-2155dba3c725



# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
