### PR TITLE
feat: DCMAW-18770 mitigate risk of script injection

### DIFF
--- a/.github/workflows/config-test.yml
+++ b/.github/workflows/config-test.yml
@@ -50,9 +50,10 @@ jobs:
           LANG: "en_US.UTF-8"
           GIT_CONFIG_NOSYSTEM: "true"
           GIT_CONFIG_GLOBAL: '${{ github.workspace }}/scripts-configs/override-git-config'
+          CONFIGURATION: ${{ inputs.configuration }}
         run: |
           bundle install
 
-          bundle exec fastlane testWithoutCoverage scheme:"OneLogin${{ inputs.configuration }}" \
-            configuration:"${{ inputs.configuration }}" \
-            testplan:OneLogin${{ inputs.configuration }}Config
+          bundle exec fastlane testWithoutCoverage scheme:"OneLogin${CONFIGURATION}" \
+            configuration:"${CONFIGURATION}" \
+            testplan:"OneLogin${CONFIGURATION}Config"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,8 +68,10 @@ jobs:
           LANG: "en_US.UTF-8"
           GIT_CONFIG_NOSYSTEM: "true"
           GIT_CONFIG_GLOBAL: '${{ github.workspace }}/scripts-configs/override-git-config'
+          GITHUB_REF_DEV: ${GITHUB_REF:-dev}
+          CONFIGURATION: ${{ inputs.configuration }}
         run: |
