### PR TITLE
feat: DCMAW-19321 enable parallel testing for unit and snapshot tests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_app_and_test:
+  build_app:
     name: (Debug) Build App
     runs-on: macos-26
     outputs:
@@ -82,17 +82,17 @@ jobs:
           compression-level: 0
 
   run_unit_tests_and_send_coverage_report:
-    needs: build_app_and_test
+    needs: build_app
     name: Test
     uses: ./.github/workflows/run_unit_tests_and_send_coverage_report.yml
     with:
-      build_products_artifact_id: '${{ needs.build_app_and_test.outputs.build_products_artifact_id }}'
+      build_products_artifact_id: '${{ needs.build_app.outputs.build_products_artifact_id }}'
     secrets: inherit
 
   run_snapshot_tests:
-    needs: build_app_and_test
+    needs: build_app
     name: Test
     uses: ./.github/workflows/run_snapshot_tests.yml
     with:
-      build_products_artifact_id: '${{ needs.build_app_and_test.outputs.build_products_artifact_id }}'
+      build_products_artifact_id: '${{ needs.build_app.outputs.build_products_artifact_id }}'
     secrets: inherit

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,8 +17,10 @@ concurrency:
 
 jobs:
   build_app_and_test:
-    name: (Debug) Build App, Run Unit/Snapshot Tests and Send Coverage Report
+    name: (Debug) Build App
     runs-on: macos-26
+    outputs:
+      build_products_artifact_id: ${{ steps.upload_build_products.outputs.artifact-id }}
 
     steps:
       - name: Add Path Globally
@@ -54,6 +56,9 @@ jobs:
         run: |
           ./scripts-configs/spm/aws_code_artifact_login.sh /Applications/Xcode_26.1.1.app
 
+      - name: Bundler install
+        run: bundle install
+
       - name: Build App for Testing
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -62,52 +67,32 @@ jobs:
           GIT_CONFIG_NOSYSTEM: "true"
           GIT_CONFIG_GLOBAL: '${{ github.workspace }}/scripts-configs/override-git-config'
         run: |
-          bundle install
-
           bundle exec fastlane buildForTesting scheme:"OneLoginBuild" \
             configuration:"Debug"
 
-      - name: Run Unit Tests and Send Coverage Report for Branch
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LC_ALL: "en_US.UTF-8"
-          LANG: "en_US.UTF-8"
-          GIT_CONFIG_NOSYSTEM: "true"
-          GIT_CONFIG_GLOBAL: '${{ github.workspace }}/scripts-configs/override-git-config'
-        run: |
-          pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+      - name: Upload Fastlane build_products
+        if: success()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pin@v7.0.1
+        id: upload_build_products
+        with:
+          if-no-files-found: error
+          name: build_products.zip
+          path: ${{ github.workspace }}/fastlane/test_output/build_products.zip
+          retention-days: 1
+          compression-level: 0
 
-          brew install sonar-scanner
-          bundle install
+  run_unit_tests_and_send_coverage_report:
+    needs: build_app_and_test
+    name: Test
+    uses: ./.github/workflows/run_unit_tests_and_send_coverage_report.yml
+    with:
+      build_products_artifact_id: '${{ needs.build_app_and_test.outputs.build_products_artifact_id }}'
+    secrets: inherit
 
