### PR TITLE
fix: DCMAW-14902 update error screen copy

### DIFF
--- a/Sources/Qualification/QualifyingCoordinator.swift
+++ b/Sources/Qualification/QualifyingCoordinator.swift
@@ -102,13 +102,12 @@ final class QualifyingCoordinator: NSObject,
         case .localAuthCancelled:
             unlockViewController.isLoading = false
         case .failed(let error):
-            let viewModel = RecoverableLoginErrorViewModel(
+            analyticsService.logCrash(error)
+            
+            let viewModel = UnrecoverableLoginErrorViewModel(
                 analyticsService: analyticsService,
                 errorDescription: error.localizedDescription
-            ) { [unowned self] in
-                analyticsService.logCrash(error)
-                fatalError("We were unable to resume the session, there's not much we can do to help the user")
-            }
+            )
             let unableToLoginErrorScreen = GDSErrorScreen(viewModel: viewModel)
             displayViewController(unableToLoginErrorScreen)
         case .appIntegrityCheckFailed:

--- a/Tests/UnitTests/Qualification/QualifyingCoordinatorTests.swift
+++ b/Tests/UnitTests/Qualification/QualifyingCoordinatorTests.swift
@@ -167,7 +167,7 @@ extension QualifyingCoordinatorTests {
         let vc = try XCTUnwrap(
             window.rootViewController as? GDSErrorScreen
         )
-        let viewModel = try XCTUnwrap(vc.viewModel as? RecoverableLoginErrorViewModel)
+        let viewModel = try XCTUnwrap(vc.viewModel as? UnrecoverableLoginErrorViewModel)
         XCTAssertEqual(viewModel.errorDescription, "Unable to login")
     }
     


### PR DESCRIPTION
# DCMAW-14902 update error screen copy

This PR updates the error screen copy from recoverable to unrecoverable, the fatalError being thrown has also been removed so users will stay on this screen instead of the app crashing and returning users to the home screen

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