-          gitbranch=$(echo ${GITHUB_REF:-dev} | sed s/refs\\/heads\\///g)
+          gitbranch=$(echo "${GITHUB_REF_DEV}" | sed s/refs\\/heads\\///g)
           echo Pushed to branch: $gitbranch
 
           bundle install
@@ -85,7 +87,7 @@ jobs:
           echo -n "${{ env.DI_IPV_DCA_MOB_IOS_GITHUB_ACTIONS_V2_AWS_SECRET_AUTH_KEY_P8_ENCODED }}" \
             | base64 --decode -o $APIKEY_PATH
 
-          bundle exec fastlane prerelease configuration:${{ inputs.configuration }} \
+          bundle exec fastlane prerelease configuration:"${CONFIGURATION}" \
             certificate_path:$CERTIFICATE_PATH \
             certificate_password:$CERTIFICATE_PASSWORD \
             apikey_path:$APIKEY_PATH --verbose \

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -52,8 +52,12 @@ jobs:
           LANG: "en_US.UTF-8"
           GIT_CONFIG_NOSYSTEM: "true"
           GIT_CONFIG_GLOBAL: '${{ github.workspace }}/scripts-configs/override-git-config'
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+          GITHUB_EVENT_PATH: $GITHUB_EVENT_PATH
         run: |
-          pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+          pull_number=$(jq --raw-output .pull_request.number "${GITHUB_EVENT_PATH}")
 
           brew install sonar-scanner
           bundle install
@@ -63,16 +67,16 @@ jobs:
             bundle exec fastlane test scheme:"OneLoginBuild" \
               configuration:"Debug" \
               testplan:OneLoginUnit \
-              workspace:${{ github.workspace }} \
+              workspace:"${GITHUB_WORKSPACE}" \
               sonar_token:${{ secrets.SONAR_TOKEN }} \
-              source_branch:${{ github.head_ref }} \
-              target_branch:${{ github.base_ref }} \
+              source_branch:"${GITHUB_HEAD_REF}" \
+              target_branch:"${GITHUB_BASE_REF}" \
               pr_number:$pull_number
           else
             bundle exec fastlane test scheme:"OneLoginBuild" \
               configuration:"Debug" \
               testplan:OneLoginUnit \
-              workspace:${{ github.workspace }} \
+              workspace:"${GITHUB_WORKSPACE}" \
               sonar_token:${{ secrets.SONAR_TOKEN }}
           fi
 


### PR DESCRIPTION
# [Mitigate the risk of a script injection by using an intermediate environment variable](https://govukverify.atlassian.net/browse/DCMAW-18770)

A number of GitHub workflows use user-controlled variables that can be used to inject shell command into an inline script.

<img width="732" height="217" alt="Screenshot 2026-03-19 at 09 07 05" src="https://github.com/user-attachments/assets/72074795-742e-4702-b50e-cf60d5761b9a" />

Specifically:

**The `.github/workflows/deploy.yml` uses:** 
* a [GITHUB_REF](https://docs.github.com/en/actions/reference/workflows-and-actions/variables#default-environment-variables). "For workflows triggered by pull_request that were not merged, this is the pull request merge branch."
* a [GITHUB_EVENT_PATH](https://docs.github.com/en/actions/reference/workflows-and-actions/variables#default-environment-variables). "The path to the file on the runner that contains the full event webhook payload.".
* an [input](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#inputs-context) property, passed into the workflow.
**The `.github/workflows/config-test.yml` uses:** 
* a [github context variable ](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context) to evaluate a number of variables, including the the `head_ref` or _source branch_ of the pull request, the `base_ref` or _target branch_ of the pull request and the `workspace` for the default working directory on the runner for steps in a workflow run
**The `.github/workflows/unit-test.yml` uses:** 
* an [input](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#inputs-context) property, passed into the workflow.

One attack that uses variables as they relate to a pull request is described at https://github.com/govuk-one-login/mobile-ios-authentication/pull/91

It is less clear what the "certain contexts" are as noted by GitHub in their warning or how some of the other user-controlled variables injected into the yaml, inlined on the script and evaluated can allows a malicious actor to execute arbitrary code in the target runner that run the workflow. **In any case,** GitHub lists some [good practices for mitigating script injection attacks](https://docs.github.com/en/actions/reference/security/secure-use#good-practices-for-mitigating-script-injection-attacks).

> For inline scripts, the preferred approach to handling untrusted input is to set the value of the expression to an intermediate environment variable. - [Use an intermediate environment variable](https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable)

## Changes

The proposed changes define every variable used in an inline script as an environment variable that interprets it as a `String`, which is then used verbatim in the inline script.

The proposed code changes also err on the side of caution by: 
* protecting the user-controlled variable before they are being used.
* ensuring every variable that is expected to be expanded and used by an inline script is interpreted as a String and only as a String.

## How these changes where tested

The [open source project act ](https://github.com/nektos/act) allows you to execute a workflow locally. I [created a sample git project with a workflow](https://github.com/qnoid/github-actions) that "mirrors" how a reusable workflow is written, will be called by a job and demonstrates the scenario of a script injection. 

The project contains 2 commits as they relate to this PR. The [first one](https://github.com/qnoid/github-actions/commit/2e1a9e2878909dfcb494d2cb408c246bbcbec5c0), demonstrates the script injection in practice.

<img width="1800" height="1130" alt="compromised_2" src="https://github.com/user-attachments/assets/c406b6f3-80db-4c1d-b936-6a7d143d5595" />

The [second one](https://github.com/qnoid/github-actions/commit/481c07c9ad6975edd7b2656fade0c965815c8f4a), uses an environment variable as recommended by GitHub to mitigate the risk

<img width="1800" height="1130" alt="secure_2" src="https://github.com/user-attachments/assets/61057abe-4808-41b7-bfbe-c5ba4d75cb38" />

## Where to focus the review
* Are the security risk, explanation and solution sound?
* Does the sample project **mirror** the scenarios in every workflow?
* Do the changes in the workflows mitigate the risk as described?

## Heads' up

Since the changes to the each workflow have not been tested under real conditions, it's important to keep an eye on when they run for any potential failures. Looking at the workflows, my best guess is that these will come up in the following use cases:
* When we run unit tests across the different environments (i.e. configurations)
* When we deploy to the App Store

## Related reading
* Act  [Installation](https://nektosact.com/installation/gh.html) and [Usage Guide](https://nektosact.com/usage/index.html)

# Checklist

## Before raising your pull request:
- [x] Update the documentation to reflect your changes
- [ ] Ran the app locally ensuring it builds 
- [ ] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
