### PR TITLE
DMCAW-0000 use test delegate when the application is under testing

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -84,6 +84,9 @@
 		7CF44B282CAB45A70027839B /* AppIntegrity in Frameworks */ = {isa = PBXBuildFile; productRef = 7CF44B272CAB45A70027839B /* AppIntegrity */; };
 		7CFFE7CE2C9D960E00ABD8A0 /* WalletSessionData+OneLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CFFE7CD2C9D960100ABD8A0 /* WalletSessionData+OneLogin.swift */; };
 		8E620E5D2F9A72CF00192775 /* MockChildCoordinatorExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E620E5C2F9A72CF00192775 /* MockChildCoordinatorExpectation.swift */; };
+		8E5B38182F8ECA1800C175F3 /* TestingSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E5B37EA2F8EC7F600C175F3 /* TestingSceneDelegate.swift */; };
+		8E8CAC0A2F894AF90010679E /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E8CAC092F894AF90010679E /* main.swift */; };
+		8E8CAC0C2F894B1A0010679E /* TestAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E8CAC0B2F894B1A0010679E /* TestAppDelegate.swift */; };
 		8E9587DA2F45E6E80073A475 /* AppIntegrityErrorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9587D92F45E6E80073A475 /* AppIntegrityErrorViewModelTests.swift */; };
 		8EA9FDBB2F3CE17E00C52D4D /* AppIntegrityErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EA9FDBA2F3CE17E00C52D4D /* AppIntegrityErrorViewModel.swift */; };
 		AB24C1132DB94A5F0080141C /* LocalAuthSettingsErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB24C1122DB948520080141C /* LocalAuthSettingsErrorViewModel.swift */; };
@@ -559,7 +562,6 @@
 		D0BE24432BEBB06700759529 /* JWKInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BE24422BEBB06700759529 /* JWKInfo.swift */; };
 		D0BE24452BEBCB5000759529 /* JWTVerifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BE24442BEBCB5000759529 /* JWTVerifierTests.swift */; };
 		D0BE24472BEBD2E400759529 /* MockJWKs.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BE24462BEBD2E400759529 /* MockJWKs.swift */; };
