### PR TITLE
DCMAW-18499 improve reliability of UI tests

### DIFF
--- a/Tests/UITests/LoginUITests.swift
+++ b/Tests/UITests/LoginUITests.swift
@@ -10,6 +10,7 @@ final class LoginUITests: XCTestCase {
 extension LoginUITests {
     func test_loginHappyPath() throws {
         let sut = try WelcomeScreen.make()
+        sut.waitForUnlockScreenNonExistence()
         sut.agreeIfAnalytics()
         // Welcome Screen
         XCTAssertEqual(sut.title.label, "GOV.UK One Login")
@@ -27,6 +28,7 @@ extension LoginUITests {
     
     func test_loginCancelPath() throws {
         let sut = try WelcomeScreen.make()
+        sut.waitForUnlockScreenNonExistence()
         sut.agreeIfAnalytics()
         // Welcome Screen
         XCTAssertEqual(sut.title.label, "GOV.UK One Login")
@@ -43,6 +45,7 @@ extension LoginUITests {
     
     func test_OAuthLoginError() throws {
         let sut = try WelcomeScreen.make()
+        sut.waitForUnlockScreenNonExistence()
         sut.agreeIfAnalytics()
         // Welcome Screen
         XCTAssertEqual(sut.title.label, "GOV.UK One Login")
@@ -60,6 +63,7 @@ extension LoginUITests {
     
     func test_noAuthCodeError() throws {
         let sut = try WelcomeScreen.make()
+        sut.waitForUnlockScreenNonExistence()
         sut.agreeIfAnalytics()
         // Welcome Screen
         XCTAssertEqual(sut.title.label, "GOV.UK One Login")
@@ -77,6 +81,7 @@ extension LoginUITests {
     
     func test_fourHundredResponseError() throws {
         let sut = try WelcomeScreen.make()
+        sut.waitForUnlockScreenNonExistence()
         sut.agreeIfAnalytics()
         // Welcome Screen
         XCTAssertEqual(sut.title.label, "GOV.UK One Login")
@@ -98,6 +103,7 @@ extension LoginUITests {
     
     func test_fiveHundredResponseError() throws {
         let sut = try WelcomeScreen.make()
+        sut.waitForUnlockScreenNonExistence()
         sut.agreeIfAnalytics()
         // Welcome Screen
         XCTAssertEqual(sut.title.label, "GOV.UK One Login")

--- a/Tests/UITests/LoginUITests.swift
+++ b/Tests/UITests/LoginUITests.swift
@@ -40,7 +40,7 @@ extension LoginUITests {
         XCTAssertEqual(loginModal.loginButton.label, "Login")
         // Select 'Cancel' Button
         loginModal.tapCancelButton()
-        XCTAssertTrue(sut.isVisible)
+        XCTAssertTrue(sut.signInButton.exists)
     }
     
     func test_OAuthLoginError() throws {

--- a/Tests/UITests/LoginUITests.swift
+++ b/Tests/UITests/LoginUITests.swift
@@ -1,39 +1,16 @@
 import XCTest
 
 final class LoginUITests: XCTestCase {
-    var sut: WelcomeScreen!
     
-    override func setUp() async throws {
-        await MainActor.run {
-            sut = WelcomeScreen()
-            guard let debugToken = ProcessInfo.processInfo.environment["FIRAAppCheckDebugToken"] else {
-                preconditionFailure("No Firebase App Check Debug Token passed in environment")
-            }
-            sut.app.launchEnvironment["FIRAAppCheckDebugToken"] = debugToken
-            sut.app.launch()
-            let exp = expectation(description: "Waiting once App has launched")
-            XCTWaiter().wait(for: [exp], timeout: 30)
-        }
-    }
-    
-    override func tearDown() {
-        sut.app.terminate()
-        sut = nil
-    }
-    
-    func agreeIfAnalytics() {
-        if sut.app.staticTexts["Help improve the app by sharing analytics"].exists {
-            let analyticsButton = sut.app.buttons["Share analytics"]
-            XCTAssertTrue(analyticsButton.exists)
-            // Tap Analytics Permission Button
-            analyticsButton.tap()
-        }
+    override func setUp() {
+        continueAfterFailure = false
     }
 }
 
 extension LoginUITests {
     func test_loginHappyPath() throws {
-        agreeIfAnalytics()
+        let sut = try WelcomeScreen.make()
+        sut.agreeIfAnalytics()
         // Welcome Screen
         XCTAssertEqual(sut.title.label, "GOV.UK One Login")
         XCTAssertEqual(sut.body.label, "Prove your identity to access government services.\n\nYou’ll need to sign in with your GOV.UK One Login details.")
@@ -44,13 +21,13 @@ extension LoginUITests {
         XCTAssertEqual(loginModal.loginButton.label, "Login")
         // Select 'Login' Button
         let loadingScreen = loginModal.tapBrowserLoginButton()
-        XCTAssertEqual(loadingScreen.title.label, "Loading")
         let homeScreen = loadingScreen.waitForHomeScreen()
         XCTAssertEqual(homeScreen.titleImage.label, "home")
     }
     
     func test_loginCancelPath() throws {
-        agreeIfAnalytics()
+        let sut = try WelcomeScreen.make()
+        sut.agreeIfAnalytics()
         // Welcome Screen
         XCTAssertEqual(sut.title.label, "GOV.UK One Login")
         XCTAssertEqual(sut.body.label, "Prove your identity to access government services.\n\nYou’ll need to sign in with your GOV.UK One Login details.")
@@ -65,7 +42,8 @@ extension LoginUITests {
     }
     
     func test_OAuthLoginError() throws {
-        agreeIfAnalytics()
+        let sut = try WelcomeScreen.make()
+        sut.agreeIfAnalytics()
         // Welcome Screen
         XCTAssertEqual(sut.title.label, "GOV.UK One Login")
         XCTAssertEqual(sut.body.label, "Prove your identity to access government services.\n\nYou’ll need to sign in with your GOV.UK One Login details.")
@@ -81,7 +59,8 @@ extension LoginUITests {
     }
     
     func test_noAuthCodeError() throws {
-        agreeIfAnalytics()
+        let sut = try WelcomeScreen.make()
+        sut.agreeIfAnalytics()
         // Welcome Screen
         XCTAssertEqual(sut.title.label, "GOV.UK One Login")
         XCTAssertEqual(sut.body.label, "Prove your identity to access government services.\n\nYou’ll need to sign in with your GOV.UK One Login details.")
@@ -97,7 +76,8 @@ extension LoginUITests {
     }
     
     func test_fourHundredResponseError() throws {
-        agreeIfAnalytics()
+        let sut = try WelcomeScreen.make()
+        sut.agreeIfAnalytics()
         // Welcome Screen
         XCTAssertEqual(sut.title.label, "GOV.UK One Login")
         XCTAssertEqual(sut.body.label, "Prove your identity to access government services.\n\nYou’ll need to sign in with your GOV.UK One Login details.")
@@ -117,7 +97,8 @@ extension LoginUITests {
     }
     
     func test_fiveHundredResponseError() throws {
-        agreeIfAnalytics()
+        let sut = try WelcomeScreen.make()
+        sut.agreeIfAnalytics()
         // Welcome Screen
         XCTAssertEqual(sut.title.label, "GOV.UK One Login")
         XCTAssertEqual(sut.body.label, "Prove your identity to access government services.\n\nYou’ll need to sign in with your GOV.UK One Login details.")

--- a/Tests/UITests/ScreenObjects/App/HomeScreen.swift
+++ b/Tests/UITests/ScreenObjects/App/HomeScreen.swift
@@ -10,4 +10,8 @@ struct HomeScreen: ScreenObject {
     var titleImage: XCUIElement {
         app.images.firstMatch
     }
+    
+    var tabBarsFirstMatch: XCUIElement {
+        app.tabBars.firstMatch
+    }
 }

--- a/Tests/UITests/ScreenObjects/App/LoadingScreen.swift
+++ b/Tests/UITests/ScreenObjects/App/LoadingScreen.swift
@@ -12,6 +12,10 @@ struct LoadingScreen: ScreenObject {
     }
     
     func waitForHomeScreen() -> HomeScreen {
-        return HomeScreen(app: app).waitForAppearance()
+        let homeScreen = HomeScreen(app: app)
+        
+        XCTAssertTrue(homeScreen.tabBarsFirstMatch.waitForExistence(timeout: .timeout))
+        
+        return homeScreen
     }
 }

--- a/Tests/UITests/ScreenObjects/App/LoadingScreen.swift
+++ b/Tests/UITests/ScreenObjects/App/LoadingScreen.swift
@@ -14,7 +14,7 @@ struct LoadingScreen: ScreenObject {
     func waitForHomeScreen() -> HomeScreen {
         let homeScreen = HomeScreen(app: app)
         
-        XCTAssertTrue(homeScreen.tabBarsFirstMatch.waitForExistence(timeout: .timeout))
+        XCTAssertTrue(homeScreen.tabBarsFirstMatch.waitForExistence(timeout: .timeout), "\(homeScreen) does no exist")
         
         return homeScreen
     }

--- a/Tests/UITests/ScreenObjects/App/LoginModal.swift
+++ b/Tests/UITests/ScreenObjects/App/LoginModal.swift
@@ -42,7 +42,7 @@ struct LoginModal: ScreenObject {
     func tapBrowserLoginButton() -> LoadingScreen {
         loginButton.tap()
         
-        return LoadingScreen(app: app).waitForAppearance()
+        return LoadingScreen(app: app)
     }
     
     func tapBrowserRedirectWithOAuthErrorButton() -> ErrorScreen {
@@ -67,7 +67,7 @@ struct LoginModal: ScreenObject {
             secondModalScreen.loginButton
         ]
         browserElements.forEach {
-            _ = $0.waitForExistence(timeout: .timeout)
+            XCTAssertTrue($0.waitForExistence(timeout: .timeout), "\($0) exists")
         }
         return secondModalScreen
     }
@@ -82,7 +82,7 @@ struct LoginModal: ScreenObject {
             secondModalScreen.loginButton
         ]
         browserElements.forEach {
-            _ = $0.waitForExistence(timeout: .timeout)
+            XCTAssertTrue($0.waitForExistence(timeout: .timeout), "\($0) exists")
         }
         return secondModalScreen
     }

--- a/Tests/UITests/ScreenObjects/App/LoginModal.swift
+++ b/Tests/UITests/ScreenObjects/App/LoginModal.swift
@@ -48,19 +48,27 @@ struct LoginModal: ScreenObject {
     func tapBrowserRedirectWithOAuthErrorButton() -> ErrorScreen {
         oAuthErrorButton.tap()
         
-        return ErrorScreen(app: app).waitForAppearance()
+        let errorScreen = ErrorScreen(app: app)
+        
+        XCTAssertTrue(errorScreen.title.waitForExistence(timeout: .timeout))
+        
+        return errorScreen
     }
     
     func tapBrowserNoAuthCodeErrorButton() -> ErrorScreen {
         noAuthCodeButton.tap()
         
-        return ErrorScreen(app: app).waitForAppearance()
+        let errorScreen = ErrorScreen(app: app)
+        
+        XCTAssertTrue(errorScreen.title.waitForExistence(timeout: .timeout))
+        
+        return errorScreen
     }
     
     func tapBrowserFourHundredResponseErrorButton() -> LoginModalSecondScreen {
         fourHundredResponseErrorButton.tap()
         
-        let secondModalScreen = LoginModalSecondScreen(app: app).waitForAppearance()
+        let secondModalScreen = LoginModalSecondScreen(app: app)
         let browserElements = [
             secondModalScreen.view,
             secondModalScreen.title,
@@ -75,7 +83,7 @@ struct LoginModal: ScreenObject {
     func tapBrowserFiveHundredResponseErrorButton() -> LoginModalSecondScreen {
         fiveHundredResponseErrorButton.tap()
         
-        let secondModalScreen = LoginModalSecondScreen(app: app).waitForAppearance()
+        let secondModalScreen = LoginModalSecondScreen(app: app)
         let browserElements = [
             secondModalScreen.view,
             secondModalScreen.title,

--- a/Tests/UITests/ScreenObjects/App/LoginModalSecondScreen.swift
+++ b/Tests/UITests/ScreenObjects/App/LoginModalSecondScreen.swift
@@ -18,6 +18,11 @@ struct LoginModalSecondScreen: ScreenObject {
     func tapBrowserLoginButton() -> ErrorScreen {
         loginButton.tap()
         
-        return ErrorScreen(app: app).waitForAppearance()
+        let errorScreen = ErrorScreen(app: app)
+        
+        XCTAssertTrue(errorScreen.title.waitForExistence(timeout: .timeout))
+        
+        return errorScreen
+
     }
 }

--- a/Tests/UITests/ScreenObjects/App/WelcomeScreen.swift
+++ b/Tests/UITests/ScreenObjects/App/WelcomeScreen.swift
@@ -70,7 +70,7 @@ struct WelcomeScreen: ScreenObject {
             loginModal.fiveHundredResponseErrorButton
         ]
         browserElements.forEach {
-            XCTAssertTrue($0.waitForExistence(timeout: .timeout), "\($0) exists")
+            XCTAssertTrue($0.waitForExistence(timeout: .timeout), "\($0) does no exist")
         }
         return loginModal
     }

--- a/Tests/UITests/ScreenObjects/App/WelcomeScreen.swift
+++ b/Tests/UITests/ScreenObjects/App/WelcomeScreen.swift
@@ -37,6 +37,11 @@ struct WelcomeScreen: ScreenObject {
         app.buttons["intro-button"]
     }
     
+    func waitForUnlockScreenNonExistence() {
+        XCTAssertTrue(self.app.staticTexts["unlock-screen-loading-label"].waitForNonExistence(timeout: .timeout),
+                      "Loading Screen took longer than \(TimeInterval.timeout) to dismiss")
+    }
+    
     func agreeIfAnalytics() {
         let analyticsScreen = app.staticTexts["Help improve the app by sharing analytics"]
         

--- a/Tests/UITests/ScreenObjects/App/WelcomeScreen.swift
+++ b/Tests/UITests/ScreenObjects/App/WelcomeScreen.swift
@@ -1,7 +1,25 @@
 import XCTest
 
 struct WelcomeScreen: ScreenObject {
-    let app = XCUIApplication()
+    
+    static func make() throws -> WelcomeScreen {
+        let app = XCUIApplication()
+        let welcomeScreen = WelcomeScreen(app: app)
+        guard let debugToken = ProcessInfo.processInfo.environment["FIRAAppCheckDebugToken"] else {
+            preconditionFailure("No Firebase App Check Debug Token passed in environment")
+        }
+        app.launchEnvironment["FIRAAppCheckDebugToken"] = debugToken
+        app.launch()
+        
+        guard app.wait(for: .runningForeground, timeout: 10) else {
+            XCTFail("Failed to launch the app and have it running in the foreground")
+            return welcomeScreen
+        }
+        
+        return welcomeScreen
+    }
+    
+    let app: XCUIApplication
     
     var view: XCUIElement {
         app.scrollViews.firstMatch
@@ -19,10 +37,24 @@ struct WelcomeScreen: ScreenObject {
         app.buttons["intro-button"]
     }
     
+    func agreeIfAnalytics() {
+        let analyticsScreen = app.staticTexts["Help improve the app by sharing analytics"]
+        
+        let analyticsScreenExists = analyticsScreen.waitForExistence(timeout: .timeout)
+        
+        if analyticsScreenExists {
+            let analyticsButton = app.buttons["Share analytics"]
+            XCTAssertTrue(analyticsButton.exists)
+            // Tap Analytics Permission Button
+            analyticsButton.tap()
+        }
+    }
+
+    
     func tapLoginButton() -> LoginModal {
         signInButton.tap()
         
-        let loginModal = LoginModal(app: app).waitForAppearance()
+        let loginModal = LoginModal(app: app)
         let browserElements = [
             loginModal.view,
             loginModal.title,
@@ -33,7 +65,7 @@ struct WelcomeScreen: ScreenObject {
             loginModal.fiveHundredResponseErrorButton
         ]
         browserElements.forEach {
-            _ = $0.waitForExistence(timeout: .timeout)
+            XCTAssertTrue($0.waitForExistence(timeout: .timeout), "\($0) exists")
         }
         return loginModal
     }

--- a/Tests/UITests/ScreenObjects/ScreenObject.swift
+++ b/Tests/UITests/ScreenObjects/ScreenObject.swift
@@ -7,10 +7,5 @@ protocol ScreenObject {
 extension ScreenObject {
     var isVisible: Bool {
         view.isHittable
-    }
-    
-    func waitForAppearance(timeout: TimeInterval = .timeout) -> Self {
-        _ = view.waitForExistence(timeout: timeout)
-        return self
-    }
+    }    
 }

--- a/Tests/UITests/ScreenObjects/ScreenObject.swift
+++ b/Tests/UITests/ScreenObjects/ScreenObject.swift
@@ -7,5 +7,5 @@ protocol ScreenObject {
 extension ScreenObject {
     var isVisible: Bool {
         view.isHittable
-    }    
+    }
 }


### PR DESCRIPTION
# [Improve reliability of UI Tests](https://govukverify.atlassian.net/browse/DCMAW-18499)

This PR ensures that UI Tests run as expected before expanding on their test coverage.
The proposed changes in this PR improve the reliability of UI Tests and in case of a failure, reduce the time it takes to report on it. Specifically, how long the [Manual UI Test](https://github.com/govuk-one-login/mobile-ios-one-login-app/actions/workflows/nightly-ui-test.yml) workflow runs.

As an example, the last run took 14 minutes to report on the UI Tests failing.
<img width="1912" height="1242" alt="Screenshot 2026-03-25 at 14 47 26" src="https://github.com/user-attachments/assets/3325f5be-bb52-4575-a218-74d45b2128da" />


As an example[^1] here is a failed run with the proposed code changes
<img width="1912" height="1242" alt="image" src="https://github.com/user-attachments/assets/8fe076f9-6a2a-41ea-ab81-4159b7c400d6" />

[^1]: It's worth pointing out that this is not a direct comparison since the two environments (the Github runner and my laptop) are not identical but the factor between 4 and 14 minutes should give a good indication of the improvements we should expect to see.

# Changes

**This PR does not make any code changes to the application code**

At a high level, here are the changes for the **UITests**:

* Stop execution after failure so that the test process fails as soon as possible to avoid running in excess
* Deterministically wait for the app to be running on the foreground rather than at an arbitary time limit
    * ensure that each test uses its own instance of the `XCUIApplication` to operate to provide stronger guarantees on the state it operates
* Add assertions on wait for existence calls so as to fail early
* Add wait for the lock screen to disappear as a GIVEN for every test
* Add wait for existence calls where required (i.e. waiting for a *specific* element to appear on screen, say a tabbar for home, rather than a broader one like "any" view)

## test_loginHappyPath

This test scenario would sometimes fail because the "Loading" label does "exist" in the UI test. Looking at the video of a failed UI Test and by reviewing the application code, such case occurs where the "Loading" view controller is replaced **before** it can become available as a `XCUIElement`.

## test_loginCancelPath

This test scenario would sometimes fail because the assertion on the scroll view was on whether or not it was "hittable". Instead will now assert that the signInButton *exists* as a way to verify that the sign in screen is shown when cancel is tapped. This is a more reliable way than a scroll view being "hittable" as it is more lenient than requiring the view to exist *and* can be clicked, tapped, or pressed at its current location.

# Testing
<img width="747" height="431" alt="Screenshot 2026-03-25 at 18 43 47" src="https://github.com/user-attachments/assets/fa91321d-0804-4d1f-a433-2d8881cbaa2e" />

## Streak of runs
1. [Manual UI Test #135](https://github.com/govuk-one-login/mobile-ios-one-login-app/actions/runs/23553118518) ✅
2. [Manual UI Test #137](https://github.com/govuk-one-login/mobile-ios-one-login-app/actions/runs/23582117418)✅
3. [Manual UI Test #138](https://github.com/govuk-one-login/mobile-ios-one-login-app/actions/runs/23609499388)✅
4. [Manual UI Test #140](https://github.com/govuk-one-login/mobile-ios-one-login-app/actions/runs/23635396175) ❌ - failed. That highlighted an issue where the UI Tests are not actually waiting for Home Screen to exist. Commit https://github.com/govuk-one-login/mobile-ios-one-login-app/commit/ba9d3ed28c5e4271bbb362c61bc9eb9b169af1a7 fixes that
5. [Manual UI Test #141](https://github.com/govuk-one-login/mobile-ios-one-login-app/actions/runs/23637963437)❌ - failed. That highlighted an issue where the UI Tests are not actually waiting for the unlock loading screen, after launch, to disappear. Commit https://github.com/govuk-one-login/mobile-ios-one-login-app/commit/7eee69a1fab00bcb003dcb8eca94234e189ab5e4 fixes that
6. [Manual UI Test #142](https://github.com/govuk-one-login/mobile-ios-one-login-app/actions/runs/23641911180)✅
7. [Manual UI Test #144](https://github.com/govuk-one-login/mobile-ios-one-login-app/actions/runs/23679974484)✅
8. [Manual UI Test #145](https://github.com/govuk-one-login/mobile-ios-one-login-app/actions/runs/23684036898)✅
9. [Manual UI Test #147](https://github.com/govuk-one-login/mobile-ios-one-login-app/actions/runs/23705121419)✅
10. [Manual UI Test #149](https://github.com/govuk-one-login/mobile-ios-one-login-app/actions/runs/23733551710)❌ - failed. That highlighted an issue where the unlock/loading view controller would [not disappear as expected](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/13dac64538799024cd9b3018684058038a2f1ed6/Tests/UITests/LoginUITests.swift#L48) for [at least 10 seconds](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/13dac64538799024cd9b3018684058038a2f1ed6/Tests/UITests/ScreenObjects/App/WelcomeScreen.swift#L41). See **failure waitForUnlockScreenNonExistence** below.
11. [Manual UI Test #151](https://github.com/govuk-one-login/mobile-ios-one-login-app/actions/runs/23783401765)✅
12. [Manual UI Test #152](https://github.com/govuk-one-login/mobile-ios-one-login-app/actions/runs/23787777578) ✅

# Failure `waitForUnlockScreenNonExistence`
UI Testing has revealed a scenario where the unlock/loading view controller would not disappear as expected for at least 10 seconds. This scenario is applicable when the app launches and the user session is in the `.notLoggedIn` state. 

https://github.com/user-attachments/assets/348bf36f-6e83-4429-999d-1a74805b1a92

In this scenario, the unlock screen will remain on screen for as long as 30 seconds before progressing to the login screen. In short, this seems to be caused because the main thread is blocked while Firebase starts up. Here is my long take:

The [`evaluateUserSession`](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.18.0/Sources/Qualification/State/AppQualifyingService.swift#L100) is required to run on the MainActor. This is the code that ultimately replaces the unlock with the login view.

Once the `evaluateUserSession` runs:
* It sets the `sessionState = .notLoggedIn` in [AppQualifyingService.swift#L110](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.18.0/Sources/Qualification/State/AppQualifyingService.swift#L110)
* Which calls the [delegate](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.18.0/Sources/Qualification/State/AppQualifyingService.swift#L38)
*  Which [launches the login coordinator](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.18.0/Sources/Qualification/QualifyingCoordinator.swift#L101)
* And [displays it](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.18.0/Sources/Qualification/QualifyingCoordinator.swift#L150)
* * By [starting the login coordinator](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.18.0/Sources/Qualification/QualifyingCoordinator.swift#L183C9-L183C18), replacing the rootViewController in the application window and hiding the [lock window](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.18.0/Sources/Qualification/QualifyingCoordinator.swift#L188), 

This method is called, [on application launch](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/8eec8a61328b1e14b0891d367d9e0d596498e121/Sources/Application/SceneDelegate.swift#L85), as part of a Task in the [`initiate`](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.18.0/Sources/Qualification/State/AppQualifyingService.swift#L65) which requires to await for the main thread to become available to run on the actor.

Effectively, **as long as the main thread is blocked/busy, this code will never execute.**

On application launch:
* the AppDelegate [calls configure](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.18.0/Sources/Application/AppDelegate.swift#L11) on the GAnalytics (i.e. `FIRApp`).
* Firebase attempts to [instantiate its components](https://github.com/firebase/firebase-ios-sdk/blob/12.9.0/FirebaseCore/Sources/FIRApp.m#L191), that includes [Crashlytics with Remote Config](https://github.com/firebase/firebase-ios-sdk/blob/12.9.0/Crashlytics/Crashlytics/FIRCrashlytics.m#L237)
* Remote config, both as part of its initialisation and any subsequent database operations, will:
* * [Wait for a database to be created/opened](https://github.com/firebase/firebase-ios-sdk/blob/12.9.0/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m#L166C17-L166C46)
* * [Wait for the data to be loaded in the database](https://github.com/firebase/firebase-ios-sdk/blob/12.9.0/FirebaseRemoteConfig/Sources/RCNConfigContent.m#L421) before attempting any operations. This wait will timeout after [30 seconds](https://github.com/firebase/firebase-ios-sdk/blob/12.9.0/FirebaseRemoteConfig/Sources/RCNConfigContent.m#L60).

As far as I can see, all these calls do not make any guarantees to NOT run on the main thread. As far as I can tell, they will run on whatever thread the call on `FIRApp#configure:` was made. In our case, the main thread.

The main risk I see is that Firebase will block the main thread long enough for [the watchdog to kill the app](https://developer.apple.com/documentation/xcode/addressing-watchdog-terminations). Having said that, I checked the Crashalytics logs for any crashes as they relate to the watchdog and didn't find any.

It's possible this is a scenario only manifests on the Github runners. Given how their available resources are limited and vary depending on availability. In other words, the conditions under which a device in the real world will be terminated will depend on the resources (i.e. available disk space, CPU) on the device and how constrained it is at the time of launch.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