-          bundle exec fastlane testWithoutBuilding scheme:"OneLoginBuild" \
-            configuration:"Debug" \
-            testplan:OneLoginUnit \
-            workspace:${{ github.workspace }} \
-            sonar_token:${{ secrets.SONAR_TOKEN }} \
-            source_branch:${{ github.head_ref }} \
-            target_branch:${{ github.base_ref }} \
-            pr_number:$pull_number
-
-      # Check the Quality Gate status.
-      - name: SonarQube Quality Gate check
-        id: sonarqube-quality-gate-check
-        uses: sonarsource/sonarqube-quality-gate-action@cf038b0e0cdecfa9e56c198bbb7d21d751d62c3b # pin@v1.2.0
-        # Force to fail step after specific time.
-        timeout-minutes: 5
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
-      - name: Run Snapshot Tests
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LC_ALL: "en_US.UTF-8"
-          LANG: "en_US.UTF-8"
-          GIT_CONFIG_NOSYSTEM: "true"
-          GIT_CONFIG_GLOBAL: '${{ github.workspace }}/scripts-configs/override-git-config'
-        run: |
-          bundle install
-
-          bundle exec fastlane testWithoutBuildingWithoutCoverage scheme:"OneLoginBuild" \
-            configuration:"Debug" \
-            testplan:OneLoginSnapshot
+  run_snapshot_tests:
+    needs: build_app_and_test
+    name: Test
+    uses: ./.github/workflows/run_snapshot_tests.yml
+    with:
+      build_products_artifact_id: '${{ needs.build_app_and_test.outputs.build_products_artifact_id }}'
+    secrets: inherit

--- a/.github/workflows/run_snapshot_tests.yml
+++ b/.github/workflows/run_snapshot_tests.yml
@@ -1,0 +1,57 @@
+on:
+  workflow_call:
+    inputs:
+      build_products_artifact_id:
+        required: true
+        type: string
+
+jobs:
+  run_snapshot_tests:
+    name: OneLoginSnapshot
+    runs-on: macos-26
+    steps:
+      - name: Add Path Globally
+        run: echo "/usr/local/bin" >> $GITHUB_PATH
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v4
+        with:
+          lfs: 'true'
+          submodules: 'true'
+          fetch-depth: 0
+          token: ${{ secrets.MODULE_FETCH_TOKEN }}
+
+      - name: Download Fastlane build_products
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # pin@v8.1
+        with:
+          artifact-ids: ${{ inputs.build_products_artifact_id }}
+          path: ${{ github.workspace }}/fastlane/test_output/
+
+      - name: Unzip Fastlane build_products          
+        run: unzip -q ${{ github.workspace }}/fastlane/test_output/build_products.zip
+
+      - name: Bundler install
+        run: bundle install
+
+      - name: Run Tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LC_ALL: "en_US.UTF-8"
+          LANG: "en_US.UTF-8"
+          GIT_CONFIG_NOSYSTEM: "true"
+          GIT_CONFIG_GLOBAL: '${{ github.workspace }}/scripts-configs/override-git-config'
+          TEST_PLAN: "OneLoginSnapshot"
+        run: |
+          xctestrun=$(find . -name "*.xctestrun" | grep -i "${TEST_PLAN}")
+
+          bundle exec fastlane testWithoutBuildingWithoutCoverage scheme:"OneLoginBuild" \
+            xctestrun:"${xctestrun}"
+
+      - name: Upload OneLoginSnapshot.xcresult
+        if: success() || failure()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # pin@v4
+        with:
+          name: OneLoginSnapshot.xcresult
+          path: ${{ github.workspace }}/fastlane/test_output/OneLoginBuild.xcresult
+          retention-days: 1
+          compression-level: 0

