### PR TITLE
fix: DCMAW-19786 a case of deeplink not handled once local auth has been successful

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		7CEFDE222E3BB684004EE532 /* Wallet in Frameworks */ = {isa = PBXBuildFile; productRef = 7CEFDE212E3BB684004EE532 /* Wallet */; };
 		7CF44B282CAB45A70027839B /* AppIntegrity in Frameworks */ = {isa = PBXBuildFile; productRef = 7CF44B272CAB45A70027839B /* AppIntegrity */; };
 		7CFFE7CE2C9D960E00ABD8A0 /* WalletSessionData+OneLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CFFE7CD2C9D960100ABD8A0 /* WalletSessionData+OneLogin.swift */; };
+		8E620E5D2F9A72CF00192775 /* MockChildCoordinatorExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E620E5C2F9A72CF00192775 /* MockChildCoordinatorExpectation.swift */; };
 		8E9587DA2F45E6E80073A475 /* AppIntegrityErrorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9587D92F45E6E80073A475 /* AppIntegrityErrorViewModelTests.swift */; };
 		8EA9FDBB2F3CE17E00C52D4D /* AppIntegrityErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EA9FDBA2F3CE17E00C52D4D /* AppIntegrityErrorViewModel.swift */; };
 		AB24C1132DB94A5F0080141C /* LocalAuthSettingsErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB24C1122DB948520080141C /* LocalAuthSettingsErrorViewModel.swift */; };
@@ -691,6 +692,7 @@
 		7CD66F862C90A96A008513F4 /* MockQualifyingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockQualifyingService.swift; sourceTree = "<group>"; };
 		7CDC2EC32C8B247300EAA592 /* MockHelloWorldService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHelloWorldService.swift; sourceTree = "<group>"; };
 		7CFFE7CD2C9D960100ABD8A0 /* WalletSessionData+OneLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WalletSessionData+OneLogin.swift"; sourceTree = "<group>"; };
+		8E620E5C2F9A72CF00192775 /* MockChildCoordinatorExpectation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockChildCoordinatorExpectation.swift; sourceTree = "<group>"; };
 		8E9587D92F45E6E80073A475 /* AppIntegrityErrorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntegrityErrorViewModelTests.swift; sourceTree = "<group>"; };
 		8EA9FDBA2F3CE17E00C52D4D /* AppIntegrityErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntegrityErrorViewModel.swift; sourceTree = "<group>"; };
 		AB24C1122DB948520080141C /* LocalAuthSettingsErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAuthSettingsErrorViewModel.swift; sourceTree = "<group>"; };
@@ -1304,6 +1306,7 @@
 		21FA1C4A2AE183830052136E /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				8E620E5B2F9A72BD00192775 /* Coordination */,
 				7CD66F852C90A95C008513F4 /* Qualification */,
 				C85DF8442AEBFDF00064F68E /* ReturnTypes */,
 				C85DF8432AEBFDCC0064F68E /* Sessions+Services */,
@@ -1554,6 +1557,14 @@
 				7CD66F862C90A96A008513F4 /* MockQualifyingService.swift */,
 			);
 			path = Qualification;