-		D0BE24492BEBD43300759529 /* MockNetworking in Frameworks */ = {isa = PBXBuildFile; productRef = D0BE24482BEBD43300759529 /* MockNetworking */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -693,6 +695,9 @@
 		7CDC2EC32C8B247300EAA592 /* MockHelloWorldService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHelloWorldService.swift; sourceTree = "<group>"; };
 		7CFFE7CD2C9D960100ABD8A0 /* WalletSessionData+OneLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WalletSessionData+OneLogin.swift"; sourceTree = "<group>"; };
 		8E620E5C2F9A72CF00192775 /* MockChildCoordinatorExpectation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockChildCoordinatorExpectation.swift; sourceTree = "<group>"; };
+		8E5B37EA2F8EC7F600C175F3 /* TestingSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestingSceneDelegate.swift; sourceTree = "<group>"; };
+		8E8CAC092F894AF90010679E /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		8E8CAC0B2F894B1A0010679E /* TestAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAppDelegate.swift; sourceTree = "<group>"; };
 		8E9587D92F45E6E80073A475 /* AppIntegrityErrorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntegrityErrorViewModelTests.swift; sourceTree = "<group>"; };
 		8EA9FDBA2F3CE17E00C52D4D /* AppIntegrityErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntegrityErrorViewModel.swift; sourceTree = "<group>"; };
 		AB24C1122DB948520080141C /* LocalAuthSettingsErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAuthSettingsErrorViewModel.swift; sourceTree = "<group>"; };
@@ -1177,6 +1182,20 @@
 		D0BE24462BEBD2E400759529 /* MockJWKs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockJWKs.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		8E8CAC112F8956B70010679E /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				AppIntegrityProviderStub.swift,
+			);
+			target = 219601E62A976302008F3427 /* OneLogin */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		8E8CAC0D2F8956AF0010679E /* Stubs */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (8E8CAC112F8956B70010679E /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Stubs; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
 		1E7F93022F1538CF00CC2CF9 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
@@ -1215,7 +1234,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D0BE24492BEBD43300759529 /* MockNetworking in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1345,6 +1363,9 @@
 				C865444C2BD7D55000433897 /* PrivacyInfo.xcprivacy */,
 				3BBF28EE2A9F7D3200491BB1 /* SceneDelegate.swift */,
 				C851FFA12BADA4B200A7B73D /* SceneLifecycle.swift */,
+				8E8CAC092F894AF90010679E /* main.swift */,
+				8E8CAC0B2F894B1A0010679E /* TestAppDelegate.swift */,
+				8E5B37EA2F8EC7F600C175F3 /* TestingSceneDelegate.swift */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -2649,6 +2670,7 @@
 		C8E6C7632AF821D2008C19C9 /* UnitTests */ = {
 			isa = PBXGroup;
 			children = (
+				8E8CAC0D2F8956AF0010679E /* Stubs */,
 				7C9CEA6D2EBA5ADE0074EB18 /* Extensions */,
 				C81ECB1E2B71767500AFC3A6 /* Application */,
 				C8520C2C2AE2C546006790C1 /* Login */,
@@ -2819,9 +2841,11 @@
 			dependencies = (
 				219601FF2A976305008F3427 /* PBXTargetDependency */,
 			);
+			fileSystemSynchronizedGroups = (
+				8E8CAC0D2F8956AF0010679E /* Stubs */,
+			);
 			name = OneLoginUnitTests;
 			packageProductDependencies = (
-				D0BE24482BEBD43300759529 /* MockNetworking */,
 			);
 			productName = "di-mobile-ios-onelogin-appTests";
 			productReference = 219601FD2A976305008F3427 /* OneLoginUnitTests.xctest */;
@@ -3448,6 +3472,7 @@
 				C86B706B2B8E43DC00F4C9BF /* AnalyticsPreferenceViewModel.swift in Sources */,
 				C8098B992AEFF287001517A0 /* AnalyticsService+GDS.swift in Sources */,
 				3BBF28F32A9F7D3200491BB1 /* AppDelegate.swift in Sources */,
+				8E8CAC0A2F894AF90010679E /* main.swift in Sources */,
 				C8A94C4A2D033EB800303578 /* AppEnvironment+InternalTypes.swift in Sources */,
 				C880DDE22AEAB6C100020796 /* AppEnvironment.swift in Sources */,
 				7CD66F812C9070D8008513F4 /* AppInformationState.swift in Sources */,
@@ -3535,6 +3560,7 @@
 				C3A2D72F2DF1B58D00F8D617 /* SignOutSuccessfulViewModel.swift in Sources */,
 				C88E40E72C34239E008A3C20 /* SignOutWarningViewModel.swift in Sources */,
 				C8C343A92B923DB300E92FB9 /* StandardButtonViewModel.swift in Sources */,
+				8E8CAC0C2F894B1A0010679E /* TestAppDelegate.swift in Sources */,
 				D08B0B812BDC0D7100769CEA /* TabbedTableViewCell.swift in Sources */,
 				C80D77442E97C65B00082040 /* AppFileManager.swift in Sources */,
 				D08B0B832BDC0F4100769CEA /* TabbedViewCellModel.swift in Sources */,
@@ -3544,6 +3570,7 @@
 				D08B0B7D2BDBF86100769CEA /* TabbedViewSectionHeader.swift in Sources */,
 				D08B0B8A2BDFEBA600769CEA /* TabbedViewSectionModel.swift in Sources */,
 				C85E21042ACEE34900AF8B4E /* TabManagerCoordinator.swift in Sources */,
+				8E5B38182F8ECA1800C175F3 /* TestingSceneDelegate.swift in Sources */,
 				C8BADD222B8652F200385FE7 /* TokenHolder.swift in Sources */,
 				D0275CBF2BFF876800AF9A50 /* TokenVerifier.swift in Sources */,
 				C865E6522C21DC24001FA62D /* UniversalLinkQualifier.swift in Sources */,
@@ -5468,11 +5495,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = D0BE243C2BEB7E5E00759529 /* XCRemoteSwiftPackageReference "jwt-kit" */;
 			productName = JWTKit;
-		};
-		D0BE24482BEBD43300759529 /* MockNetworking */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C844A6942BCD2684000538A9 /* XCRemoteSwiftPackageReference "mobile-ios-networking" */;
-			productName = MockNetworking;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Sources/Application/AppDelegate.swift
+++ b/Sources/Application/AppDelegate.swift
@@ -2,7 +2,6 @@ import AppIntegrity
 import GAnalytics
 import UIKit
 
-@main
 final class AppDelegate: UIResponder, UIApplicationDelegate, BackupDisabler {
     
     func application(_ application: UIApplication,

--- a/Sources/Application/TestAppDelegate.swift
+++ b/Sources/Application/TestAppDelegate.swift
@@ -2,8 +2,6 @@ import UIKit
 
 class TestAppDelegate: UIResponder, UIApplicationDelegate {
 
-
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         UIView.setAnimationsEnabled(false)
         removeCachedScenes(from: application)
@@ -16,7 +14,7 @@ class TestAppDelegate: UIResponder, UIApplicationDelegate {
         let sceneConfiguration = UISceneConfiguration(name: nil, sessionRole: connectingSceneSession.role)
         sceneConfiguration.delegateClass = TestingSceneDelegate.self
         return sceneConfiguration
-    } 
+    }
 
     private func removeCachedScenes(from application: UIApplication) {
         /* Remove any cached scene configurations to ensure that

--- a/Sources/Application/TestAppDelegate.swift
+++ b/Sources/Application/TestAppDelegate.swift
@@ -1,0 +1,32 @@
+import UIKit
+
+class TestAppDelegate: UIResponder, UIApplicationDelegate {
+
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        UIView.setAnimationsEnabled(false)
+        removeCachedScenes(from: application)
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        let sceneConfiguration = UISceneConfiguration(name: nil, sessionRole: connectingSceneSession.role)
+        sceneConfiguration.delegateClass = TestingSceneDelegate.self
+        return sceneConfiguration
+    } 
+
+    private func removeCachedScenes(from application: UIApplication) {
+        /* Remove any cached scene configurations to ensure that
+         TestingAppDelegate.application(_:configurationForConnecting:options:) is called
+         and TestingSceneDelegate will be used when running unit tests.
+         
+         Warning: This is a private API and may break in the future.
+         It is perfectly app-store safe since it is not included in the main app targets. */
+        for sceneSession in application.openSessions {
+            application.perform(Selector(("_removeSessionFromSessionSet:")), with: sceneSession)
+        }
+    }
+}

--- a/Sources/Application/TestingSceneDelegate.swift
+++ b/Sources/Application/TestingSceneDelegate.swift
@@ -1,0 +1,17 @@
+import UIKit
+
+class TestingSceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let windowScene = (scene as? UIWindowScene) else { return }
+        
+        window = UIWindow(windowScene: windowScene)
+        window?.rootViewController = UIViewController()
+        window?.makeKeyAndVisible()
+    }
+}

--- a/Sources/Application/main.swift
+++ b/Sources/Application/main.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+let isRunningTests = ProcessInfo.processInfo.environment["IS_RUNNING_TESTS"] == "1"
+let delegateClassName = isRunningTests
+        ? NSStringFromClass(TestAppDelegate.self)
+        : NSStringFromClass(AppDelegate.self)
+
+UIApplicationMain(
+    CommandLine.argc,
+    CommandLine.unsafeArgv,
+    nil,
+    delegateClassName
+)

--- a/Sources/Qualification/State/AppQualifyingService.swift
+++ b/Sources/Qualification/State/AppQualifyingService.swift
@@ -54,7 +54,10 @@ final class AppQualifyingService: QualifyingService {
         updateService: AppInformationProvider = AppInformationService(baseURL: AppEnvironment.appInfoURL),
         sessionManager: SessionManager
     ) {
-        self.init(analyticsService: analyticsService, updateService: updateService, sessionManager: sessionManager, appIntegrityProvider: try FirebaseAppIntegrityService.firebaseAppCheck())
+        self.init(analyticsService: analyticsService,
+                  updateService: updateService,
+                  sessionManager: sessionManager,
+                  appIntegrityProvider: try FirebaseAppIntegrityService.firebaseAppCheck())
     }
 
     init(

--- a/Sources/Qualification/State/AppQualifyingService.swift
+++ b/Sources/Qualification/State/AppQualifyingService.swift
@@ -49,12 +49,19 @@ final class AppQualifyingService: QualifyingService {
         }
     }
     
+    convenience init(
+        analyticsService: OneLoginAnalyticsService,
+        updateService: AppInformationProvider = AppInformationService(baseURL: AppEnvironment.appInfoURL),
+        sessionManager: SessionManager
+    ) {
+        self.init(analyticsService: analyticsService, updateService: updateService, sessionManager: sessionManager, appIntegrityProvider: try FirebaseAppIntegrityService.firebaseAppCheck())
+    }
+
     init(
         analyticsService: OneLoginAnalyticsService,
         updateService: AppInformationProvider = AppInformationService(baseURL: AppEnvironment.appInfoURL),
         sessionManager: SessionManager,
-        appIntegrityProvider: @autoclosure @escaping () throws -> AppIntegrityProvider = try FirebaseAppIntegrityService.firebaseAppCheck()
-    ) {
+        appIntegrityProvider: @autoclosure @escaping () throws(AppIntegritySigningError) -> AppIntegrityProvider) {
         self.analyticsService = analyticsService
         self.updateService = updateService
         self.sessionManager = sessionManager

--- a/Sources/Qualification/State/AppQualifyingService.swift
+++ b/Sources/Qualification/State/AppQualifyingService.swift
@@ -22,6 +22,7 @@ final class AppQualifyingService: QualifyingService {
     private let analyticsService: OneLoginAnalyticsService
     private let updateService: AppInformationProvider
     private let sessionManager: SessionManager
+    private let appIntegrityProvider: () throws -> AppIntegrityProvider
     weak var delegate: AppQualifyingServiceDelegate?
     
     private var appInfoState: AppInformationState = .notChecked {
@@ -51,11 +52,13 @@ final class AppQualifyingService: QualifyingService {
     init(
         analyticsService: OneLoginAnalyticsService,
         updateService: AppInformationProvider = AppInformationService(baseURL: AppEnvironment.appInfoURL),
-        sessionManager: SessionManager
+        sessionManager: SessionManager,
+        appIntegrityProvider: @autoclosure @escaping () throws -> AppIntegrityProvider = try FirebaseAppIntegrityService.firebaseAppCheck()
     ) {
         self.analyticsService = analyticsService
         self.updateService = updateService
         self.sessionManager = sessionManager
+        self.appIntegrityProvider = appIntegrityProvider
         subscribe()
     }
     
@@ -114,7 +117,7 @@ final class AppQualifyingService: QualifyingService {
             do {
                 try await sessionManager.resumeSession(
                     tokenExchangeManager: RefreshTokenExchangeManager(),
-                    appIntegrityProvider: try FirebaseAppIntegrityService.firebaseAppCheck()
+                    appIntegrityProvider: try appIntegrityProvider()
                 )
                 sessionState = .loggedIn
             } catch RefreshTokenExchangeError.noInternet {

--- a/Sources/Service/NetworkingService.swift
+++ b/Sources/Service/NetworkingService.swift
@@ -7,16 +7,19 @@ import Networking
 final class NetworkingService {
     let networkClient: NetworkClient
     let sessionManager: SessionManager
+    private let appIntegrityProvider: () throws -> AppIntegrityProvider
     let refreshExchangeManager: TokenExchangeManaging
     
     init(
         networkClient: NetworkClient = NetworkClient(),
         refreshExchangeManager: TokenExchangeManaging = RefreshTokenExchangeManager(),
-        sessionManager: SessionManager
+        sessionManager: SessionManager,
+        appIntegrityProvider: @autoclosure @escaping () throws -> AppIntegrityProvider = try FirebaseAppIntegrityService.firebaseAppCheck()
     ) {
         self.networkClient = networkClient
         self.refreshExchangeManager = refreshExchangeManager
         self.sessionManager = sessionManager
+        self.appIntegrityProvider = appIntegrityProvider
         self.networkClient.authorizationProvider = sessionManager.tokenProvider
     }
     
@@ -66,7 +69,7 @@ extension NetworkingService {
     ) async throws {
         let tokenResponse = try await refreshExchangeManager.getUpdatedTokens(
             refreshToken: refreshToken,
-            appIntegrityProvider: try FirebaseAppIntegrityService.firebaseAppCheck()
+            appIntegrityProvider: try appIntegrityProvider()
         )
         
         // Save new tokens

--- a/Tests/TestPlans/OneLoginUnit.xctestplan
+++ b/Tests/TestPlans/OneLoginUnit.xctestplan
@@ -10,6 +10,12 @@
   ],
   "defaultOptions" : {
     "diagnosticCollectionPolicy" : "Always",
+    "environmentVariableEntries" : [
+      {
+        "key" : "IS_RUNNING_TESTS",
+        "value" : "1"
+      }
+    ],
     "targetForVariableExpansion" : {
       "containerPath" : "container:OneLogin.xcodeproj",
       "identifier" : "219601E62A976302008F3427",

--- a/Tests/UnitTests/Application/BackupDisablerTests.swift
+++ b/Tests/UnitTests/Application/BackupDisablerTests.swift
@@ -2,9 +2,11 @@ import Foundation
 @testable import OneLogin
 import Testing
 
-struct BackupDisablerTests {
+struct BackupDisablerTests: BackupDisabler {
     @Test
     func documentsFolderBackupsDisabled() throws {
+        disableFileBackup()
+        
         guard let url: URL = try? FileManager.default.url(
             for: .documentDirectory,
             in: .userDomainMask,

--- a/Tests/UnitTests/Extensions/CustomTypes/AppIntegrityProvider+OneLoginTests.swift
+++ b/Tests/UnitTests/Extensions/CustomTypes/AppIntegrityProvider+OneLoginTests.swift
@@ -1,9 +1,9 @@
 @testable import AppIntegrity
 import Firebase
 import Foundation.NSDate
+import GAnalytics
 @testable import OneLogin
 import Testing
-import GAnalytics
 
 struct AppIntegrityProviderTests: ~Copyable {
     let attestationStore: SecureAttestationStore

--- a/Tests/UnitTests/Extensions/CustomTypes/AppIntegrityProvider+OneLoginTests.swift
+++ b/Tests/UnitTests/Extensions/CustomTypes/AppIntegrityProvider+OneLoginTests.swift
@@ -3,6 +3,7 @@ import Firebase
 import Foundation.NSDate
 @testable import OneLogin
 import Testing
+import GAnalytics
 
 struct AppIntegrityProviderTests: ~Copyable {
     let attestationStore: SecureAttestationStore
@@ -22,7 +23,9 @@ struct AppIntegrityProviderTests: ~Copyable {
             clientAttestation: "example.mock.jwt",
             attestationExpiry: .distantFuture
         )
-
+        FirebaseAppIntegrityService.configure()
+        GAnalytics.configure()
+        
         // WHEN I take several moments to login
         let appCheck = try FirebaseAppIntegrityService.firebaseAppCheck()
         let date = Date()

--- a/Tests/UnitTests/Mocks/Sessions+Services/MockAppInfoService.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/MockAppInfoService.swift
@@ -1,6 +1,7 @@
 import Foundation
 @testable import MobilePlatformServices
 import Networking
+import XCTest
 
 @testable import OneLogin
 
@@ -26,5 +27,28 @@ final class MockAppInformationService: AppInformationProvider {
                    allowAppUsage: allowAppUsage,
                    releaseFlags: releaseFlags,
                    featureFlags: featureFlags)
+    }
+}
+
+
+final class MockAppInformationServiceExpectation: AppInformationProvider {
+    var currentVersion: Version {
+        mockAppInformationService.currentVersion
+    }
+
+    let mockAppInformationService: MockAppInformationService
+    var expectation: XCTestExpectation
+    
+    init(mockAppInformationService: MockAppInformationService = MockAppInformationService(), expectation: XCTestExpectation) {
+        self.mockAppInformationService = mockAppInformationService
+        self.expectation = expectation
+    }
+    
+    func fetchAppInfo() async throws -> App {
+        defer {
+            expectation.fulfill()
+        }
+
+        return try await mockAppInformationService.fetchAppInfo()
     }
 }

--- a/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
+++ b/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
@@ -1,4 +1,6 @@
 // swiftlint:disable file_length
+import AppIntegrity
+import GAnalytics
 import MobilePlatformServices
 import Networking
 @testable import OneLogin
@@ -6,415 +8,527 @@ import SecureStore
 import XCTest
 import AppIntegrity
 
+extension AppQualifyingService {
+    
+    static func make(analyticsService: OneLoginAnalyticsService = MockAnalyticsService(),
+                     appInformationProvider: AppInformationProvider = MockAppInformationService(),
+                     sessionManager: SessionManager = MockSessionManager(),
+                     appIntegrityProvider: AppIntegrityProvider = AppIntegrityProviderStub()) -> AppQualifyingService {
+        
+        return AppQualifyingService(analyticsService: analyticsService,
+                                    updateService: appInformationProvider,
+                                    sessionManager: sessionManager,
+                                    appIntegrityProvider: appIntegrityProvider)
+    }
+}
+
+class AppQualifyingServiceDelegateExpectation: AppQualifyingServiceDelegate {
+    
+    typealias didChangeAppInfoState = (AppInformationState) -> Void
+    typealias didChangeSessionState = (AppSessionState) -> Void
+    typealias didChangeServiceState = (RemoteServiceState) -> Void
+    
+    let didChangeAppInfoState: didChangeAppInfoState
+    let didChangeSessionState: didChangeSessionState
+    let didChangeServiceState: didChangeServiceState
+    
+    init(didChangeAppInfoState: @escaping didChangeAppInfoState = { _ in },
+         didChangeSessionState: @escaping didChangeSessionState = { _ in },
+         didChangeServiceState: @escaping didChangeServiceState = { _ in }) {
+        self.didChangeAppInfoState = didChangeAppInfoState
+        self.didChangeSessionState = didChangeSessionState
+        self.didChangeServiceState = didChangeServiceState
+    }
+    
+    func didChangeAppInfoState(state appInfoState: AppInformationState) {
+        self.didChangeAppInfoState(appInfoState)
+    }
+    
+    func didChangeSessionState(state sessionState: AppSessionState) {
+        self.didChangeSessionState(sessionState)
+    }
+    
+    func didChangeServiceState(state: RemoteServiceState) {
+        self.didChangeServiceState(state)
+    }
+}
+
 final class AppQualifyingServiceTests: XCTestCase {
-    private var analyticsService: MockAnalyticsService!
-    private var sessionManager: MockSessionManager!
-    private var appInformationProvider: MockAppInformationService!
-    private var sut: AppQualifyingService!
-
-    private var appState: AppInformationState?
-    private var sessionState: AppSessionState?
-    private var serviceState: RemoteServiceState?
-
-    override func setUp() {
-        super.setUp()
-
-
-        analyticsService = MockAnalyticsService()
-        sessionManager = MockSessionManager()
-        appInformationProvider = MockAppInformationService()
-        sut = AppQualifyingService(analyticsService: analyticsService,
-                                   updateService: appInformationProvider,
-                                   sessionManager: sessionManager,
-        appIntegrityProvider: AppIntegrityProviderStub())
-    }
-
-    override func tearDown() {
-        analyticsService = nil
-        sessionManager = nil
-        appInformationProvider = nil
-
-        appState = nil
-        sessionState = nil
-
-        sut = nil
-
-        AppEnvironment.updateFlags(
-            releaseFlags: [:],
-            featureFlags: [:]
-        )
-        super.tearDown()
-    }
 }
 
 // MARK: - App Info Requests
 extension AppQualifyingServiceTests {
+    
     func test_appInfoIsRequested() {
+        let expectation = expectation(description: #function)
+        let mockAppInformationService = MockAppInformationService()
+        let appInformationProvider = MockAppInformationServiceExpectation(mockAppInformationService: mockAppInformationService,
+                                                                          expectation: expectation)
+        
+        let sut: AppQualifyingService = .make(appInformationProvider: appInformationProvider)
+        
         sut.initiate()
 
-        waitForTruth(
-            self.appInformationProvider.didCallFetchAppInfo,
-            timeout: 5
-        )
+        wait(for: [expectation], timeout: 5)
+        XCTAssertTrue(mockAppInformationService.didCallFetchAppInfo)
     }
     
+    @MainActor
     func test_appUnavailable_setsStateCorrectly() {
         // GIVEN app usage is not allowed
+        let appInformationProvider = MockAppInformationService()
         appInformationProvider.allowAppUsage = false
+        let sut: AppQualifyingService = .make(appInformationProvider: appInformationProvider)
 
-        sut.delegate = self
-        sut.initiate()
-
-        // THEN the unavailable state is set
-        waitForTruth(
-            self.appState == .unavailable,
-            timeout: 5
-        )
+        let (appState, _) = waitForAppInfoStateChange(sut: sut, when: { sut in
+            sut.initiate()
+        })
+        
+        XCTAssertEqual(appState, .unavailable)
     }
 
-    
+    @MainActor
     func test_outdatedApp_setsStateCorrectly() {
         // GIVEN the app is outdated
+        let appInformationProvider = MockAppInformationService()
         appInformationProvider.currentVersion = .init(.min, .min, .min)
-
-        sut.delegate = self
-        sut.initiate()
-
-        // THEN the outdated state is set
-        waitForTruth(
-            self.appState == .outdated,
-            timeout: 5
-        )
+        let sut: AppQualifyingService = .make(appInformationProvider: appInformationProvider)
+        
+        let (appState, _) = waitForAppInfoStateChange(sut: sut, when: { sut in
+            sut.initiate()
+        })
+        
+        XCTAssertEqual(appState, .outdated)
     }
 
+    @MainActor
     func test_upToDateApp_setsStateCorrectly() {
         let releaseFlags = ["TestFlag": true]
+
+        let appInformationProvider = MockAppInformationService()
         appInformationProvider.releaseFlags = releaseFlags
-        sut.delegate = self
-        sut.initiate()
+        let sut: AppQualifyingService = .make(appInformationProvider: appInformationProvider)
 
-        // THEN the qualified state is set
-        waitForTruth(
-            self.appState == .qualified,
-            timeout: 5
-        )
-
+        let (appState, _) = waitForAppInfoStateChange(sut: sut, when: { sut in
+            sut.initiate()
+        })
+        
+        XCTAssertEqual(appState, .qualified)
         XCTAssertEqual(AppEnvironment.remoteReleaseFlags.flags, releaseFlags)
     }
 
+    @MainActor
     func test_errorThrown_setsStateCorrectly() {
         // GIVEN `appInfo` cannot be accessed
+        let appInformationProvider = MockAppInformationService()
         appInformationProvider.errorFromFetchAppInfo = URLError(.timedOut)
+        let sut: AppQualifyingService = .make(appInformationProvider: appInformationProvider)
 
-        sut.delegate = self
-        sut.initiate()
-
-        // THEN the error state is set
-        waitForTruth(
-            self.appState == .error,
-            timeout: 5
-        )
+        let (appState, _) = waitForAppInfoStateChange(sut: sut, when: { sut in
+            sut.initiate()
+        })
+        
+        XCTAssertEqual(appState, .error)
     }
     
+    @MainActor
     func test_appInfoOfflineError_setsStateCorrectly() {
         // GIVEN the app is offline
+        let appInformationProvider = MockAppInformationService()
         appInformationProvider.errorFromFetchAppInfo = AppInfoError.notConnectedToInternet
+        let sut: AppQualifyingService = .make(appInformationProvider: appInformationProvider)
 
-        sut.delegate = self
-        sut.initiate()
-
-        // THEN the offline state is set
-        waitForTruth(
-            self.appState == .offline,
-            timeout: 5
-        )
+        let (appState, _) = waitForAppInfoStateChange(sut: sut, when: { sut in
+            sut.initiate()
+        })
+        
+        XCTAssertEqual(appState, .offline)
     }
     
+    @MainActor
     func test_accountIntervention_returns() {
         // GIVEN the a receives an account intervention
+        let appInformationProvider = MockAppInformationService()
         appInformationProvider.errorFromFetchAppInfo = ServerError(endpoint: "test", errorCode: 400)
+        let sut: AppQualifyingService = .make(appInformationProvider: appInformationProvider)
 
-        sut.delegate = self
-        sut.initiate()
-
-        // THEN the original session state is maintained
-        waitForTruth(
-            self.sessionState == nil,
-            timeout: 5
-        )
+        let (_, sessionState) = waitForAppInfoStateChange(sut: sut, when: { sut in
+            sut.initiate()
+        })
+        
+        XCTAssertNil(sessionState)
     }
     
+    @MainActor
     func test_appInfoInvalidError_setsStateCorrectly() {
+        let appInformationProvider = MockAppInformationService()
         appInformationProvider.errorFromFetchAppInfo = AppInfoError.invalidResponse
+        let sut: AppQualifyingService = .make(appInformationProvider: appInformationProvider)
+
+        let (appState, _) = waitForAppInfoStateChange(sut: sut, when: { sut in
+            sut.initiate()
+        })
         
-        sut.delegate = self
-        sut.initiate()
-        
-        waitForTruth(
-            self.appState == .unavailable,
-            timeout: 5
-        )
+        XCTAssertEqual(appState, .unavailable)
     }
 }
 
 // MARK: - User State Evaluation
 extension AppQualifyingServiceTests {
-    func test_oneTimeUser_userConfirmed() {
-        sessionManager.sessionState = .oneTime
-        sut.delegate = self
-        sut.initiate()
+    
+    @MainActor
+    func waitForSessionStateChange(expectation e: XCTestExpectation? = nil, sut: AppQualifyingService, when: (AppQualifyingService) -> Void) -> (appState: AppInformationState?, sessionState: AppSessionState?) {
+        let expectation = e ?? expectation(description: #function)
+        var _appState: AppInformationState? = nil
+        var _sessionState: AppSessionState? = nil
 
-        waitForTruth(
-            self.appState == .qualified,
-            timeout: 5
-        )
+        let appQualifyingServiceDelegateExpectation = AppQualifyingServiceDelegateExpectation(didChangeAppInfoState: { appState in
+            _appState = appState
+        }, didChangeSessionState: { sessionState in
+            _sessionState = sessionState
+            expectation.fulfill()
+        })
+
+        sut.delegate = appQualifyingServiceDelegateExpectation
+        when(sut)
+
+        wait(for: [expectation], timeout: 5)
         
-        XCTAssert(self.sessionState == .loggedIn)
+        return (appState: _appState, sessionState: _sessionState)
     }
     
+    @MainActor
+    func waitForAppInfoStateChange(expectation e: XCTestExpectation? = nil, sut: AppQualifyingService, when: (AppQualifyingService) -> Void) -> (appState: AppInformationState?, sessionState: AppSessionState?) {
+        let expectation = e ?? expectation(description: #function)
+        var _appState: AppInformationState? = nil
+        var _sessionState: AppSessionState? = nil
+
+        let appQualifyingServiceDelegateExpectation = AppQualifyingServiceDelegateExpectation(didChangeAppInfoState: { appState in
+            _appState = appState
+            expectation.fulfill()
+        }, didChangeSessionState: { sessionState in
+            _sessionState = sessionState
+        })
+
+        sut.delegate = appQualifyingServiceDelegateExpectation
+        when(sut)
+
+        wait(for: [expectation], timeout: 5)
+        
+        return (appState: _appState, sessionState: _sessionState)
+    }
+
+    
+    @MainActor
+    func test_oneTimeUser_userConfirmed() {
+        let sessionManager = MockSessionManager()
+        sessionManager.sessionState = .oneTime
+        let sut: AppQualifyingService = .make(sessionManager: sessionManager)
+
+        let (appState, sessionState) = waitForSessionStateChange(sut: sut, when: { sut in
+            sut.initiate()
+        })
+        
+        XCTAssertEqual(appState, .qualified)
+        XCTAssertEqual(sessionState, .loggedIn)
+    }
+    
+    @MainActor
     func test_noExpiryDate_userUnconfirmed() {
-        sut.delegate = self
-        sut.initiate()
+        let sut: AppQualifyingService = .make()
+
+        let (appState, sessionState) = waitForSessionStateChange(sut: sut, when: { sut in
+            sut.initiate()
+        })
         
-        waitForTruth(
-            self.appState == .qualified,
-            timeout: 5
-        )
-        
-        XCTAssert(self.sessionState == .notLoggedIn)
+        XCTAssertEqual(appState, .qualified)
+        XCTAssertEqual(sessionState, .notLoggedIn)
     }
     
+    @MainActor
     func test_sessionInvalid_userExpired() {
+        let sessionManager = MockSessionManager()
         sessionManager.expiryDate = .distantFuture
         sessionManager.sessionState = .expired
-        sut.delegate = self
-        sut.initiate()
+        let sut: AppQualifyingService = .make(sessionManager: sessionManager)
+
+        let (appState, sessionState) = waitForSessionStateChange(sut: sut, when: { sut in
+            sut.initiate()
+        })
         
-        waitForTruth(
-            self.appState == .qualified,
-            timeout: 5
-        )
-        
-        XCTAssert(self.sessionState == .expired)
+        XCTAssertEqual(appState, .qualified)
+        XCTAssertEqual(sessionState, .expired)
     }
     
+    @MainActor
     func test_resumeSession_userConfirmed() {
+        let sessionManager = MockSessionManager()
         sessionManager.expiryDate = .distantFuture
         sessionManager.sessionState = .saved
-        sut.delegate = self
-        sut.initiate()
+        let sut: AppQualifyingService = .make(sessionManager: sessionManager)
+
+        let (appState, sessionState) = waitForSessionStateChange(sut: sut, when: { sut in
+            sut.initiate()
+        })
         
-        waitForTruth(
-            self.appState == .qualified,
-            timeout: 5
-        )
-        
-        XCTAssert(self.sessionState == .loggedIn)
+        XCTAssertEqual(appState, .qualified)
+        XCTAssertEqual(sessionState, .loggedIn)
     }
     
+    @MainActor
     func test_resumeSession_noInternet_error() {
+        let expectation = expectation(description: #function)
+        expectation.expectedFulfillmentCount = 2
+        
+        let sessionManager = MockSessionManager()
         sessionManager.expiryDate = .distantFuture
         sessionManager.sessionState = .saved
         sessionManager.errorFromResumeSession = RefreshTokenExchangeError.noInternet
-        sut.delegate = self
-        sut.initiate()
+        let sut: AppQualifyingService = .make(sessionManager: sessionManager)
+
+        let (appState, _) = waitForAppInfoStateChange(expectation: expectation, sut: sut, when: { sut in
+            sut.initiate()
+        })
         
-        waitForTruth(
-            self.appState == .offline,
-            timeout: 5
-        )
+        XCTAssertEqual(appState, .offline)
     }
     
+    @MainActor
     func test_resumeSession_appIntegrityFailed() {
+        let sessionManager = MockSessionManager()
         sessionManager.expiryDate = .distantFuture
         sessionManager.sessionState = .saved
         sessionManager.errorFromResumeSession = RefreshTokenExchangeError.appIntegrityFailed
-        sut.delegate = self
-        sut.initiate()
+        let sut: AppQualifyingService = .make(sessionManager: sessionManager)
+
+        let (appState, sessionState) = waitForSessionStateChange(sut: sut, when: { sut in
+            sut.initiate()
+        })
         
-        waitForTruth(
-            self.sessionState == .appIntegrityCheckFailed,
-            timeout: 5
-        )
+        XCTAssertEqual(appState, .qualified)
+        XCTAssertEqual(sessionState, .appIntegrityCheckFailed)
     }
     
+    @MainActor
     func test_resumeSession_accountIntervention() throws {
+        let analyticsService = MockAnalyticsService()
+        let sessionManager = MockSessionManager()
         sessionManager.expiryDate = .distantFuture
         sessionManager.sessionState = .saved
         sessionManager.errorFromResumeSession = ServerError(endpoint: "test", errorCode: 400)
-        sut.delegate = self
-        sut.initiate()
+        let sut: AppQualifyingService = .make(analyticsService: analyticsService, sessionManager: sessionManager)
+
+        let (_, sessionState) = waitForAppInfoStateChange(sut: sut, when: { sut in
+            sut.initiate()
+        })
         
         // THEN the original session state is maintained
-        waitForTruth(
-            self.sessionState == nil,
-            timeout: 5
-        )
-        
         let error = try XCTUnwrap(analyticsService.crashesLogged.first as? ServerError)
         XCTAssert(error.errorCode == 400)
+        XCTAssertNil(sessionState)
     }
     
+    @MainActor
     func test_resumeSession_secureStoreError_cantDecryptData() {
+        let sessionManager = MockSessionManager()
         sessionManager.expiryDate = .distantFuture
         sessionManager.sessionState = .saved
         sessionManager.errorFromResumeSession = SecureStoreErrorV2(.cantDecryptData)
-        sut.delegate = self
-        sut.initiate()
+        let sut: AppQualifyingService = .make(sessionManager: sessionManager)
+
+        let (appState, sessionState) = waitForSessionStateChange(sut: sut, when: { sut in
+            sut.initiate()
+        })
         
-        waitForTruth(
-            self.appState == .qualified,
-            timeout: 5
-        )
-        
-        XCTAssert(self.sessionState == .expired)
+        XCTAssertEqual(appState, .qualified)
+        XCTAssert(sessionState == .expired)
     }
     
+    @MainActor
     func test_resumeSession_secureStoreError() throws {
+        let analyticsService = MockAnalyticsService()
+        
+        let sessionManager = MockSessionManager()
         sessionManager.expiryDate = .distantFuture
         sessionManager.sessionState = .saved
         sessionManager.errorFromResumeSession = SecureStoreErrorV2(.unableToRetrieveFromUserDefaults)
-        sut.delegate = self
-        sut.initiate()
         
-        waitForTruth(
-            self.appState == .qualified,
-            timeout: 5
-        )
+        let sut: AppQualifyingService = .make(analyticsService: analyticsService,
+                                              sessionManager: sessionManager)
 
+        let (appState, sessionState) = waitForSessionStateChange(sut: sut, when: { sut in
+            sut.initiate()
+        })
+
+        XCTAssertEqual(appState, .qualified)
         let error = try XCTUnwrap(analyticsService.crashesLogged.first as? SecureStoreErrorV2)
         XCTAssert(error.kind == .unableToRetrieveFromUserDefaults)
         XCTAssertFalse(sessionManager.didCallClearAllSessionData)
-        XCTAssert(self.sessionState == .localAuthCancelled)
+        XCTAssertEqual(sessionState, .localAuthCancelled)
     }
     
+    @MainActor
     func test_resumeSession_secureStoreError_keepsSessionData() {
+        let sessionManager = MockSessionManager()
         sessionManager.expiryDate = .distantFuture
         sessionManager.sessionState = .saved
-        sessionManager.errorFromResumeSession = SecureStoreErrorV2(.unableToRetrieveFromUserDefaults)
-        sessionManager.errorFromClearAllSessionData = MockWalletError.cantDelete
-        sut.delegate = self
-        sut.initiate()
+        sessionManager.errorFromResumeSession = SecureStoreErrorV2(.cantDecryptData)
+        let sut: AppQualifyingService = .make(sessionManager: sessionManager)
+
+        let (appState, sessionState) = waitForAppInfoStateChange(sut: sut, when: { sut in
+            sut.initiate()
+        })
         
-        waitForTruth(
-            self.appState == .qualified,
-            timeout: 5
-        )
-        
-        XCTAssertFalse(self.sessionState == .failed(MockWalletError.cantDelete))
+        XCTAssertEqual(appState, .qualified)
+        XCTAssertNotEqual(sessionState, .failed(MockWalletError.cantDelete))
     }
     
+    @MainActor
     func test_resumeSession_userRemovedLocalAuth_clearSessionData() {
+        let analyticsService = MockAnalyticsService()
+        
+        let sessionManager = MockSessionManager()
         sessionManager.expiryDate = .distantFuture
         sessionManager.sessionState = .saved
         sessionManager.errorFromResumeSession = PersistentSessionError(.userRemovedLocalAuth)
-        sut.delegate = self
-        sut.initiate()
         
-        waitForTruth(
-            self.appState == .qualified,
-            timeout: 5
-        )
+        let sut: AppQualifyingService = .make(analyticsService: analyticsService,
+                                              sessionManager: sessionManager)
 
+        let (appState, sessionState) = waitForSessionStateChange(sut: sut, when: { sut in
+            sut.initiate()
+        })
+
+        XCTAssertEqual(appState, .qualified)
         XCTAssert(analyticsService.crashesLogged.first as? PersistentSessionError == PersistentSessionError(.userRemovedLocalAuth))
         XCTAssert(sessionManager.didCallClearAllSessionData)
-        XCTAssert(self.sessionState == .systemLogOut)
+        XCTAssertEqual(sessionState, .systemLogOut)
     }
     
+    @MainActor
     func test_resumeSession_noPersistentSessionError_clearSessionData() {
+        let analyticsService = MockAnalyticsService()
+        
+        let sessionManager = MockSessionManager()
         sessionManager.expiryDate = .distantFuture
         sessionManager.sessionState = .saved
         sessionManager.errorFromResumeSession = PersistentSessionError(.noSessionExists)
-        sut.delegate = self
-        sut.initiate()
         
-        waitForTruth(
-            self.appState == .qualified,
-            timeout: 5
-        )
+        let sut: AppQualifyingService = .make(analyticsService: analyticsService,
+                                              sessionManager: sessionManager)
 
+        let (appState, sessionState) = waitForSessionStateChange(sut: sut, when: { sut in
+            sut.initiate()
+        })
+
+        XCTAssertEqual(appState, .qualified)
         XCTAssert(analyticsService.crashesLogged.first as? PersistentSessionError == PersistentSessionError(.noSessionExists))
         XCTAssert(sessionManager.didCallClearAllSessionData)
-        XCTAssert(self.sessionState == .systemLogOut)
+        XCTAssertEqual(sessionState, .systemLogOut)
     }
     
+    @MainActor
     func test_resumeSession_idTokenNotStoredError_clearSessionData() {
+        let analyticsService = MockAnalyticsService()
+        
+        let sessionManager = MockSessionManager()
         sessionManager.expiryDate = .distantFuture
         sessionManager.sessionState = .saved
         sessionManager.errorFromResumeSession = PersistentSessionError(.idTokenNotStored)
-        sut.delegate = self
-        sut.initiate()
         
-        waitForTruth(
-            self.appState == .qualified,
-            timeout: 5
-        )
+        let sut: AppQualifyingService = .make(analyticsService: analyticsService,
+                                              sessionManager: sessionManager)
 
+        let (appState, sessionState) = waitForSessionStateChange(sut: sut, when: { sut in
+            sut.initiate()
+        })
+
+        XCTAssertEqual(appState, .qualified)
         XCTAssert(analyticsService.crashesLogged.first as? PersistentSessionError == PersistentSessionError(.idTokenNotStored))
         XCTAssert(sessionManager.didCallClearAllSessionData)
-        XCTAssert(self.sessionState == .systemLogOut)
+        XCTAssertEqual(sessionState, .systemLogOut)
     }
     
+    @MainActor
     func test_resumeSession_idTokenNotStoredError_clearSessionDataFails() {
+        let analyticsService = MockAnalyticsService()
+        
+        let sessionManager = MockSessionManager()
         sessionManager.expiryDate = .distantFuture
         sessionManager.sessionState = .saved
         sessionManager.errorFromResumeSession = PersistentSessionError(.idTokenNotStored)
         sessionManager.errorFromClearAllSessionData = MockWalletError.cantDelete
+        let sut: AppQualifyingService = .make(analyticsService: analyticsService,
+                                              sessionManager: sessionManager)
+
+        let (appState, sessionState) = waitForSessionStateChange(sut: sut, when: { sut in
+            sut.initiate()
+        })
         
-        sut.delegate = self
-        sut.initiate()
-        
-        waitForTruth(
-            self.appState == .qualified,
-            timeout: 5
-        )
-        
+        XCTAssertEqual(appState, .qualified)
         XCTAssert(analyticsService.crashesLogged.first as? PersistentSessionError == PersistentSessionError(.idTokenNotStored))
         XCTAssert(sessionManager.didCallClearAllSessionData)
-        XCTAssert(self.sessionState == .failed(MockWalletError.cantDelete))
+        XCTAssertEqual(sessionState, .failed(MockWalletError.cantDelete))
     }
 }
 
 // MARK: - Subscription Tests
 extension AppQualifyingServiceTests {
+    
+    @MainActor
     func test_enrolmentComplete_changesSessionState() {
+        let appInformationProvider = MockAppInformationService()
         appInformationProvider.errorFromFetchAppInfo = AppInfoError.invalidResponse
-        sut.delegate = self
-        sut.initiate()
+        let sut: AppQualifyingService = .make(appInformationProvider: appInformationProvider)
 
-        NotificationCenter.default.post(name: .enrolmentComplete)
-        waitForTruth(self.sessionState == .loggedIn, timeout: 5)
-    }
-    
-    func test_sessionExpiry_changesSessionState() {
-        appInformationProvider.errorFromFetchAppInfo = AppInfoError.invalidResponse
-        sut.delegate = self
-        sut.initiate()
-
-        NotificationCenter.default.post(name: .sessionExpired)
-        waitForTruth(self.sessionState == .expired, timeout: 5)
-    }
-    
-    func test_logOut_changesSessionState() {
-        appInformationProvider.errorFromFetchAppInfo = AppInfoError.invalidResponse
-        sut.delegate = self
-        sut.initiate()
+        let (_, sessionState) = waitForSessionStateChange(sut: sut, when: { _ in
+            NotificationCenter.default.post(name: .enrolmentComplete)
+        })
         
-        NotificationCenter.default.post(name: .systemLogUserOut)
-        waitForTruth(self.sessionState == .systemLogOut, timeout: 5)
+        XCTAssertEqual(sessionState, .loggedIn)
     }
-}
+    
+    @MainActor
+    func test_sessionExpiry_changesSessionState() {
+        let appInformationProvider = MockAppInformationService()
+        appInformationProvider.errorFromFetchAppInfo = AppInfoError.invalidResponse
+        let sut: AppQualifyingService = .make(appInformationProvider: appInformationProvider)
 
-extension AppQualifyingServiceTests: AppQualifyingServiceDelegate {
-    func didChangeAppInfoState(state appInfoState: AppInformationState) {
-        self.appState = appInfoState
+        let (_, sessionState) = waitForSessionStateChange(sut: sut, when: { _ in
+            NotificationCenter.default.post(name: .sessionExpired)
+        })
+        
+        XCTAssertEqual(sessionState, .expired)
     }
     
-    func didChangeSessionState(state sessionState: AppSessionState) {
-        self.sessionState = sessionState
+    @MainActor
+    func test_logOut_changesSessionState() {
+        let appInformationProvider = MockAppInformationService()
+        appInformationProvider.errorFromFetchAppInfo = AppInfoError.invalidResponse
+        let sut: AppQualifyingService = .make(appInformationProvider: appInformationProvider)
+
+        let (_, sessionState) = waitForSessionStateChange(sut: sut, when: { _ in
+            NotificationCenter.default.post(name: .systemLogUserOut)
+        })
+        
+        XCTAssertEqual(sessionState, .systemLogOut)
     }
     
-    func didChangeServiceState(state serviceState: RemoteServiceState) {
-        self.serviceState = serviceState
+    @MainActor
+    func test_initiate_resumeSession_with_firebaseAppCheck() throws {
+        let analyticsService = MockAnalyticsService()
+        let sessionManager = MockSessionManager()
+        sessionManager.sessionState = .oneTime
+    
+        let sut = AppQualifyingService(analyticsService: analyticsService,
+                                       updateService: MockAppInformationService(),
+                                       sessionManager: sessionManager)
+    
+        let (appState, sessionState) = waitForSessionStateChange(sut: sut, when: { sut in
+            sut.initiate()
+        })
+    
+        XCTAssertEqual(appState, .qualified)
+        XCTAssertEqual(sessionState, .loggedIn)
     }
 }

--- a/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
+++ b/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
@@ -4,6 +4,7 @@ import Networking
 @testable import OneLogin
 import SecureStore
 import XCTest
+import AppIntegrity
 
 final class AppQualifyingServiceTests: XCTestCase {
     private var analyticsService: MockAnalyticsService!
@@ -24,7 +25,8 @@ final class AppQualifyingServiceTests: XCTestCase {
         appInformationProvider = MockAppInformationService()
         sut = AppQualifyingService(analyticsService: analyticsService,
                                    updateService: appInformationProvider,
-                                   sessionManager: sessionManager)
+                                   sessionManager: sessionManager,
+        appIntegrityProvider: AppIntegrityProviderStub())
     }
 
     override func tearDown() {

--- a/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
+++ b/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
@@ -6,7 +6,6 @@ import Networking
 @testable import OneLogin
 import SecureStore
 import XCTest
-import AppIntegrity
 
 extension AppQualifyingService {
     
@@ -24,17 +23,17 @@ extension AppQualifyingService {
 
 class AppQualifyingServiceDelegateExpectation: AppQualifyingServiceDelegate {
     
-    typealias didChangeAppInfoState = (AppInformationState) -> Void
-    typealias didChangeSessionState = (AppSessionState) -> Void
-    typealias didChangeServiceState = (RemoteServiceState) -> Void
+    typealias DidChangeAppInfoState = (AppInformationState) -> Void
+    typealias DidChangeSessionState = (AppSessionState) -> Void
+    typealias DidChangeServiceState = (RemoteServiceState) -> Void
     
-    let didChangeAppInfoState: didChangeAppInfoState
-    let didChangeSessionState: didChangeSessionState
-    let didChangeServiceState: didChangeServiceState
+    let didChangeAppInfoState: DidChangeAppInfoState
+    let didChangeSessionState: DidChangeSessionState
+    let didChangeServiceState: DidChangeServiceState
     
-    init(didChangeAppInfoState: @escaping didChangeAppInfoState = { _ in },
-         didChangeSessionState: @escaping didChangeSessionState = { _ in },
-         didChangeServiceState: @escaping didChangeServiceState = { _ in }) {
+    init(didChangeAppInfoState: @escaping DidChangeAppInfoState = { _ in },
+         didChangeSessionState: @escaping DidChangeSessionState = { _ in },
+         didChangeServiceState: @escaping DidChangeServiceState = { _ in }) {
         self.didChangeAppInfoState = didChangeAppInfoState
         self.didChangeSessionState = didChangeSessionState
         self.didChangeServiceState = didChangeServiceState
@@ -68,7 +67,7 @@ extension AppQualifyingServiceTests {
         let sut: AppQualifyingService = .make(appInformationProvider: appInformationProvider)
         
         sut.initiate()
-
+        
         wait(for: [expectation], timeout: 5)
         XCTAssertTrue(mockAppInformationService.didCallFetchAppInfo)
     }
@@ -79,14 +78,14 @@ extension AppQualifyingServiceTests {
         let appInformationProvider = MockAppInformationService()
         appInformationProvider.allowAppUsage = false
         let sut: AppQualifyingService = .make(appInformationProvider: appInformationProvider)
-
+        
         let (appState, _) = waitForAppInfoStateChange(sut: sut, when: { sut in
             sut.initiate()
         })
         
         XCTAssertEqual(appState, .unavailable)
     }
-
+    
     @MainActor
     func test_outdatedApp_setsStateCorrectly() {
         // GIVEN the app is outdated
@@ -100,15 +99,15 @@ extension AppQualifyingServiceTests {
         
         XCTAssertEqual(appState, .outdated)
     }
-
+    
     @MainActor
     func test_upToDateApp_setsStateCorrectly() {
         let releaseFlags = ["TestFlag": true]
-
+        
         let appInformationProvider = MockAppInformationService()
         appInformationProvider.releaseFlags = releaseFlags
         let sut: AppQualifyingService = .make(appInformationProvider: appInformationProvider)
-
+        
         let (appState, _) = waitForAppInfoStateChange(sut: sut, when: { sut in
             sut.initiate()
         })
@@ -116,14 +115,14 @@ extension AppQualifyingServiceTests {
         XCTAssertEqual(appState, .qualified)
         XCTAssertEqual(AppEnvironment.remoteReleaseFlags.flags, releaseFlags)
     }
-
+    
     @MainActor
     func test_errorThrown_setsStateCorrectly() {
         // GIVEN `appInfo` cannot be accessed
         let appInformationProvider = MockAppInformationService()
         appInformationProvider.errorFromFetchAppInfo = URLError(.timedOut)
         let sut: AppQualifyingService = .make(appInformationProvider: appInformationProvider)
-
+        
         let (appState, _) = waitForAppInfoStateChange(sut: sut, when: { sut in
             sut.initiate()
         })
@@ -137,7 +136,7 @@ extension AppQualifyingServiceTests {
         let appInformationProvider = MockAppInformationService()
         appInformationProvider.errorFromFetchAppInfo = AppInfoError.notConnectedToInternet
         let sut: AppQualifyingService = .make(appInformationProvider: appInformationProvider)
-
+        
         let (appState, _) = waitForAppInfoStateChange(sut: sut, when: { sut in
             sut.initiate()
         })
@@ -151,7 +150,7 @@ extension AppQualifyingServiceTests {
         let appInformationProvider = MockAppInformationService()
         appInformationProvider.errorFromFetchAppInfo = ServerError(endpoint: "test", errorCode: 400)
         let sut: AppQualifyingService = .make(appInformationProvider: appInformationProvider)
-
+        
         let (_, sessionState) = waitForAppInfoStateChange(sut: sut, when: { sut in
             sut.initiate()
         })
@@ -164,7 +163,7 @@ extension AppQualifyingServiceTests {
         let appInformationProvider = MockAppInformationService()
         appInformationProvider.errorFromFetchAppInfo = AppInfoError.invalidResponse
         let sut: AppQualifyingService = .make(appInformationProvider: appInformationProvider)
-
+        
         let (appState, _) = waitForAppInfoStateChange(sut: sut, when: { sut in
             sut.initiate()
         })
@@ -177,54 +176,60 @@ extension AppQualifyingServiceTests {
 extension AppQualifyingServiceTests {
     
     @MainActor
-    func waitForSessionStateChange(expectation e: XCTestExpectation? = nil, sut: AppQualifyingService, when: (AppQualifyingService) -> Void) -> (appState: AppInformationState?, sessionState: AppSessionState?) {
+    func waitForSessionStateChange(expectation e: XCTestExpectation? = nil,
+                                   sut: AppQualifyingService,
+                                   when: (AppQualifyingService) -> Void)
+    -> (appState: AppInformationState?, sessionState: AppSessionState?) {
         let expectation = e ?? expectation(description: #function)
-        var _appState: AppInformationState? = nil
-        var _sessionState: AppSessionState? = nil
-
+        var _appState: AppInformationState?
+        var _sessionState: AppSessionState?
+        
         let appQualifyingServiceDelegateExpectation = AppQualifyingServiceDelegateExpectation(didChangeAppInfoState: { appState in
             _appState = appState
         }, didChangeSessionState: { sessionState in
             _sessionState = sessionState
             expectation.fulfill()
         })
-
+        
         sut.delegate = appQualifyingServiceDelegateExpectation
         when(sut)
-
+        
         wait(for: [expectation], timeout: 5)
         
         return (appState: _appState, sessionState: _sessionState)
     }
     
     @MainActor
-    func waitForAppInfoStateChange(expectation e: XCTestExpectation? = nil, sut: AppQualifyingService, when: (AppQualifyingService) -> Void) -> (appState: AppInformationState?, sessionState: AppSessionState?) {
+    func waitForAppInfoStateChange(expectation e: XCTestExpectation? = nil,
+                                   sut: AppQualifyingService,
+                                   when: (AppQualifyingService) -> Void)
+    -> (appState: AppInformationState?, sessionState: AppSessionState?) {
         let expectation = e ?? expectation(description: #function)
-        var _appState: AppInformationState? = nil
-        var _sessionState: AppSessionState? = nil
-
+        var _appState: AppInformationState?
+        var _sessionState: AppSessionState?
+        
         let appQualifyingServiceDelegateExpectation = AppQualifyingServiceDelegateExpectation(didChangeAppInfoState: { appState in
             _appState = appState
             expectation.fulfill()
         }, didChangeSessionState: { sessionState in
             _sessionState = sessionState
         })
-
+        
         sut.delegate = appQualifyingServiceDelegateExpectation
         when(sut)
-
+        
         wait(for: [expectation], timeout: 5)
         
         return (appState: _appState, sessionState: _sessionState)
     }
-
+    
     
     @MainActor
     func test_oneTimeUser_userConfirmed() {
         let sessionManager = MockSessionManager()
         sessionManager.sessionState = .oneTime
         let sut: AppQualifyingService = .make(sessionManager: sessionManager)
-
+        
         let (appState, sessionState) = waitForSessionStateChange(sut: sut, when: { sut in
             sut.initiate()
         })
@@ -236,7 +241,7 @@ extension AppQualifyingServiceTests {
     @MainActor
     func test_noExpiryDate_userUnconfirmed() {
         let sut: AppQualifyingService = .make()
-
+        
         let (appState, sessionState) = waitForSessionStateChange(sut: sut, when: { sut in
             sut.initiate()
         })
@@ -251,7 +256,7 @@ extension AppQualifyingServiceTests {
         sessionManager.expiryDate = .distantFuture
         sessionManager.sessionState = .expired
         let sut: AppQualifyingService = .make(sessionManager: sessionManager)
-
+        
         let (appState, sessionState) = waitForSessionStateChange(sut: sut, when: { sut in
             sut.initiate()
         })
@@ -266,7 +271,7 @@ extension AppQualifyingServiceTests {
         sessionManager.expiryDate = .distantFuture
         sessionManager.sessionState = .saved
         let sut: AppQualifyingService = .make(sessionManager: sessionManager)
-
+        
         let (appState, sessionState) = waitForSessionStateChange(sut: sut, when: { sut in
             sut.initiate()
         })
@@ -285,7 +290,7 @@ extension AppQualifyingServiceTests {
         sessionManager.sessionState = .saved
         sessionManager.errorFromResumeSession = RefreshTokenExchangeError.noInternet
         let sut: AppQualifyingService = .make(sessionManager: sessionManager)
-
+        
         let (appState, _) = waitForAppInfoStateChange(expectation: expectation, sut: sut, when: { sut in
             sut.initiate()
         })
@@ -300,7 +305,7 @@ extension AppQualifyingServiceTests {
         sessionManager.sessionState = .saved
         sessionManager.errorFromResumeSession = RefreshTokenExchangeError.appIntegrityFailed
         let sut: AppQualifyingService = .make(sessionManager: sessionManager)
-
+        
         let (appState, sessionState) = waitForSessionStateChange(sut: sut, when: { sut in
             sut.initiate()
         })
@@ -317,7 +322,7 @@ extension AppQualifyingServiceTests {
         sessionManager.sessionState = .saved
         sessionManager.errorFromResumeSession = ServerError(endpoint: "test", errorCode: 400)
         let sut: AppQualifyingService = .make(analyticsService: analyticsService, sessionManager: sessionManager)
-
+        
         let (_, sessionState) = waitForAppInfoStateChange(sut: sut, when: { sut in
             sut.initiate()
         })
@@ -335,7 +340,7 @@ extension AppQualifyingServiceTests {
         sessionManager.sessionState = .saved
         sessionManager.errorFromResumeSession = SecureStoreErrorV2(.cantDecryptData)
         let sut: AppQualifyingService = .make(sessionManager: sessionManager)
-
+        
         let (appState, sessionState) = waitForSessionStateChange(sut: sut, when: { sut in
             sut.initiate()
         })
@@ -355,11 +360,11 @@ extension AppQualifyingServiceTests {
         
         let sut: AppQualifyingService = .make(analyticsService: analyticsService,
                                               sessionManager: sessionManager)
-
+        
         let (appState, sessionState) = waitForSessionStateChange(sut: sut, when: { sut in
             sut.initiate()
         })
-
+        
         XCTAssertEqual(appState, .qualified)
         let error = try XCTUnwrap(analyticsService.crashesLogged.first as? SecureStoreErrorV2)
         XCTAssert(error.kind == .unableToRetrieveFromUserDefaults)
@@ -374,7 +379,7 @@ extension AppQualifyingServiceTests {
         sessionManager.sessionState = .saved
         sessionManager.errorFromResumeSession = SecureStoreErrorV2(.cantDecryptData)
         let sut: AppQualifyingService = .make(sessionManager: sessionManager)
-
+        
         let (appState, sessionState) = waitForAppInfoStateChange(sut: sut, when: { sut in
             sut.initiate()
         })
@@ -394,11 +399,11 @@ extension AppQualifyingServiceTests {
         
         let sut: AppQualifyingService = .make(analyticsService: analyticsService,
                                               sessionManager: sessionManager)
-
+        
         let (appState, sessionState) = waitForSessionStateChange(sut: sut, when: { sut in
             sut.initiate()
         })
-
+        
         XCTAssertEqual(appState, .qualified)
         XCTAssert(analyticsService.crashesLogged.first as? PersistentSessionError == PersistentSessionError(.userRemovedLocalAuth))
         XCTAssert(sessionManager.didCallClearAllSessionData)
@@ -416,11 +421,11 @@ extension AppQualifyingServiceTests {
         
         let sut: AppQualifyingService = .make(analyticsService: analyticsService,
                                               sessionManager: sessionManager)
-
+        
         let (appState, sessionState) = waitForSessionStateChange(sut: sut, when: { sut in
             sut.initiate()
         })
-
+        
         XCTAssertEqual(appState, .qualified)
         XCTAssert(analyticsService.crashesLogged.first as? PersistentSessionError == PersistentSessionError(.noSessionExists))
         XCTAssert(sessionManager.didCallClearAllSessionData)
@@ -438,11 +443,11 @@ extension AppQualifyingServiceTests {
         
         let sut: AppQualifyingService = .make(analyticsService: analyticsService,
                                               sessionManager: sessionManager)
-
+        
         let (appState, sessionState) = waitForSessionStateChange(sut: sut, when: { sut in
             sut.initiate()
         })
-
+        
         XCTAssertEqual(appState, .qualified)
         XCTAssert(analyticsService.crashesLogged.first as? PersistentSessionError == PersistentSessionError(.idTokenNotStored))
         XCTAssert(sessionManager.didCallClearAllSessionData)
@@ -460,7 +465,7 @@ extension AppQualifyingServiceTests {
         sessionManager.errorFromClearAllSessionData = MockWalletError.cantDelete
         let sut: AppQualifyingService = .make(analyticsService: analyticsService,
                                               sessionManager: sessionManager)
-
+        
         let (appState, sessionState) = waitForSessionStateChange(sut: sut, when: { sut in
             sut.initiate()
         })
@@ -480,7 +485,7 @@ extension AppQualifyingServiceTests {
         let appInformationProvider = MockAppInformationService()
         appInformationProvider.errorFromFetchAppInfo = AppInfoError.invalidResponse
         let sut: AppQualifyingService = .make(appInformationProvider: appInformationProvider)
-
+        
         let (_, sessionState) = waitForSessionStateChange(sut: sut, when: { _ in
             NotificationCenter.default.post(name: .enrolmentComplete)
         })
@@ -493,7 +498,7 @@ extension AppQualifyingServiceTests {
         let appInformationProvider = MockAppInformationService()
         appInformationProvider.errorFromFetchAppInfo = AppInfoError.invalidResponse
         let sut: AppQualifyingService = .make(appInformationProvider: appInformationProvider)
-
+        
         let (_, sessionState) = waitForSessionStateChange(sut: sut, when: { _ in
             NotificationCenter.default.post(name: .sessionExpired)
         })
@@ -506,7 +511,7 @@ extension AppQualifyingServiceTests {
         let appInformationProvider = MockAppInformationService()
         appInformationProvider.errorFromFetchAppInfo = AppInfoError.invalidResponse
         let sut: AppQualifyingService = .make(appInformationProvider: appInformationProvider)
-
+        
         let (_, sessionState) = waitForSessionStateChange(sut: sut, when: { _ in
             NotificationCenter.default.post(name: .systemLogUserOut)
         })
@@ -519,15 +524,15 @@ extension AppQualifyingServiceTests {
         let analyticsService = MockAnalyticsService()
         let sessionManager = MockSessionManager()
         sessionManager.sessionState = .oneTime
-    
+        
         let sut = AppQualifyingService(analyticsService: analyticsService,
                                        updateService: MockAppInformationService(),
                                        sessionManager: sessionManager)
-    
+        
         let (appState, sessionState) = waitForSessionStateChange(sut: sut, when: { sut in
             sut.initiate()
         })
-    
+        
         XCTAssertEqual(appState, .qualified)
         XCTAssertEqual(sessionState, .loggedIn)
     }

--- a/Tests/UnitTests/Service/NetworkingServiceTests.swift
+++ b/Tests/UnitTests/Service/NetworkingServiceTests.swift
@@ -21,7 +21,8 @@ struct NetworkingSerivceTests {
         sut = NetworkingService(
             networkClient: networkClient,
             refreshExchangeManager: MockRefreshTokenExchangeManager(),
-            sessionManager: mockSessionManager
+            sessionManager: mockSessionManager,
+            appIntegrityProvider: AppIntegrityProviderStub()
         )
         
         networkClient.authorizationProvider = self

--- a/Tests/UnitTests/Stubs/AppIntegrityProviderStub.swift
+++ b/Tests/UnitTests/Stubs/AppIntegrityProviderStub.swift
@@ -1,0 +1,5 @@
+import AppIntegrity
+
+struct AppIntegrityProviderStub: AppIntegrityProvider {
+    let integrityAssertions: [String : String] = [:]
+}

--- a/Tests/UnitTests/Stubs/AppIntegrityProviderStub.swift
+++ b/Tests/UnitTests/Stubs/AppIntegrityProviderStub.swift
@@ -1,5 +1,5 @@
 import AppIntegrity
 
 struct AppIntegrityProviderStub: AppIntegrityProvider {
-    let integrityAssertions: [String : String] = [:]
+    let integrityAssertions: [String: String] = [:]
 }

--- a/scripts-configs/sonar-project.properties
+++ b/scripts-configs/sonar-project.properties
@@ -6,6 +6,9 @@ sonar.organization=govuk-one-login
 sonar.sources=Sources,AppIntegrity/Sources,LocalAuthenticationWrapper/Sources,MobilePlatformServices/Sources
 sonar.tests=Tests,AppIntegrity/Tests,LocalAuthenticationWrapper/Tests,MobilePlatformServices/Tests
 
+sonar.coverage.exclusions=Sources/Application/TestAppDelegate.swift,Sources/Application/TestingSceneDelegate.swift
+sonar.exclusions=Sources/Application/main.swift,Sources/Application/TestAppDelegate.swift,Sources/Application/TestingSceneDelegate.swift
+
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8
 sonar.pullrequest.provider=github


### PR DESCRIPTION
# Replace the AppDelegate with a TestDelegate

The proposed code changes in this PR aim to

* remove any side effects
* improve reliability
* reduce the time it takes to run tests 

as they relate mainly due to configuring and kickstarting Firebase which is what the AppDelgate does. 

# Changes

* Introduce a TestDelegate when running tests. The `TestDelegate` is conditional on an environment variable (i.e. IS_RUNNING_TESTS) which is expected to be set by a test plan when running logic tests. In the future, the same environment variable can be used when running UI Tests.

This is done in order to speedup test execution, eliminate any side effects and improve reliability. As an example, the `AppDelegate` configures Firebase which may have affected the [reliability of our UI Tests](https://github.com/govuk-one-login/mobile-ios-one-login-app/pull/747). The `SceneDelegate` initiates the `AppQualifyingService` which in turn performs a firebaseAppCheck under certain conditions.)

I have performed a first-time installation of the app on the simulator to test that the application delegate is correctly assigned and the scene is connected. Bellow is a screenshot of the app running for the first time using the main.swift file introduced in the PR.


<img width="50%" height="50%" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-14 at 20 25 09" src="https://github.com/user-attachments/assets/6d7f3d2f-a4aa-422b-803b-6a26c4b281c1" />

The change required replacing the [main attribute](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/attributes/#main) in favor of a `main.swift` file that, at runtime evaluates the app delegate to use.

* Another change is the call to `FirebaseAppIntegrityService.firebaseAppCheck()`.  A reference to the `FirebaseAppIntegrityService.firebaseAppCheck()` function is passed on as a dependency with a default value of `FirebaseAppIntegrityService.firebaseAppCheck()` so that tests can provide a stub since Firebase is not configured in the `TestAppDelegate` when running tests like in the `AppDelegate`.

This PR also resolves an issue where a log entry reported
> Class _TtC10Networking13NetworkClient is implemented in both 
	MockNetworking_2571C89223E3A5C0_PackageProduct.framework and OneLogin.app/OneLogin.debug.dylib 

with a warning of 

> "This may cause spurious casting failures and mysterious crashes. One of the duplicates must be removed or renamed." 

This was resolved by removing the MockNetworking library from the test target.

# Where to focus the review

The vast majority of code changes do not change any of the test assertions, other than a few rare cases where it was deemed necessary.

* Please double check the changes on each test case to ensure no accidental changes to the tests have been made.
* Please review the changes in the `AppQualifyingService` and `NetworkingService` as they relate to the `firebaseAppCheck()`. Does it work as expected?
 * Review the logic in the `main.swift` that assigns the correct delegate. Do you think there is a different implementation that minimises the risk of picking up the wrong delegate under the normal lifecycle of the app?

# Background reading
* [What does @main do in Swift 5.3?](https://useyourloaf.com/blog/what-does-@main-do-in-swift-5.3/)
* [UIApplicationMain(_:_:_:_:)](https://developer.apple.com/documentation/uikit/uiapplicationmain(_:_:_:_:)-1yub7)
* [Testing Tips & Tricks](https://developer.apple.com/videos/play/wwdc2018/417/)
* [Testing Tips & Tricks Presentation Slide, Page 170](https://devstreaming-cdn.apple.com/videos/wwdc/2018/417j8ucs9p8w7seip/417/417_testing_tips__tricks.pdf?dl=1)

<img width="1800" height="1182" alt="Screenshot 2026-04-27 at 12 53 30" src="https://github.com/user-attachments/assets/e38ee797-cb0b-4baa-a815-c077e1939184" />



# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [ ] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