--- a/.github/workflows/run_unit_tests_and_send_coverage_report.yml
+++ b/.github/workflows/run_unit_tests_and_send_coverage_report.yml
@@ -1,0 +1,75 @@
+on:
+  workflow_call:
+    inputs:
+      build_products_artifact_id:
+        required: true
+        type: string
+
+jobs:
+  run_unit_tests_and_send_coverage_report:
+    name: OneLoginUnit
+    runs-on: macos-26
+    steps:
+      - name: Add Path Globally
+        run: echo "/usr/local/bin" >> $GITHUB_PATH
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v4
+        with:
+          lfs: 'true'
+          submodules: 'true'
+          fetch-depth: 0
+          token: ${{ secrets.MODULE_FETCH_TOKEN }}
+
+      - name: Download Fastlane build_products
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # pin@v8.1
+        with:
+          artifact-ids: ${{ inputs.build_products_artifact_id }}
+          path: ${{ github.workspace }}/fastlane/test_output/
+
+      - name: Unzip Fastlane build_products          
+        run: unzip -q ${{ github.workspace }}/fastlane/test_output/build_products.zip
+
+      - name: Bundler install
+        run: bundle install
+
+      - name: Install sonar scanner
+        run: brew install sonar-scanner
+
+      - name: Run Tests and Send Coverage Report
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LC_ALL: "en_US.UTF-8"
+          LANG: "en_US.UTF-8"
+          GIT_CONFIG_NOSYSTEM: "true"
+          GIT_CONFIG_GLOBAL: '${{ github.workspace }}/scripts-configs/override-git-config'
+          TEST_PLAN: "OneLoginUnit"
+        run: |
+          xctestrun=$(find . -name "*.xctestrun" | grep -i "${TEST_PLAN}")
+          pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+
+          bundle exec fastlane testWithoutBuilding scheme:"OneLoginBuild" \
+            xctestrun:"${xctestrun}" \
+            workspace:${{ github.workspace }} \
+            sonar_token:${{ secrets.SONAR_TOKEN }} \
+            source_branch:${{ github.head_ref }} \
+            target_branch:${{ github.base_ref }} \
+            pr_number:$pull_number
+
+      # Check the Quality Gate status.
+      - name: SonarQube Quality Gate check
+        id: sonarqube-quality-gate-check
+        uses: sonarsource/sonarqube-quality-gate-action@cf038b0e0cdecfa9e56c198bbb7d21d751d62c3b # pin@v1.2.0
+        # Force to fail step after specific time.
+        timeout-minutes: 5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      - name: Upload OneLoginUnit.xcresult
+        if: success() || failure()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # pin@v4
+        with:
+          name: OneLoginUnit.xcresult
+          path: ${{ github.workspace }}/fastlane/test_output/OneLoginBuild.xcresult
+          retention-days: 1
+          compression-level: 0

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -65,3 +65,4 @@ jobs:
           name: UITestArtifact
           path: ./fastlane/UITestArtifact.zip
           retention-days: 1
+          compression-level: 0

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -26,20 +26,22 @@ platform :ios do
       device: "iPhone 17 (26.1)",
       scheme: options[:scheme],
       configuration: options[:configuration],
+      xcodebuild_formatter: "xcpretty",
       build_for_testing: true,
+      should_zip_build_products: true,
       xcargs: '-skipPackagePluginValidation'
     )
   end
   desc "Run Tests without Sonar Coverage"
   lane :testWithoutBuildingWithoutCoverage do |options|
     run_tests(
-      workspace: "OneLogin.xcworkspace",
       device: "iPhone 17 (26.1)",
       scheme: options[:scheme],
-      configuration: options[:configuration],
+      xcodebuild_formatter: "xcpretty",
+      xctestrun: options[:xctestrun],
       test_without_building: true,
-      testplan: options[:testplan],
-      xcargs: '-skipPackagePluginValidation'
+      result_bundle: true,
+      skip_package_dependencies_resolution: true
     )
   end
   desc "Run Tests without Sonar Coverage"
@@ -49,6 +51,7 @@ platform :ios do
       device: "iPhone 17 (26.1)",
       scheme: options[:scheme],
       configuration: options[:configuration],
+      xcodebuild_formatter: "xcpretty",
       testplan: options[:testplan],
       xcargs: '-skipPackagePluginValidation'
     )
@@ -61,6 +64,7 @@ platform :ios do
       device: "iPhone 17 (26.1)",
       scheme: options[:scheme],
       configuration: options[:configuration],
+      xcodebuild_formatter: "xcpretty",
       testplan: options[:testplan],
       prelaunch_simulator: true,
       result_bundle: true,
@@ -76,6 +80,7 @@ platform :ios do
       device: "iPhone 17 (26.1)",
       scheme: options[:scheme],
       configuration: options[:configuration],
+      xcodebuild_formatter: "xcpretty",
       testplan: options[:testplan],
       result_bundle: true,
       xcargs: '-skipPackagePluginValidation'