+			sourceTree = "<group>";
+		};
+		8E620E5B2F9A72BD00192775 /* Coordination */ = {
+			isa = PBXGroup;
+			children = (
+				8E620E5C2F9A72CF00192775 /* MockChildCoordinatorExpectation.swift */,
+			);
+			path = Coordination;
 			sourceTree = "<group>";
 		};
 		ABB941FD2C6CAD840007052B /* Service */ = {
@@ -3611,6 +3622,7 @@
 				1E69F8732EF08A5400D8A292 /* NetworkingServiceTests.swift in Sources */,
 				7CD66F872C90A96A008513F4 /* MockQualifyingService.swift in Sources */,
 				C8E6A3EB2BBC05FA005015AF /* MockSceneDelegate.swift in Sources */,
+				8E620E5D2F9A72CF00192775 /* MockChildCoordinatorExpectation.swift in Sources */,
 				C8BADD272B87AEEA00385FE7 /* MockSecureStoreService.swift in Sources */,
 				C80D77462E97C6A200082040 /* BackupDisablerTests.swift in Sources */,
 				41C0F5B92C8F45DA0055C571 /* MockSecureTokenStore.swift in Sources */,

--- a/Sources/Utilities/OneLoginEnrolmentManager.swift
+++ b/Sources/Utilities/OneLoginEnrolmentManager.swift
@@ -61,8 +61,8 @@ struct OneLoginEnrolmentManager: EnrolmentManager {
     func completeEnrolment(isWalletEnrolment: Bool = false, completion: (() -> Void)? = nil) {
         if !isWalletEnrolment {
             NotificationCenter.default.post(name: .enrolmentComplete)
+            coordinator?.finish()
         }
         completion?()
-        coordinator?.finish()
     }
 }

--- a/Tests/UnitTests/Mocks/Coordination/MockChildCoordinatorExpectation.swift
+++ b/Tests/UnitTests/Mocks/Coordination/MockChildCoordinatorExpectation.swift
@@ -1,0 +1,25 @@
+import Coordination
+
+class MockChildCoordinatorExpectation: ChildCoordinator {
+
+    weak var parentCoordinator: (any Coordination.ParentCoordinator)?
+
+    typealias StartAsFunction = () -> Void
+    typealias FinishAsFunction = () -> Void
+
+    var startAsFunction: StartAsFunction
+    var finishAsFunction: FinishAsFunction
+
+    init(startAsFunction: @escaping StartAsFunction = {}, finishAsFunction: @escaping FinishAsFunction = {}) {
+        self.startAsFunction = startAsFunction
+        self.finishAsFunction = finishAsFunction
+    }
+
+    func start() {
+        self.startAsFunction()
+    }
+
+    func finish() {
+        self.finishAsFunction()
+    }
+}

--- a/Tests/UnitTests/Utilities/OneLoginEnrolmentManagerTests.swift
+++ b/Tests/UnitTests/Utilities/OneLoginEnrolmentManagerTests.swift
@@ -1,33 +1,8 @@
 import Coordination
 import LocalAuthenticationWrapper
 import Networking
-import XCTest
-
 @testable import OneLogin
-
-class MockChildCoordinatorExpectation: ChildCoordinator {
-
-    weak var parentCoordinator: (any Coordination.ParentCoordinator)?
-
-    typealias StartAsFunction = () -> Void
-    typealias FinishAsFunction = () -> Void
-
-    var startAsFunction: StartAsFunction
-    var finishAsFunction: FinishAsFunction
-
-    init(startAsFunction: @escaping StartAsFunction = {}, finishAsFunction: @escaping FinishAsFunction = {}) {
-        self.startAsFunction = startAsFunction
-        self.finishAsFunction = finishAsFunction
-    }
-
-    func start() {
-        self.startAsFunction()
-    }
-
-    func finish() {
-        self.finishAsFunction()
-    }
-}
+import XCTest
 
 extension OneLoginEnrolmentManager {
     static func make(
@@ -51,6 +26,8 @@ extension OneLoginEnrolmentManager {
         )
     }
 }
+
+@MainActor
 final class OneLoginEnrolmentManagerTests: XCTestCase {
     private var mockLocalAuthContext: MockLocalAuthManager!
     private var mockSessionManager: MockSessionManager!
@@ -58,7 +35,6 @@ final class OneLoginEnrolmentManagerTests: XCTestCase {
     private var coordinator: ChildCoordinator!
     private var sut: OneLoginEnrolmentManager!
 
-    @MainActor
     override func setUp() {
         mockLocalAuthContext = MockLocalAuthManager()
         mockSessionManager = MockSessionManager()
@@ -90,7 +66,6 @@ final class OneLoginEnrolmentManagerTests: XCTestCase {
 }
 
 extension OneLoginEnrolmentManagerTests {
-    @MainActor
     func test_saveSession_succeeds() async {
         let exp = XCTNSNotificationExpectation(
             name: .enrolmentComplete,
@@ -105,7 +80,6 @@ extension OneLoginEnrolmentManagerTests {
         await fulfillment(of: [exp], timeout: 5)
     }
 
-    @MainActor
     func test_saveSession_fails() {
         // GIVEN the user has given FaceID permission
         mockLocalAuthContext.userDidConsentToFaceID = true
@@ -118,7 +92,6 @@ extension OneLoginEnrolmentManagerTests {
         XCTAssertEqual(mockAnalyticsService.crashesLogged, [MockError.generic as NSError])
     }
 
-    @MainActor
     func test_saveSession_promptForPermission_false() {
         // GIVEN the user has already given FaceID permission
         mockLocalAuthContext.userDidConsentToFaceID = false
@@ -129,7 +102,6 @@ extension OneLoginEnrolmentManagerTests {
         XCTAssertEqual(mockAnalyticsService.crashesLogged, [])
     }
 
-    @MainActor
     func test_saveSession_promptForPermission_cancelled() {
         // GIVEN promptForPermission throws a cancelled error
         mockLocalAuthContext.errorFromEnrolLocalAuth = LocalAuthenticationWrapperError.cancelled
@@ -140,7 +112,6 @@ extension OneLoginEnrolmentManagerTests {
         XCTAssertEqual(mockAnalyticsService.crashesLogged, [])
     }
 
-    @MainActor
     func test_saveSession_promptForPermission_fails() {
         // GIVEN promptForPermission throws an uncaught error
         mockLocalAuthContext.errorFromEnrolLocalAuth = MockError.generic
@@ -151,7 +122,6 @@ extension OneLoginEnrolmentManagerTests {
         XCTAssertEqual(mockAnalyticsService.crashesLogged, [MockError.generic as NSError])
     }
 
-    @MainActor
     func test_saveSession_isWalletEnrolmentTrue_finishOnCoordinator_not_called() {
         //  GIVEN OneLoginEnrolmentManager with a coordinator
         //  WHEN performing save session
@@ -171,7 +141,6 @@ extension OneLoginEnrolmentManagerTests {
         XCTAssertEqual(result, .completed)
     }
 
-    @MainActor
     func test_saveSession_isWalletEnrolmentFalse_finishOnCoordinator_called() {
         //  GIVEN OneLoginEnrolmentManager with a coordinator
         //  WHEN performing save session
@@ -190,7 +159,6 @@ extension OneLoginEnrolmentManagerTests {
         XCTAssertEqual(result, .completed)
     }
 
-    @MainActor
     func test_saveSession_default_finishOnCoordinator_called() {
         //  GIVEN OneLoginEnrolmentManager with a coordinator
         //  WHEN performing save session (where by default `isWalletEnrolment` is false)
@@ -208,7 +176,6 @@ extension OneLoginEnrolmentManagerTests {
         XCTAssertEqual(result, .completed)
     }
 
-    @MainActor
     func test_saveSession_isWalletEnrolmentTrue_walletCoordinator_notRemoved_asChild() {
         //  GIVEN a `TabManagerCoordinator`
         //  AND a `WalletCoordinator`

--- a/Tests/UnitTests/Utilities/OneLoginEnrolmentManagerTests.swift
+++ b/Tests/UnitTests/Utilities/OneLoginEnrolmentManagerTests.swift
@@ -147,7 +147,7 @@ extension OneLoginEnrolmentManagerTests {
     }
 
     @MainActor
-    func test_saveSession_isWalletEnrolmentTrue_callsFinishOnCoordinator() {
+    func test_saveSession_isWalletEnrolmentTrue_finishOnCoordinator_not_called() {
         let expectation = expectation(description: #function)
         expectation.isInverted = true
         let mockChildCoordinatorExpectation = MockChildCoordinatorExpectation(finishAsFunction: {
@@ -163,7 +163,7 @@ extension OneLoginEnrolmentManagerTests {
     }
     
     @MainActor
-    func test_saveSession_isWalletEnrolmentFalse_finishOnCoordinatorNotCalled() {
+    func test_saveSession_isWalletEnrolmentFalse_finishOnCoordinator_called() {
         let expectation = expectation(description: #function)
         let mockChildCoordinatorExpectation = MockChildCoordinatorExpectation(finishAsFunction: {
                 expectation.fulfill()
@@ -177,7 +177,7 @@ extension OneLoginEnrolmentManagerTests {
     }
     
     @MainActor
-    func test_saveSession_default_finishOnCoordinatorNotCalled() {
+    func test_saveSession_default_finishOnCoordinator_called() {
         let expectation = expectation(description: #function)
         let mockChildCoordinatorExpectation = MockChildCoordinatorExpectation(finishAsFunction: {
                 expectation.fulfill()
@@ -191,7 +191,7 @@ extension OneLoginEnrolmentManagerTests {
     }
     
     @MainActor
-    func test_saveSession_isWalletEnrolmentTrue__walletCoordinator_notRemoved_asChild() {
+    func test_saveSession_isWalletEnrolmentTrue_walletCoordinator_notRemoved_asChild() {
         let expectation = expectation(description: #function)
         let tabManagerCoordinator = TabManagerCoordinator(root: UITabBarController(),
                                         analyticsService: mockAnalyticsService,

--- a/Tests/UnitTests/Utilities/OneLoginEnrolmentManagerTests.swift
+++ b/Tests/UnitTests/Utilities/OneLoginEnrolmentManagerTests.swift
@@ -157,7 +157,9 @@ extension OneLoginEnrolmentManagerTests {
         let sut: OneLoginEnrolmentManager = .make(coordinator: mockChildCoordinatorExpectation)
         // WHEN saveSession is called
         sut.saveSession(isWalletEnrolment: true)
-        wait(for: [expectation], timeout: 1)
+        let result = XCTWaiter().wait(for: [expectation], timeout: 1)
+        
+        XCTAssertEqual(result, .completed)
     }
     
     @MainActor
@@ -170,7 +172,8 @@ extension OneLoginEnrolmentManagerTests {
         let sut: OneLoginEnrolmentManager = .make(coordinator: mockChildCoordinatorExpectation)
         // WHEN saveSession is called
         sut.saveSession(isWalletEnrolment: false)
-        wait(for: [expectation], timeout: 5)
+        let result = XCTWaiter().wait(for: [expectation], timeout: 5)
+        XCTAssertEqual(result, .completed)
     }
     
     @MainActor
@@ -183,7 +186,8 @@ extension OneLoginEnrolmentManagerTests {
         let sut: OneLoginEnrolmentManager = .make(coordinator: mockChildCoordinatorExpectation)
         // WHEN saveSession is called
         sut.saveSession()
-        wait(for: [expectation], timeout: 5)
+        let result = XCTWaiter().wait(for: [expectation], timeout: 5)
+        XCTAssertEqual(result, .completed)
     }
     
     @MainActor

--- a/Tests/UnitTests/Utilities/OneLoginEnrolmentManagerTests.swift
+++ b/Tests/UnitTests/Utilities/OneLoginEnrolmentManagerTests.swift
@@ -1,16 +1,17 @@
 import Coordination
 import LocalAuthenticationWrapper
 import Networking
-@testable import OneLogin
 import XCTest
 
+@testable import OneLogin
+
 class MockChildCoordinatorExpectation: ChildCoordinator {
-    
+
     weak var parentCoordinator: (any Coordination.ParentCoordinator)?
-    
+
     typealias StartAsFunction = () -> Void
     typealias FinishAsFunction = () -> Void
-    
+
     var startAsFunction: StartAsFunction
     var finishAsFunction: FinishAsFunction
 
@@ -18,26 +19,30 @@ class MockChildCoordinatorExpectation: ChildCoordinator {
         self.startAsFunction = startAsFunction
         self.finishAsFunction = finishAsFunction
     }
-    
+
     func start() {
         self.startAsFunction()
     }
-    
+
     func finish() {
         self.finishAsFunction()
     }
 }
 
 extension OneLoginEnrolmentManager {
-    static func make(mockLocalAuthContext: LocalAuthManaging = MockLocalAuthManager(),
-                     mockSessionManager: SessionManager = MockSessionManager(),
-                     mockAnalyticsService: OneLoginAnalyticsService = MockAnalyticsService(),
-                     coordinator: ChildCoordinator? = nil) -> OneLoginEnrolmentManager {
-        let coordinator = coordinator ?? EnrolmentCoordinator(
-            root: UINavigationController(),
-            analyticsService: mockAnalyticsService,
-            sessionManager: mockSessionManager
-        )
+    static func make(
+        mockLocalAuthContext: LocalAuthManaging = MockLocalAuthManager(),
+        mockSessionManager: SessionManager = MockSessionManager(),
+        mockAnalyticsService: OneLoginAnalyticsService = MockAnalyticsService(),
+        coordinator: ChildCoordinator? = nil
+    ) -> OneLoginEnrolmentManager {
+        let coordinator =
+            coordinator
+            ?? EnrolmentCoordinator(
+                root: UINavigationController(),
+                analyticsService: mockAnalyticsService,
+                sessionManager: mockSessionManager
+            )
         return OneLoginEnrolmentManager(
             localAuthContext: mockLocalAuthContext,
             sessionManager: mockSessionManager,
@@ -52,7 +57,7 @@ final class OneLoginEnrolmentManagerTests: XCTestCase {
     private var mockAnalyticsService: MockAnalyticsService!
     private var coordinator: ChildCoordinator!
     private var sut: OneLoginEnrolmentManager!
-    
+
     @MainActor
     override func setUp() {
         mockLocalAuthContext = MockLocalAuthManager()
@@ -70,7 +75,7 @@ final class OneLoginEnrolmentManagerTests: XCTestCase {
             coordinator: coordinator
         )
     }
-    
+
     override func tearDown() {
         mockLocalAuthContext = nil
         mockSessionManager = nil
@@ -78,7 +83,7 @@ final class OneLoginEnrolmentManagerTests: XCTestCase {
         coordinator = nil
         sut = nil
     }
-    
+
     enum MockError: Error {
         case generic
     }
@@ -99,7 +104,7 @@ extension OneLoginEnrolmentManagerTests {
         // THEN enrolment complete notification is sent
         await fulfillment(of: [exp], timeout: 5)
     }
-    
+
     @MainActor
     func test_saveSession_fails() {
         // GIVEN the user has given FaceID permission
@@ -112,7 +117,7 @@ extension OneLoginEnrolmentManagerTests {
         // THEN an error is recorded in Crashlytics
         XCTAssertEqual(mockAnalyticsService.crashesLogged, [MockError.generic as NSError])
     }
-    
+
     @MainActor
     func test_saveSession_promptForPermission_false() {
         // GIVEN the user has already given FaceID permission
@@ -123,7 +128,7 @@ extension OneLoginEnrolmentManagerTests {
         // THEN no error is recorded in Crashlytics
         XCTAssertEqual(mockAnalyticsService.crashesLogged, [])
     }
-    
+
     @MainActor
     func test_saveSession_promptForPermission_cancelled() {
         // GIVEN promptForPermission throws a cancelled error
@@ -134,7 +139,7 @@ extension OneLoginEnrolmentManagerTests {
         // THEN no error is recorded in Crashlytics
         XCTAssertEqual(mockAnalyticsService.crashesLogged, [])
     }
-    
+
     @MainActor
     func test_saveSession_promptForPermission_fails() {
         // GIVEN promptForPermission throws an uncaught error
@@ -148,63 +153,86 @@ extension OneLoginEnrolmentManagerTests {
 
     @MainActor
     func test_saveSession_isWalletEnrolmentTrue_finishOnCoordinator_not_called() {
+        //  GIVEN OneLoginEnrolmentManager with a coordinator
+        //  WHEN performing save session
+        //  AND `isWalletEnrolment` is true
+        //  ASSERT that `finish` is NOT called on the coordinator
+
         let expectation = expectation(description: #function)
         expectation.isInverted = true
         let mockChildCoordinatorExpectation = MockChildCoordinatorExpectation(finishAsFunction: {
-                expectation.fulfill()
-            })
-        
+            expectation.fulfill()
+        })
+
         let sut: OneLoginEnrolmentManager = .make(coordinator: mockChildCoordinatorExpectation)
         // WHEN saveSession is called
         sut.saveSession(isWalletEnrolment: true)
         let result = XCTWaiter().wait(for: [expectation], timeout: 1)
-        
         XCTAssertEqual(result, .completed)
     }
-    
+
     @MainActor
     func test_saveSession_isWalletEnrolmentFalse_finishOnCoordinator_called() {
+        //  GIVEN OneLoginEnrolmentManager with a coordinator
+        //  WHEN performing save session
+        //  AND `isWalletEnrolment` is false
+        //  ASSERT that `finish` is called on the coordinator
+
         let expectation = expectation(description: #function)
         let mockChildCoordinatorExpectation = MockChildCoordinatorExpectation(finishAsFunction: {
-                expectation.fulfill()
-            })
-        
+            expectation.fulfill()
+        })
+
         let sut: OneLoginEnrolmentManager = .make(coordinator: mockChildCoordinatorExpectation)
         // WHEN saveSession is called
         sut.saveSession(isWalletEnrolment: false)
         let result = XCTWaiter().wait(for: [expectation], timeout: 5)
         XCTAssertEqual(result, .completed)
     }
-    
+
     @MainActor
     func test_saveSession_default_finishOnCoordinator_called() {
+        //  GIVEN OneLoginEnrolmentManager with a coordinator
+        //  WHEN performing save session (where by default `isWalletEnrolment` is false)
+        //  ASSERT that `finish` is called on the coordinator
+
         let expectation = expectation(description: #function)
         let mockChildCoordinatorExpectation = MockChildCoordinatorExpectation(finishAsFunction: {
-                expectation.fulfill()
-            })
-        
+            expectation.fulfill()
+        })
+
         let sut: OneLoginEnrolmentManager = .make(coordinator: mockChildCoordinatorExpectation)
         // WHEN saveSession is called
         sut.saveSession()
         let result = XCTWaiter().wait(for: [expectation], timeout: 5)
         XCTAssertEqual(result, .completed)
     }
-    
+
     @MainActor
     func test_saveSession_isWalletEnrolmentTrue_walletCoordinator_notRemoved_asChild() {
+        //  GIVEN a `TabManagerCoordinator`
+        //  AND a `WalletCoordinator`
+        //  WITH a a parent/child relationship
+        //  WHEN performing save session
+        //  AND `isWalletEnrolment` is true
+        //  ASSERT that the `WalletCoordinator` is not removed as a child
+
         let expectation = expectation(description: #function)
-        let tabManagerCoordinator = TabManagerCoordinator(root: UITabBarController(),
-                                        analyticsService: mockAnalyticsService,
-                                        networkingService: NetworkClient(),
-                                        sessionManager: mockSessionManager)
-        
-        let walletCoordinator =  WalletCoordinator(analyticsService: mockAnalyticsService,
-                                               networkingService: NetworkClient(),
-                                               sessionManager: mockSessionManager)
-        
+        let tabManagerCoordinator = TabManagerCoordinator(
+            root: UITabBarController(),
+            analyticsService: mockAnalyticsService,
+            networkingService: NetworkClient(),
+            sessionManager: mockSessionManager
+        )
+
+        let walletCoordinator = WalletCoordinator(
+            analyticsService: mockAnalyticsService,
+            networkingService: NetworkClient(),
+            sessionManager: mockSessionManager
+        )
+
         tabManagerCoordinator.childCoordinators.append(walletCoordinator)
         walletCoordinator.parentCoordinator = tabManagerCoordinator
-
 
         let sut: OneLoginEnrolmentManager = .make(coordinator: walletCoordinator)
         // WHEN saveSession is called

--- a/Tests/UnitTests/Utilities/OneLoginEnrolmentManagerTests.swift
+++ b/Tests/UnitTests/Utilities/OneLoginEnrolmentManagerTests.swift
@@ -1,8 +1,51 @@
 import Coordination
 import LocalAuthenticationWrapper
+import Networking
 @testable import OneLogin
 import XCTest
 
+class MockChildCoordinatorExpectation: ChildCoordinator {
+    
+    weak var parentCoordinator: (any Coordination.ParentCoordinator)?
+    
+    typealias StartAsFunction = () -> Void
+    typealias FinishAsFunction = () -> Void
+    
+    var startAsFunction: StartAsFunction
+    var finishAsFunction: FinishAsFunction
+
+    init(startAsFunction: @escaping StartAsFunction = {}, finishAsFunction: @escaping FinishAsFunction = {}) {
+        self.startAsFunction = startAsFunction
+        self.finishAsFunction = finishAsFunction
+    }
+    
+    func start() {
+        self.startAsFunction()
+    }
+    
+    func finish() {
+        self.finishAsFunction()
+    }
+}
+
+extension OneLoginEnrolmentManager {
+    static func make(mockLocalAuthContext: LocalAuthManaging = MockLocalAuthManager(),
+                     mockSessionManager: SessionManager = MockSessionManager(),
+                     mockAnalyticsService: OneLoginAnalyticsService = MockAnalyticsService(),
+                     coordinator: ChildCoordinator? = nil) -> OneLoginEnrolmentManager {
+        let coordinator = coordinator ?? EnrolmentCoordinator(
+            root: UINavigationController(),
+            analyticsService: mockAnalyticsService,
+            sessionManager: mockSessionManager
+        )
+        return OneLoginEnrolmentManager(
+            localAuthContext: mockLocalAuthContext,
+            sessionManager: mockSessionManager,
+            analyticsService: mockAnalyticsService,
+            coordinator: coordinator
+        )
+    }
+}
 final class OneLoginEnrolmentManagerTests: XCTestCase {
     private var mockLocalAuthContext: MockLocalAuthManager!
     private var mockSessionManager: MockSessionManager!
@@ -101,5 +144,70 @@ extension OneLoginEnrolmentManagerTests {
         waitForTruth(self.mockLocalAuthContext.didCallEnrolFaceIDIfAvailable, timeout: 5)
         // THEN an error is recorded in Crashlytics
         XCTAssertEqual(mockAnalyticsService.crashesLogged, [MockError.generic as NSError])
+    }
+
+    @MainActor
+    func test_saveSession_isWalletEnrolmentTrue_callsFinishOnCoordinator() {
+        let expectation = expectation(description: #function)
+        expectation.isInverted = true
+        let mockChildCoordinatorExpectation = MockChildCoordinatorExpectation(finishAsFunction: {
+                expectation.fulfill()
+            })
+        
+        let sut: OneLoginEnrolmentManager = .make(coordinator: mockChildCoordinatorExpectation)
+        // WHEN saveSession is called
+        sut.saveSession(isWalletEnrolment: true)
+        wait(for: [expectation], timeout: 1)
+    }
+    
+    @MainActor
+    func test_saveSession_isWalletEnrolmentFalse_finishOnCoordinatorNotCalled() {
+        let expectation = expectation(description: #function)
+        let mockChildCoordinatorExpectation = MockChildCoordinatorExpectation(finishAsFunction: {
+                expectation.fulfill()
+            })
+        
+        let sut: OneLoginEnrolmentManager = .make(coordinator: mockChildCoordinatorExpectation)
+        // WHEN saveSession is called
+        sut.saveSession(isWalletEnrolment: false)
+        wait(for: [expectation], timeout: 5)
+    }
+    
+    @MainActor
+    func test_saveSession_default_finishOnCoordinatorNotCalled() {
+        let expectation = expectation(description: #function)
+        let mockChildCoordinatorExpectation = MockChildCoordinatorExpectation(finishAsFunction: {
+                expectation.fulfill()
+            })
+        
+        let sut: OneLoginEnrolmentManager = .make(coordinator: mockChildCoordinatorExpectation)
+        // WHEN saveSession is called
+        sut.saveSession()
+        wait(for: [expectation], timeout: 5)
+    }
+    
+    @MainActor
+    func test_saveSession_isWalletEnrolmentTrue__walletCoordinator_notRemoved_asChild() {
+        let expectation = expectation(description: #function)
+        let tabManagerCoordinator = TabManagerCoordinator(root: UITabBarController(),
+                                        analyticsService: mockAnalyticsService,
+                                        networkingService: NetworkClient(),
+                                        sessionManager: mockSessionManager)
+        
+        let walletCoordinator =  WalletCoordinator(analyticsService: mockAnalyticsService,
+                                               networkingService: NetworkClient(),
+                                               sessionManager: mockSessionManager)
+        
+        tabManagerCoordinator.childCoordinators.append(walletCoordinator)
+        walletCoordinator.parentCoordinator = tabManagerCoordinator
+
+
+        let sut: OneLoginEnrolmentManager = .make(coordinator: walletCoordinator)
+        // WHEN saveSession is called
+        sut.saveSession(isWalletEnrolment: true) {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 5)
+        XCTAssert(tabManagerCoordinator.childCoordinators.count == 1)
     }
 }


### PR DESCRIPTION
# [Fixed a case where the "deep link" is not handled](https://govukverify.atlassian.net/browse/DCMAW-19786)

Under certain conditions, the `WalletCoordinator` used to handle a "deep link" becomes nil. This PR ensures that the `WalletCoordinator` is never `nil` in that specific case.


Evidence of defect 

https://github.com/user-attachments/assets/42f6a2b8-8e83-4c59-bddd-dd6972c886e6

Evidence of fix

https://github.com/user-attachments/assets/8b9261aa-a90d-4420-a682-41cf0332cc9a

# Preface

The `WalletCoordinator` is an optional, [computed property](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.19.1/Sources/Tabs/TabManagerCoordinator.swift#L32) in the [TabManagerCoordinator](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.19.1/Sources/Tabs/TabManagerCoordinator.swift#L57) from the array of `childCoordinators`.

The [Coordination](https://github.com/govuk-one-login/mobile-ios-coordination) package, includes types like the [ParentCoordinator](https://github.com/govuk-one-login/mobile-ios-coordination/blob/1.3.0/Sources/Coordination/ParentCoordinator.swift), which the `TabManagerCoordinator` adopts and the [ChildCoordinator](https://github.com/govuk-one-login/mobile-ios-coordination/blob/1.3.0/Sources/Coordination/ChildCoordinator.swift#L7), which the WalletCoordinator adopts and makes it a child of the `TabManagerCoordinator`.

The `ChildCoordinator` defines a `finish` function. The [default implementation](https://github.com/govuk-one-login/mobile-ios-coordination/blob/1.3.0/Sources/Coordination/ChildCoordinator.swift#L20) and part of its contract, is to call `childDidFinish(_:)` on [its parent](https://github.com/govuk-one-login/mobile-ios-coordination/blob/1.3.0/Sources/Coordination/ParentCoordinator.swift#L35). On the condition that the child is indeed present in the array of `childCordinators`, the child is removed from the array.

So the question becomes, is there a use case where the `WalletCoordinator` has it `finish()` function called?

Here is the object graph for the `WalletCoordinator`.

* [WalletCoordinator](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/develop/Sources/Tabs/TabManagerCoordinator.swift#L85)
* * [walletAuthService](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.19.1/Sources/Tabs/WalletCoordinator.swift#L24): [LocalAuthServiceWallet](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.19.1/Sources/Utilities/WalletUtilities/LocalAuthServiceWallet.swift)
* * * [localAuthManager](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/develop/Sources/Utilities/WalletUtilities/LocalAuthServiceWallet.swift#L30): [OneLoginEnrolmentManager](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/develop/Sources/Utilities/OneLoginEnrolmentManager.swift#L24)
* * * * [coordinator](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/develop/Sources/Utilities/OneLoginEnrolmentManager.swift#L28): WalletCoordinator

The `OneLoginEnrolmentManager` type calls `finish` on the WalletCoordinator under the [completeEnrolment(isWalletEnrolment: completion:)](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/develop/Sources/Utilities/OneLoginEnrolmentManager.swift#L66)

This stack trace for this call is In case of a successful [save session](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/develop/Sources/Utilities/OneLoginEnrolmentManager.swift#L45), either in the case of:

* [A passcode is accepted as the only type available for local auth](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.19.1/Sources/Utilities/WalletUtilities/LocalAuthServiceWallet.swift#L64).
* [Biometrics are accepted](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.19.1/Sources/Utilities/WalletUtilities/LocalAuthServiceWallet.swift#L118).

**On an unrelated note** but I think it's worth pointing out that the there is another stack trace for the call in case of a successful [save session](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/develop/Sources/Utilities/OneLoginEnrolmentManager.swift#L45), which instead uses the [**EnrolmentCoordinator**](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.19.1/Sources/Login/EnrolmentCoordinator.swift).

The stack trace for this is either in the case of:

* [A passcode](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.19.1/Sources/Login/EnrolmentCoordinator.swift#L53)
* Biometrics [are allowed](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.19.1/Sources/Login/EnrolmentCoordinator.swift#L46) or [skipped](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.19.1/Sources/Login/EnrolmentCoordinator.swift#L48).

<img width="50%" height="50%" alt="test_biometricsEnrolmentScreen_faceID 1" src="https://github.com/user-attachments/assets/4c9d3bfd-e795-4fde-adfa-2bceba421a4f" />

# Changes

The proposed code change is to only call finish when the coordinator is NOT a `WalletCoordinator`.

## Where to focus the review

Is this the expected behaviour of the code? Do you see any risk of a regression?

## Testing

Wrote 2 tests that demonstrate the defect and fail

* test_saveSession_isWalletEnrolmentTrue_finishOnCoordinator_not_called
* test_saveSession_isWalletEnrolmentTrue_walletCoordinator_notRemoved_asChild


<img width="1912" height="1242" alt="Screenshot 2026-04-23 at 10 14 13" src="https://github.com/user-attachments/assets/e2c52c1e-ca62-4276-bb61-60ba4b879e79" />


Applied the recommended fix and both tests now pass

<img width="1912" height="1242" alt="Screenshot 2026-04-23 at 10 12 00" src="https://github.com/user-attachments/assets/d1168d32-10bf-462e-8a42-db4f7337c7d2" />


It's not clear how the code is expected to work. Which makes it hard to decide what test to write against.

The `Coordination` package suggests that every child coordinator has a lifecycle and that lifecycle has to finish at some point with the removal of the child from its parent. On the other hand, the `TabManagerCoordinator` expects the `WalletCoordinator` child to match its lifecycle. 

As of today, based on the product requirement that handling a deep link should be done for the duration of the lifecycle of the `TabManagerCoordinator`, it's safe to say this is the expected behavior.

However, should a new requirement arise in the future that expects the call to `WalletCoordinator.finish()` to have been made, any future code carries a risk of being blindsided by this fix at worse or have to grapple with the same decision at best.

Although I think this change carries a very low risk of regressions today for two reasons:
1. The proposed code change modifies a small part of a public contract (i.e. when/if the call to finish is made)
2. The affected code path is very narrow (i.e. to remove the wallet coordinator from the tab manager coordinator)

I would still like to use this PR as an opportunity to discuss and decide on the expected behaviour so a test can be written alongside the proposed code changes.

# Discussion

AFAICT, the call to `finish` on a child coordinator is done for two reasons:
* Memory management, i.e. release the coordinator once the work is done
* The work is not repeated by the same child coordinator once it's done.

Looking at the WalletCoordinator, it looks like it has two main responsibilities outside those enforced by any protocol adoption.
* [Handle the deep link](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.19.1/Sources/Tabs/WalletCoordinator.swift#L82)
* [User cancellation](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.19.1/Sources/Tabs/WalletCoordinator.swift#L87)

Since a defect has been raised due to not handling a deep link, (i.e. we expect the work to be repeatable) I think it's safe to assume that the `WalletCoordinator` should not be removed in this use case.

Which leaves the memory management side to it. With the proposed changes, the call to finish on the `WalletCoordinator` is never done. Which means the `WalletCoordinator` will be released once the `childCoordinators` array is released, which will be done when the `TabManagerCoordinator` is released, which seems to be when its call to `finish` is made, which is done when the [SettingsCoordinator is removed](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.19.1/Sources/Tabs/SettingsCoordinator.swift#L89) and [a logout is posted](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.19.1/Sources/Tabs/TabManagerCoordinator.swift#L124). That looks sufficient but happy to hear anything to the contrary.

```
extension TabManagerCoordinator: ParentCoordinator {
    func performChildCleanup(child: ChildCoordinator) {
        if child is SettingsCoordinator {
            NotificationCenter.default.post(name: .userDidLogout)
            finish()
        }
    }
}
```

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
