### PR TITLE
fix: DCMAW-19875 a case of deeplink not handled once local auth has been successful

### DIFF
--- a/Sources/Utilities/OneLoginEnrolmentManager.swift
+++ b/Sources/Utilities/OneLoginEnrolmentManager.swift
@@ -63,6 +63,10 @@ struct OneLoginEnrolmentManager: EnrolmentManager {
             NotificationCenter.default.post(name: .enrolmentComplete)
         }
         completion?()
+        
+        guard !(coordinator is WalletCoordinator) else {
+            return
+        }
         coordinator?.finish()
     }
 }


### PR DESCRIPTION
# [Fixed a case where the "deep link" is not handled](https://govukverify.atlassian.net/browse/DCMAW-19875)

Under certain conditions, the `WalletCoordinator` used to handle a "deep link" becomes nil. This PR ensures that the `WalletCoordinator` is never `nil` in that specific case.

# Preface

The `WalletCoordinator` is an optional, [computed property](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.19.1/Sources/Tabs/TabManagerCoordinator.swift#L32) in the [TabManagerCoordinator](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.19.1/Sources/Tabs/TabManagerCoordinator.swift#L57) from the array of `childCoordinators`.

The [Coordination](https://github.com/govuk-one-login/mobile-ios-coordination) package, includes types like the [ParentCoordinator](https://github.com/govuk-one-login/mobile-ios-coordination/blob/1.3.0/Sources/Coordination/ParentCoordinator.swift), which the `TabManagerCoordinator` adopts and the [ChildCoordinator](https://github.com/govuk-one-login/mobile-ios-coordination/blob/1.3.0/Sources/Coordination/ChildCoordinator.swift#L7), which the WalletCoordinator adopts and makes it a child of the `TabManagerCoordinator`.

The `ChildCoordinator` defines a **`finish`** function. The [default implementation](https://github.com/govuk-one-login/mobile-ios-coordination/blob/1.3.0/Sources/Coordination/ChildCoordinator.swift#L20) and part of its contract, is to call `childDidFinish(_:)` on [its parent](https://github.com/govuk-one-login/mobile-ios-coordination/blob/1.3.0/Sources/Coordination/ParentCoordinator.swift#L35). On the condition that the child is indeed present in the array of `childCordinators`, **the child is removed from the array**.

So the question becomes, is there a use case where the `WalletCoordinator` has it `finish()` function called?

Here is the object graph for the `WalletCoordinator`.

* [WalletCoordinator](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/develop/Sources/Tabs/TabManagerCoordinator.swift#L85)
* * [walletAuthService](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.19.1/Sources/Tabs/WalletCoordinator.swift#L24): [LocalAuthServiceWallet](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.19.1/Sources/Utilities/WalletUtilities/LocalAuthServiceWallet.swift)
* * * [localAuthManager](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/develop/Sources/Utilities/WalletUtilities/LocalAuthServiceWallet.swift#L30): [OneLoginEnrolmentManager](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/develop/Sources/Utilities/OneLoginEnrolmentManager.swift#L24)
* * * * [coordinator](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/develop/Sources/Utilities/OneLoginEnrolmentManager.swift#L28): WalletCoordinator

The `OneLoginEnrolmentManager` type calls `finish` on the WalletCoordinator under the [completeEnrolment(isWalletEnrolment: completion:)](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/develop/Sources/Utilities/OneLoginEnrolmentManager.swift#L66)

This stack trace for this call is In case of a successful [save session](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/develop/Sources/Utilities/OneLoginEnrolmentManager.swift#L45), either in the case of:

* [A passcode is accepted as the only type available for local auth](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.19.1/Sources/Utilities/WalletUtilities/LocalAuthServiceWallet.swift#L64).
* [Biometrics are accepted](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.19.1/Sources/Utilities/WalletUtilities/LocalAuthServiceWallet.swift#L118).

**On an unrelated note** but I think it's worth pointing out that the there is another stack trace for the call in case of a successful [save session](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/develop/Sources/Utilities/OneLoginEnrolmentManager.swift#L45), which instead uses the [**EnrolmentCoordinator**](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.19.1/Sources/Login/EnrolmentCoordinator.swift).

The stack trace for this is either in the case of:

* [A passcode](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.19.1/Sources/Login/EnrolmentCoordinator.swift#L53)
* Biometrics [are allowed](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.19.1/Sources/Login/EnrolmentCoordinator.swift#L46) or [skipped](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.19.1/Sources/Login/EnrolmentCoordinator.swift#L48).

<img width="50%" height="50%" alt="test_biometricsEnrolmentScreen_faceID 1" src="https://github.com/user-attachments/assets/4c9d3bfd-e795-4fde-adfa-2bceba421a4f" />

# Changes

The proposed code change is to only call finish when the coordinator is NOT a `WalletCoordinator`.

## Where to focus the review

Is this the expected behaviour of the code? Do you see any risk of a regression?

## Testing

It's not clear how the code is expected to work. Which makes it hard to decide what test to write against.

The `Coordination` package suggests that every child coordinator has a lifecycle and that lifecycle has to finish at some point with the removal of the child from its parent. On the other hand, the `TabManagerCoordinator` expects the `WalletCoordinator` child to match its lifecycle. 

As of today, based on the product requirement that handling a deep link should be done for the duration of the lifecycle of the `TabManagerCoordinator`, it's safe to say this is the expected behavior.

However, should a new requirement arise in the future that expects the call to `WalletCoordinator.finish()` to have been made, any future code carries a risk of being blindsided by this fix at worse or have to grapple with the same decision at best.

Although I think this change carries a very low risk of regressions today for two reasons:
1. The proposed code change modifies a small part of a public contract (i.e. when/if the call to finish is made)
2. The affected code path is very narrow (i.e. to remove the wallet coordinator from the tab manager coordinator)

I would still like to use this PR as an opportunity to discuss and decide on the expected behaviour so a test can be written alongside the proposed code changes.

# Discussion

AFAICT, the call to `finish` on a child coordinator is done for two reasons:
* Memory management, i.e. release the coordinator once the work is done
* The work is not repeated by the same child coordinator once it's done.

Looking at the WalletCoordinator, it looks like it has two main responsibilities outside those enforced by any protocol adoption.
* [Handle the deep link](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.19.1/Sources/Tabs/WalletCoordinator.swift#L82)
* [User cancellation](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.19.1/Sources/Tabs/WalletCoordinator.swift#L87)

Since a defect has been raised due to not handling a deep link, (i.e. we expect the work to be repeatable) I think it's safe to assume that the `WalletCoordinator` should not be removed in this use case.

Which leaves the memory management side to it. With the proposed changes, the call to finish on the `WalletCoordinator` is never done. Which means the `WalletCoordinator` will be released once the `childCoordinators` array is released, which will be done when the `TabManagerCoordinator` is released, which seems to be when its call to `finish` is made, which is done when the [SettingsCoordinator is removed](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.19.1/Sources/Tabs/SettingsCoordinator.swift#L89) and [a logout is posted](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.19.1/Sources/Tabs/TabManagerCoordinator.swift#L124). That looks sufficient but happy to hear anything to the contrary.

```
extension TabManagerCoordinator: ParentCoordinator {
    func performChildCleanup(child: ChildCoordinator) {
        if child is SettingsCoordinator {
            NotificationCenter.default.post(name: .userDidLogout)
            finish()
        }
    }
}
```

# Checklist

## Before raising your pull request:
- [ ] Commit messages that conform to conventional commit messages
- [ ] Ran the app locally ensuring it builds 
- [ ] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