@@ -98,14 +103,13 @@ platform :ios do
   desc "Run Tests and Output Code Coverage"
   lane :testWithoutBuilding do |options|
     run_tests(
-      workspace: "OneLogin.xcworkspace",
       device: "iPhone 17 (26.1)",
       scheme: options[:scheme],
-      configuration: options[:configuration],
-      testplan: options[:testplan],
+      xcodebuild_formatter: "xcpretty",
+      xctestrun: options[:xctestrun],
       test_without_building: true,      
       result_bundle: true,
-      xcargs: '-skipPackagePluginValidation'
+      skip_package_dependencies_resolution: true
     )
     
     sh(

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -47,6 +47,14 @@ Run Tests without Sonar Coverage
 
 Run Tests without Sonar Coverage
 
+### ios test
+
+```sh
+[bundle exec] fastlane ios test
+```
+
+Run Tests and Output Code Coverage
+
 ### ios testWithoutBuilding
 
 ```sh

--- a/quality-gate.manifest.json
+++ b/quality-gate.manifest.json
@@ -6,21 +6,43 @@
       "quality-gates": [
         {
           "check-types": [
-            "code style and linting",
-            "unit test coverage",
-            "code quality",
-            "secret scanning",
-            "vulnerability detection",
-            "visual regression"
+            "code style and linting"
           ],
           "config": {
             "file": ".github/workflows/pull-request.yml",
             "name": "Verify code base when pull request is published/updated (into 'develop' or 'release/*' branches)",
-            "path": "jobs.build_app_and_test"
+            "path": "jobs.build_app"
           },
           "phase": "pre-merge",
           "provider": "GitHub"
         },
+        {
+          "check-types": [
+            "unit test coverage",
+            "code quality",
+            "secret scanning",
+            "vulnerability detection"
+          ],
+          "config": {
+            "file": ".github/workflows/run_unit_tests_and_send_coverage_report.yml",
+            "name": "Run Unit Tests when pull request is published/updated (into 'develop' or 'release/*' branches)",
+            "path": "jobs.run_unit_tests_and_send_coverage_report"
+          },
+          "phase": "pre-merge",
+          "provider": "GitHub"
+        },
+        {
+          "check-types": [
+            "visual regression"
+          ],
+          "config": {
+            "file": ".github/workflows/run_snapshot_tests.yml",
+            "name": "Run Snapshot Tests when pull request is published/updated (into 'develop' or 'release/*' branches)",
+            "path": "jobs.run_snapshot_tests"
+          },
+          "phase": "pre-merge",
+          "provider": "GitHub"
+        },        
         {
           "check-types": [
             "unit"


### PR DESCRIPTION
# [Run tests in parallel in the pipeline](https://govukverify.atlassian.net/browse/DCMAW-19321)

**This PR does not contain any source code changes**

This PR modifies the pull request workflow to run unit and snapshot tests in parallel.

# Preface

The `test-without-building` command in `xcodebuild` can run tests in 2 different ways:
* By looking at the `DerivedData` folder for binary products
* By using an `.xctestrun` file, the `.app` product and any `*.xctest` files produced for non app products (e.g. `AppIntegrity` which we run tests against)

When using an `*.xctestrun` file, alongside the `.app` (let's call them "build products") there is no requirement to have a local copy of the workspace/project. That is to say, as long as you have the "build products" you can merely run the following command to run the tests.

`xcodebuild -xctestrun OneLoginBuild_OneLoginUnit_iphonesimulator26.4-arm64.xctestrun -destination "platform=iOS Simulator,name=iPhone 17 Pro" test-without-building`

<img width="1800" height="1130" alt="Screenshot 2026-04-17 at 10 27 59" src="https://github.com/user-attachments/assets/b6ae000c-7aee-47cb-bf90-34ee9d72c687" />

This allows you to distribute the "build products" alongside the xctestrun file to run tests in parallel and across simulators.

# Changes

In order to support parallel execution, a number of changes have to be made. At a high level these are:

* Modify the lane used to build without testing in fastlane to **zip the "build products"**
* * Modify the GitHub workflow to **upload** the zip of the "build products"
* Modify the lanes used to test without building in fastlane 
* * to **use the xctestrun** as an argument
* * to **skip package resolution**. This is no longer a requirement to run tests since the local copy of the workspace/project is not required to run the tests
* **Introduce 2 GitHub workflows**, one to run Unit, another one to run Snapshot tests
* * Each uses the "build products" zip to run the tests
* Modify the pull request workflow to **call out to the two workflows** once the build app has been successful 

One more thing. I noticed in the past logs the following message
```
[12:29:32]: Skipping HTML... only available with `xcodebuild_formatter: 'xcpretty'` right now
[12:29:32]: Your 'xcodebuild_formatter' doesn't support these 'output_types'. Change your 'output_types' to prevent these warnings from showing...
```

It seems at some point formatter used by Fastlane changed from `xcpretty` to `xcbeautify`. AFAICT this was used to generate an junit report in html. AFAICS the code now uses the `xctestresult` file via `xccov` to generate the coverage reported to Sonarqube.

Having said that, this PR reverts the formatter to `xcpretty` since the command to generate the junit report, creates a `/fastlane/test_output` directory which is the path fastlane uses to zip the build products. In case the `test_output` is missing, fastlane [happily reports that the zip file was created](https://github.com/govuk-one-login/mobile-ios-one-login-app/actions/runs/24516803637/job/71663028737) even tho it has failed [silently](https://github.com/fastlane/fastlane/blob/2.232.2/scan/lib/scan/runner.rb#L349). That was a very subtle defect that took ages to resolve.  One more battle scar. Dear future reader, hope that helps you in times of peril.

<img width="1326" height="564" alt="Screenshot 2026-04-17 at 10 58 21" src="https://github.com/user-attachments/assets/ce6f3dbf-8ab9-483f-8412-2fc9b793eeb7" />

# Where to focus the review

* Please confirm that no accidental changes were made as a result of moving things around and changing them to meet the new requirements.
* Quality gates. Is it correct in that it reports the correct check-type for the job?

I am still learning about GitHub Actions and the workflow setup as it relates to One Login. Please do review the changes to make sure it matches the expectations and works as expected.

# Future Work

## Do not checkout local copy of the workspace/project

Since `xcodebuild` does not request a copy of the workspace/project, there shouldn't be a need for a step to checkout the project and ideally should be removed in the future. 

However, there are a few things preventing us from doing so:
* our fastlane setup is configured with a Gemfile that is required to be present in the local copy of the project. This is used to do dependency resolution for fastlane.
* fastlane uses the workspace with the `run_test` action to run `-showBuildSettings`.
* the lane (`testWithoutBuilding`) used to run the tests, also reports on code coverage. This uses a script found in the project structure under `scripts-configs/xccov-to-sonarqube-generic.sh`

## Update the workflow that runs UI tests to make use of the build products

The changes in this PR open the door to allow us to [run our UI Tests also without building ](https://github.com/govuk-one-login/mobile-ios-one-login-app/pull/780). This will significantly reduce the times it takes to run them ([> 20 minutes at the time of writing](https://github.com/govuk-one-login/mobile-ios-one-login-app/actions/runs/24541312538/job/71747529253)). It will also alleviate some of the pain of retrying any failures until we make further improvements to their reliability.

## Reduce the size of build products

The option that fastlane offers to zip the build products includes way more products than what is actually required for our purposes. The current size of build products is twice as much as required. 
* zipped, 224M vs 145M (required)
* unzipped, 761M vs 389M (required)

<img width="1800" height="1130" alt="Screenshot 2026-04-17 at 11 38 42" src="https://github.com/user-attachments/assets/f66313e4-00cd-40f6-987a-39113efb62e4" />

# Related Reading
* [Advanced Testing and Continuous Integration, Session 409, WWDC16](https://devstreaming-cdn.apple.com/videos/wwdc/2016/409jh83sf1h8dqrt00q/409/409_advanced_testing_and_continuous_integration.pdf)


# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [ ] Ran the app locally ensuring it builds 
- [ ] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
