### PR TITLE
DMCAW-0000 improve execution time on unit tests

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		7CF44B282CAB45A70027839B /* AppIntegrity in Frameworks */ = {isa = PBXBuildFile; productRef = 7CF44B272CAB45A70027839B /* AppIntegrity */; };
 		7CFFE7CE2C9D960E00ABD8A0 /* WalletSessionData+OneLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CFFE7CD2C9D960100ABD8A0 /* WalletSessionData+OneLogin.swift */; };
 		8E620E5D2F9A72CF00192775 /* MockChildCoordinatorExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E620E5C2F9A72CF00192775 /* MockChildCoordinatorExpectation.swift */; };
+		8E660A6A2F9B940F00120531 /* MockNavigationControllerExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E660A692F9B940F00120531 /* MockNavigationControllerExpectation.swift */; };
 		8E5B38182F8ECA1800C175F3 /* TestingSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E5B37EA2F8EC7F600C175F3 /* TestingSceneDelegate.swift */; };
 		8E8CAC0A2F894AF90010679E /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E8CAC092F894AF90010679E /* main.swift */; };
 		8E8CAC0C2F894B1A0010679E /* TestAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E8CAC0B2F894B1A0010679E /* TestAppDelegate.swift */; };
@@ -695,6 +696,7 @@
 		7CDC2EC32C8B247300EAA592 /* MockHelloWorldService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHelloWorldService.swift; sourceTree = "<group>"; };
 		7CFFE7CD2C9D960100ABD8A0 /* WalletSessionData+OneLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WalletSessionData+OneLogin.swift"; sourceTree = "<group>"; };
 		8E620E5C2F9A72CF00192775 /* MockChildCoordinatorExpectation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockChildCoordinatorExpectation.swift; sourceTree = "<group>"; };
+		8E660A692F9B940F00120531 /* MockNavigationControllerExpectation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNavigationControllerExpectation.swift; sourceTree = "<group>"; };
 		8E5B37EA2F8EC7F600C175F3 /* TestingSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestingSceneDelegate.swift; sourceTree = "<group>"; };
 		8E8CAC092F894AF90010679E /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		8E8CAC0B2F894B1A0010679E /* TestAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAppDelegate.swift; sourceTree = "<group>"; };
@@ -1324,6 +1326,7 @@
 		21FA1C4A2AE183830052136E /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				8E660A682F9B940100120531 /* UIKit */,
 				8E620E5B2F9A72BD00192775 /* Coordination */,
 				7CD66F852C90A95C008513F4 /* Qualification */,
 				C85DF8442AEBFDF00064F68E /* ReturnTypes */,
@@ -1586,6 +1589,14 @@
 				8E620E5C2F9A72CF00192775 /* MockChildCoordinatorExpectation.swift */,
 			);
 			path = Coordination;
+			sourceTree = "<group>";
+		};
+		8E660A682F9B940100120531 /* UIKit */ = {
+			isa = PBXGroup;
+			children = (
+				8E660A692F9B940F00120531 /* MockNavigationControllerExpectation.swift */,
+			);
+			path = UIKit;
 			sourceTree = "<group>";
 		};
 		ABB941FD2C6CAD840007052B /* Service */ = {
@@ -3609,6 +3620,7 @@
 				41FF35AF2B222CAC00419DB3 /* WebAuthenticationServiceTests.swift in Sources */,
 				41C8E42F2B72920F0063B8A3 /* BiometricsEnrolmentViewModelTests.swift in Sources */,
 				C8D678222C540297000AA26C /* DataDeletedWarningViewModelTests.swift in Sources */,
+				8E660A6A2F9B940F00120531 /* MockNavigationControllerExpectation.swift in Sources */,
 				C86E223E2BE108140085453F /* DeveloperMenuViewControllerTests.swift in Sources */,
 				C8BFE5E72CB57A8700FA9A35 /* DeveloperMenuViewModelTests.swift in Sources */,
 				C81ECB212B71769F00AFC3A6 /* EnrolmentCoordinatorTests.swift in Sources */,

--- a/Sources/Tabs/SettingsCoordinator.swift
+++ b/Sources/Tabs/SettingsCoordinator.swift
@@ -12,7 +12,7 @@ final class SettingsCoordinator: NSObject,
                                  ChildCoordinator,
                                  NavigationCoordinator,
                                  TabItemCoordinator {
-    let root = UINavigationController()
+    let root: UINavigationController
     weak var parentCoordinator: ParentCoordinator?
     
     private let analyticsService: OneLoginAnalyticsService
@@ -21,11 +21,13 @@ final class SettingsCoordinator: NSObject,
     private let urlOpener: URLOpener
     
     init(
+        root: UINavigationController? = nil,
         analyticsService: OneLoginAnalyticsService,
         sessionManager: SessionManager & UserProvider,
         networkingService: OneLoginNetworkingService,
         urlOpener: URLOpener
     ) {
+        self.root = root ?? UINavigationController()
         self.analyticsService = analyticsService
         self.sessionManager = sessionManager
         self.networkingService = networkingService

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -6,6 +6,47 @@ import GDSCommon
 import SecureStore
 import XCTest
 
+class MockNavigationControllerExpectation: UINavigationController {
+    var expectation: XCTestExpectation?
+    
+    init(expectation: XCTestExpectation? = nil) {
+        self.expectation = expectation
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+    
+    override func pushViewController(_ viewController: UIViewController, animated: Bool) {
+        super.pushViewController(viewController, animated: animated)
+        self.expectation?.fulfill()
+    }
+}
+
+extension LoginCoordinator {
+    
+    static func make(mockNavigationController: UINavigationController = UINavigationController(), mockSessionManager: SessionManager = MockSessionManager()) -> LoginCoordinator {
+        
+        let appWindow = UIWindow()
+        let mockAnalyticsService = MockAnalyticsService()
+        let mockNetworkMonitor = MockNetworkMonitor()
+        let mockAuthenticationService = MockAuthenticationService(sessionManager: mockSessionManager)
+        appWindow.rootViewController = mockNavigationController
+        appWindow.makeKeyAndVisible()
+
+        return LoginCoordinator(appWindow: appWindow,
+                               root: mockNavigationController,
+                               analyticsService: mockAnalyticsService,
+                               sessionManager: mockSessionManager,
+                               networkMonitor: mockNetworkMonitor,
+                               authService: mockAuthenticationService,
+                               sessionState: .notLoggedIn,
+                               serviceState: nil)
+        
+    }
+}
+
 final class LoginCoordinatorTests: XCTestCase {
     var appWindow: UIWindow!
     var navigationController: UINavigationController!
@@ -61,6 +102,61 @@ final class LoginCoordinatorTests: XCTestCase {
                                sessionState: .expired,
                                serviceState: nil)
     }
+    
+    @MainActor
+    func given(errorFromStartSession: Error, when: (LoginCoordinator) -> Void) throws -> GDSErrorViewModelV3 {
+        let startAuthSessionExpectation = expectation(description: #function)
+        let pushViewControllerExpectation = self.expectation(description: #function)
+
+        // GIVEN the authentication session returns a sessionMismatch error
+        let mockNavigationController = MockNavigationControllerExpectation(expectation: pushViewControllerExpectation)
+        
+        let mockSessionManager = MockSessionManager()
+        let mockSessionManagerExpectation = MockSessionManagerExpectation(sessionManager: mockSessionManager, didStartAuthSessionAsFunction: { _, _ in
+            startAuthSessionExpectation.fulfill()
+        })
+        
+        mockSessionManager.errorFromStartSession = errorFromStartSession
+        let sut: LoginCoordinator = .make(mockNavigationController: mockNavigationController, mockSessionManager: mockSessionManagerExpectation)
+
+        when(sut)
+
+        wait(for: [startAuthSessionExpectation, pushViewControllerExpectation], timeout: 10)
+        XCTAssertTrue(mockSessionManager.didCallStartSession)
+        
+        let vc = try XCTUnwrap(mockNavigationController.topViewController as? GDSErrorScreen)
+        
+        return vc.viewModel
+    }
+    
+    @MainActor
+    func given(errorFromStartSession: Error, repeats count: Int, when:(LoginCoordinator) -> Void, then: (_ count: Int, _ topViewController: UIViewController?) throws -> Void) rethrows {
+        let mockNavigationController = MockNavigationControllerExpectation()
+        let mockSessionManager = MockSessionManager()
+        mockSessionManager.errorFromStartSession = errorFromStartSession
+        let mockSessionManagerExpectation = MockSessionManagerExpectation(sessionManager: mockSessionManager)
+        
+        let sut: LoginCoordinator = .make(mockNavigationController: mockNavigationController, mockSessionManager: mockSessionManagerExpectation)
+
+        for count in 1...count {
+            let startAuthSessionExpectation = expectation(description: #function)
+            mockSessionManagerExpectation.didStartAuthSessionAsFunction = { _, _ in
+                startAuthSessionExpectation.fulfill()
+            }
+            
+            mockSessionManager.didCallStartSession = false
+            
+            let pushViewControllerExpectation = self.expectation(description: #function)
+            mockNavigationController.expectation = pushViewControllerExpectation
+            
+            when(sut)
+            
+            wait(for: [startAuthSessionExpectation, pushViewControllerExpectation], timeout: 10)
+            XCTAssertTrue(mockSessionManager.didCallStartSession)
+            
+            try then(count, mockNavigationController.topViewController)
+        }
+    }
 }
 
 enum AuthenticationError: Error {
@@ -93,10 +189,19 @@ extension LoginCoordinatorTests {
     
     @MainActor
     func test_authenticate_launchAuthenticationService() {
+        let expectation = expectation(description: #function)
+        let mockSessionManager = MockSessionManager()
+        let mockSessionManagerExpectation = MockSessionManagerExpectation(sessionManager: mockSessionManager, didStartAuthSessionAsFunction: { _, _ in
+            expectation.fulfill()
+        })
+        
+        let sut: LoginCoordinator = .make(mockSessionManager: mockSessionManagerExpectation)
+        
         // WHEN the LoginCoordinator's authenticate method is called
         sut.authenticate()
         // THEN the AuthenticationService should be launched
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
+        wait(for: [expectation], timeout: 20)
+        XCTAssertTrue(mockSessionManager.didCallStartSession)
     }
     
     @MainActor
@@ -113,578 +218,559 @@ extension LoginCoordinatorTests {
     
     @MainActor
     func test_launchAuthenticationService() {
+        let expectation = self.expectation(description: #function)
+        let mockSessionManager = MockSessionManager()
+        let mockSessionManagerExpectation = MockSessionManagerExpectation(sessionManager: mockSessionManager,
+                                                                          didStartAuthSessionAsFunction: { _, _ in
+            expectation.fulfill()
+        })
+        
+        let sut: LoginCoordinator = .make(mockSessionManager: mockSessionManagerExpectation)
+        
         // WHEN the LoginCoordinator's launchAuthenticationService method is called
         sut.launchAuthenticationService()
         // THEN the AuthenticationService should be launched
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
+        wait(for: [expectation], timeout: 20)
+        XCTAssertTrue(mockSessionManager.didCallStartSession)
     }
     
     @MainActor
     func test_launchAuthenticationService_sessionMismatch() throws {
         // GIVEN the authentication session returns a sessionMismatch error
-        mockSessionManager.errorFromStartSession = PersistentSessionError(.sessionMismatch)
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        let viewModel = try given(errorFromStartSession: PersistentSessionError(.sessionMismatch), when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
         // THEN the visible view controller's view model should be the DataDeletedWarningViewModel
-        XCTAssertTrue(vc.viewModel is DataDeletedWarningViewModel)
+        XCTAssertTrue(viewModel is DataDeletedWarningViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_cannotDeleteData() throws {
         // GIVEN the authentication session returns a cannotDeleteData error
-        mockSessionManager.errorFromStartSession = PersistentSessionError(.cannotDeleteData,
+        let errorFromStartSession = PersistentSessionError(.cannotDeleteData,
                                                                           originalError: MockWalletError.cantDelete)
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
-        // THEN the visible view controller's view model should be the UnableToLoginErrorViewModel
-        XCTAssertTrue(vc.viewModel is RecoverableLoginErrorViewModel)
+        let viewModel = try given(errorFromStartSession: errorFromStartSession, when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
+        // THEN the visible view controller's view model should be the RecoverableLoginErrorViewModel
+        XCTAssertTrue(viewModel is RecoverableLoginErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_idTokenNotStored() throws {
         // GIVEN the authentication session returns a idTokenNotStored error
-        mockSessionManager.errorFromStartSession = PersistentSessionError(.idTokenNotStored)
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        let viewModel = try given(errorFromStartSession: PersistentSessionError(.idTokenNotStored), when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
         // THEN the visible view controller's view model should be the GenericErrorViewModel
-        XCTAssertTrue(vc.viewModel is GenericErrorViewModel)
+        XCTAssertTrue(viewModel is GenericErrorViewModel)
+
     }
     
     @MainActor
     func test_launchAuthenticationService_accessDenied() throws {
         // GIVEN the authentication session returns an access denied error
-        mockSessionManager.errorFromStartSession = LoginError(reason: .authorizationAccessDenied)
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        let viewModel = try given(errorFromStartSession: LoginError(reason: .authorizationAccessDenied), when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
         // THEN the visible view controller's view model should be the DataDeletedWarningViewModel
-        XCTAssertTrue(vc.viewModel is DataDeletedWarningViewModel)
+        XCTAssertTrue(viewModel is DataDeletedWarningViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_network() throws {
         // GIVEN the authentication session returns a network error
-        mockSessionManager.errorFromStartSession = LoginError(reason: .network)
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        let viewModel = try given(errorFromStartSession: LoginError(reason: .network), when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
         // THEN the visible view controller's view model should be the NetworkConnectionErrorViewModel
-        XCTAssertTrue(vc.viewModel is NetworkConnectionErrorViewModel)
+        XCTAssertTrue(viewModel is NetworkConnectionErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_authInvalidRequest() throws {
         // GIVEN the authentication session returns an invalidRequest error
-        mockSessionManager.errorFromStartSession = LoginError(reason: .authorizationInvalidRequest)
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        let viewModel = try given(errorFromStartSession: LoginError(reason: .authorizationInvalidRequest), when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
         // THEN the visible view controller's view model should be the UnrecoverableLoginErrorViewModel
-        XCTAssertTrue(vc.viewModel is UnrecoverableLoginErrorViewModel)
+        XCTAssertTrue(viewModel is UnrecoverableLoginErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_authUnauthorizedClient() throws {
-        // GIVEN the authentication session returns an invalidRequest error
-        mockSessionManager.errorFromStartSession = LoginError(reason: .authorizationUnauthorizedClient)
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        // GIVEN the authentication session returns an unauthorizedClient error
+        let viewModel = try given(errorFromStartSession: LoginError(reason: .authorizationUnauthorizedClient), when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
         // THEN the visible view controller's view model should be the UnrecoverableLoginErrorViewModel
-        XCTAssertTrue(vc.viewModel is UnrecoverableLoginErrorViewModel)
+        XCTAssertTrue(viewModel is UnrecoverableLoginErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_unsupportedResponse() throws {
-        // GIVEN the authentication session returns an invalidRequest error
+        // GIVEN the authentication session returns an unsupportedResponseType error
         mockSessionManager.errorFromStartSession = LoginError(reason: .authorizationUnsupportedResponseType)
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        let viewModel = try given(errorFromStartSession: LoginError(reason: .authorizationUnsupportedResponseType), when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
         // THEN the visible view controller's view model should be the UnrecoverableLoginErrorViewModel
-        XCTAssertTrue(vc.viewModel is UnrecoverableLoginErrorViewModel)
+        XCTAssertTrue(viewModel is UnrecoverableLoginErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_authInvalidScope() throws {
-        // GIVEN the authentication session returns an invalidRequest error
-        mockSessionManager.errorFromStartSession = LoginError(reason: .authorizationInvalidScope)
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        // GIVEN the authentication session returns an invalidScope error
+        let viewModel = try given(errorFromStartSession: LoginError(reason: .authorizationInvalidScope), when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
         // THEN the visible view controller's view model should be the UnrecoverableLoginErrorViewModel
-        XCTAssertTrue(vc.viewModel is UnrecoverableLoginErrorViewModel)
+        XCTAssertTrue(viewModel is UnrecoverableLoginErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_temporarilyUnavailable() throws {
-        // GIVEN the authentication session returns an invalidRequest error
-        mockSessionManager.errorFromStartSession = LoginError(reason: .authorizationTemporarilyUnavailable)
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        // GIVEN the authentication session returns an temporarilyUnavailable error
+        let viewModel = try given(errorFromStartSession: LoginError(reason: .authorizationTemporarilyUnavailable), when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
         // THEN the visible view controller's view model should be the UnrecoverableLoginErrorViewModel
-        XCTAssertTrue(vc.viewModel is UnrecoverableLoginErrorViewModel)
+        XCTAssertTrue(viewModel is UnrecoverableLoginErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_tokenInvalidRequest() throws {
         // GIVEN the authentication session returns an invalidRequest error
-        mockSessionManager.errorFromStartSession = LoginError(reason: .tokenInvalidRequest)
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        let viewModel = try given(errorFromStartSession: LoginError(reason: .tokenInvalidRequest), when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
         // THEN the visible view controller's view model should be the UnrecoverableLoginErrorViewModel
-        XCTAssertTrue(vc.viewModel is UnrecoverableLoginErrorViewModel)
+        XCTAssertTrue(viewModel is UnrecoverableLoginErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_tokenUnauthorizedClient() throws {
-        // GIVEN the authentication session returns an invalidRequest error
-        mockSessionManager.errorFromStartSession = LoginError(reason: .tokenUnauthorizedClient)
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        // GIVEN the authentication session returns an tokenUnauthorizedClient error
+        let viewModel = try given(errorFromStartSession: LoginError(reason: .tokenUnauthorizedClient), when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
         // THEN the visible view controller's view model should be the UnrecoverableLoginErrorViewModel
-        XCTAssertTrue(vc.viewModel is UnrecoverableLoginErrorViewModel)
+        XCTAssertTrue(viewModel is UnrecoverableLoginErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_tokenInvalidScope() throws {
-        // GIVEN the authentication session returns an invalidRequest error
-        mockSessionManager.errorFromStartSession = LoginError(reason: .tokenInvalidScope)
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        // GIVEN the authentication session returns an tokenInvalidScope error
+        let viewModel = try given(errorFromStartSession: LoginError(reason: .tokenInvalidScope), when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
         // THEN the visible view controller's view model should be the UnrecoverableLoginErrorViewModel
-        XCTAssertTrue(vc.viewModel is UnrecoverableLoginErrorViewModel)
+        XCTAssertTrue(viewModel is UnrecoverableLoginErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_invalidClient() throws {
-        // GIVEN the authentication session returns an invalidRequest error
-        mockSessionManager.errorFromStartSession = LoginError(reason: .tokenInvalidClient)
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        // GIVEN the authentication session returns an tokenInvalidClient error
+        let viewModel = try given(errorFromStartSession: LoginError(reason: .tokenInvalidClient), when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
         // THEN the visible view controller's view model should be the UnrecoverableLoginErrorViewModel
-        XCTAssertTrue(vc.viewModel is UnrecoverableLoginErrorViewModel)
+        XCTAssertTrue(viewModel is UnrecoverableLoginErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_invalidGrant() throws {
-        // GIVEN the authentication session returns an invalidRequest error
-        mockSessionManager.errorFromStartSession = LoginError(reason: .tokenInvalidGrant)
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        // GIVEN the authentication session returns an tokenInvalidGrant error
+        let viewModel = try given(errorFromStartSession: LoginError(reason: .tokenInvalidGrant), when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
         // THEN the visible view controller's view model should be the UnrecoverableLoginErrorViewModel
-        XCTAssertTrue(vc.viewModel is UnrecoverableLoginErrorViewModel)
+        XCTAssertTrue(viewModel is UnrecoverableLoginErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_unsupportedGrant() throws {
-        // GIVEN the authentication session returns an invalidRequest error
-        mockSessionManager.errorFromStartSession = LoginError(reason: .tokenUnsupportedGrantType)
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        // GIVEN the authentication session returns an tokenUnsupportedGrantType error
+        let viewModel = try given(errorFromStartSession: LoginError(reason: .tokenUnsupportedGrantType), when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
         // THEN the visible view controller's view model should be the UnrecoverableLoginErrorViewModel
-        XCTAssertTrue(vc.viewModel is UnrecoverableLoginErrorViewModel)
+        XCTAssertTrue(viewModel is UnrecoverableLoginErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_clientError() throws {
-        // GIVEN the authentication session returns an invalidRequest error
-        mockSessionManager.errorFromStartSession = LoginError(reason: .tokenClientError)
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        // GIVEN the authentication session returns an tokenClientError error
+        let viewModel = try given(errorFromStartSession: LoginError(reason: .tokenClientError), when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
         // THEN the visible view controller's view model should be the UnrecoverableLoginErrorViewModel
-        XCTAssertTrue(vc.viewModel is UnrecoverableLoginErrorViewModel)
+        XCTAssertTrue(viewModel is UnrecoverableLoginErrorViewModel)
     }
-    
+
     @MainActor
     func test_launchAuthenticationService_authServerError() throws {
-        // GIVEN the authentication session returns an invalidRequest error
-        mockSessionManager.errorFromStartSession = LoginError(reason: .authorizationServerError)
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
-        // THEN the visible view controller's view model should be the RecoverableLoginErrorViewModel
-        XCTAssertTrue(vc.viewModel is RecoverableLoginErrorViewModel)
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        let vc2 = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
-        XCTAssertTrue(vc2.viewModel is RecoverableLoginErrorViewModel)
-        
-        // 3rd server error should show non-recoverable error screen
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        let vc3 = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
-        XCTAssertTrue(vc3.viewModel is UnrecoverableLoginErrorViewModel)
+        let threeTimes = 3
+        // GIVEN the authentication session returns a serverError error
+        try self.given(errorFromStartSession: LoginError(reason: .authorizationServerError), repeats: threeTimes, when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        }, then: { attempt, vc in
+            if attempt < threeTimes {
+                // THEN the visible view controller's view model should be the RecoverableLoginErrorViewModel
+                let vc = try XCTUnwrap(vc as? GDSErrorScreen)
+                XCTAssertTrue(vc.viewModel is RecoverableLoginErrorViewModel)
+            }
+            else {
+                // 3rd server error should show non-recoverable error screen
+                let vc = try XCTUnwrap(vc as? GDSErrorScreen)
+                XCTAssertTrue(vc.viewModel is UnrecoverableLoginErrorViewModel)
+            }
+        })
     }
     
     @MainActor
     func test_launchAuthenticationService_authUnknownError() throws {
-        // GIVEN the authentication session returns an invalidRequest error
-        mockSessionManager.errorFromStartSession = LoginError(reason: .authorizationUnknownError)
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        // GIVEN the authentication session returns an authorizationUnknownError error
+        let viewModel = try given(errorFromStartSession: LoginError(reason: .authorizationUnknownError), when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
         // THEN the visible view controller's view model should be the RecoverableLoginErrorViewModel
-        XCTAssertTrue(vc.viewModel is RecoverableLoginErrorViewModel)
+        XCTAssertTrue(viewModel is RecoverableLoginErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_tokenUnknownError() throws {
-        // GIVEN the authentication session returns a clientError error
-        mockSessionManager.errorFromStartSession = LoginError(reason: .tokenUnknownError)
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
-        // THEN the visible view controller's view model should be the UnableToLoginErrorViewModel
-        XCTAssertTrue(vc.viewModel is RecoverableLoginErrorViewModel)
+        // GIVEN the authentication session returns an tokenUnknownError error
+        let viewModel = try given(errorFromStartSession: LoginError(reason: .tokenUnknownError), when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
+        // THEN the visible view controller's view model should be the RecoverableLoginErrorViewModel
+        XCTAssertTrue(viewModel is RecoverableLoginErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_serverError() throws {
-        // GIVEN the authentication session returns a serverError error
-        mockSessionManager.errorFromStartSession = LoginError(reason: .generalServerError)
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
-        // THEN the visible view controller's view model should be the UnableToLoginErrorViewModel
-        XCTAssertTrue(vc.viewModel is RecoverableLoginErrorViewModel)
-        
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        let vc2 = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
-        XCTAssertTrue(vc2.viewModel is RecoverableLoginErrorViewModel)
-        
-        // 3rd server error should show non-recoverable error screen
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        let vc3 = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
-        XCTAssertTrue(vc3.viewModel is UnrecoverableLoginErrorViewModel)
+        let threeTimes = 3
+        try self.given(errorFromStartSession: LoginError(reason: .generalServerError), repeats: threeTimes, when: { sut in
+            sut.launchAuthenticationService()
+        }, then: { attempt, vc in
+            if attempt < threeTimes {
+                let vc = try XCTUnwrap(vc as? GDSErrorScreen)
+                XCTAssertTrue(vc.viewModel is RecoverableLoginErrorViewModel)
+            }
+            else {
+                let vc = try XCTUnwrap(vc as? GDSErrorScreen)
+                XCTAssertTrue(vc.viewModel is UnrecoverableLoginErrorViewModel)
+            }
+        })
     }
     
     @MainActor
     func test_launchAuthenticationService_safariError() throws {
-        // GIVEN the authentication session returns a serverError error
-        mockSessionManager.errorFromStartSession = LoginError(reason: .safariOpenError)
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
-        // THEN the visible view controller's view model should be the UnableToLoginErrorViewModel
-        XCTAssertTrue(vc.viewModel is RecoverableLoginErrorViewModel)
+        // GIVEN the authentication session returns an safariOpenError error
+        let viewModel = try given(errorFromStartSession: LoginError(reason: .safariOpenError), when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
+        // THEN the visible view controller's view model should be the RecoverableLoginErrorViewModel
+        XCTAssertTrue(viewModel is RecoverableLoginErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_jwtFetchError() throws {
         // GIVEN the authentication session returns an unableToFetchJWKs error
-        mockSessionManager.errorFromStartSession = JWTVerifierError.unableToFetchJWKs
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
-        // THEN the visible view controller's view model should be the UnableToLoginErrorViewModel
-        XCTAssertTrue(vc.viewModel is RecoverableLoginErrorViewModel)
+        let viewModel = try given(errorFromStartSession: JWTVerifierError.unableToFetchJWKs, when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
+        // THEN the visible view controller's view model should be the RecoverableLoginErrorViewModel
+        XCTAssertTrue(viewModel is RecoverableLoginErrorViewModel)
+
     }
     
     @MainActor
     func test_launchAuthenticationService_jwtVerifyError() throws {
         // GIVEN the authentication session returns an invalidJWTFormat error
-        mockSessionManager.errorFromStartSession = JWTVerifierError.invalidJWTFormat
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
-        // THEN the visible view controller's view model should be the UnableToLoginErrorViewModel
-        XCTAssertTrue(vc.viewModel is RecoverableLoginErrorViewModel)
+        let viewModel = try given(errorFromStartSession: JWTVerifierError.invalidJWTFormat, when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
+        // THEN the visible view controller's view model should be the RecoverableLoginErrorViewModel
+        XCTAssertTrue(viewModel is RecoverableLoginErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_appIntegrityNetworkError() throws {
         // GIVEN the authentication session returns an app integrity network error
-        mockSessionManager.errorFromStartSession = FirebaseAppCheckError(
+        let errorFromStartSession = FirebaseAppCheckError(
             .network,
             reason: "test reason"
         )
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        let viewModel = try given(errorFromStartSession: errorFromStartSession, when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
         // THEN the visible view controller's view model should be the AppIntegrityErrorViewModel
-        XCTAssertTrue(vc.viewModel is AppIntegrityErrorViewModel)
+        XCTAssertTrue(viewModel is AppIntegrityErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_appIntegrityUnknownError() throws {
         // GIVEN the authentication session returns an app integrity unknown error
-        mockSessionManager.errorFromStartSession = FirebaseAppCheckError(
+        let errorFromStartSession = FirebaseAppCheckError(
             .unknown,
             reason: "test reason"
         )
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        let viewModel = try given(errorFromStartSession: errorFromStartSession, when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
         // THEN the visible view controller's view model should be the AppIntegrityErrorViewModel
-        XCTAssertTrue(vc.viewModel is AppIntegrityErrorViewModel)
+        XCTAssertTrue(viewModel is AppIntegrityErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_appIntegrityGenericError() throws {
         // GIVEN the authentication session returns an app integrity generic error
-        mockSessionManager.errorFromStartSession = FirebaseAppCheckError(
+        let errorFromStartSession = FirebaseAppCheckError(
             .generic,
             reason: "test reason"
         )
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        let viewModel = try given(errorFromStartSession: errorFromStartSession, when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
         // THEN the visible view controller's view model should be the AppIntegrityErrorViewModel
-        XCTAssertTrue(vc.viewModel is AppIntegrityErrorViewModel)
+        XCTAssertTrue(viewModel is AppIntegrityErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_appIntegrityInvalidTokenError() throws {
         // GIVEN the authentication session returns an app integrity invalid token error
-        mockSessionManager.errorFromStartSession = ClientAssertionError(
+        let errorFromStartSession = ClientAssertionError(
             .invalidToken,
             reason: "test reason"
         )
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        let viewModel = try given(errorFromStartSession: errorFromStartSession, when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
         // THEN the visible view controller's view model should be the AppIntegrityErrorViewModel
-        XCTAssertTrue(vc.viewModel is AppIntegrityErrorViewModel)
+        XCTAssertTrue(viewModel is AppIntegrityErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_appIntegrityServerError() throws {
         // GIVEN the authentication session returns an app integrity server error
-        mockSessionManager.errorFromStartSession = ClientAssertionError(
+        let errorFromStartSession = ClientAssertionError(
             .serverError,
             reason: "test reason"
         )
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        let viewModel = try given(errorFromStartSession: errorFromStartSession, when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
         // THEN the visible view controller's view model should be the AppIntegrityErrorViewModel
-        XCTAssertTrue(vc.viewModel is AppIntegrityErrorViewModel)
+        XCTAssertTrue(viewModel is AppIntegrityErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_appIntegrityCantDecodeClientAssertionError() throws {
         // GIVEN the authentication session returns an cant decode client assertion error
-        mockSessionManager.errorFromStartSession = ClientAssertionError(
+        let errorFromStartSession = ClientAssertionError(
             .cantDecodeClientAssertion,
             reason: "test reason"
         )
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        let viewModel = try given(errorFromStartSession: errorFromStartSession, when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
         // THEN the visible view controller's view model should be the AppIntegrityErrorViewModel
-        XCTAssertTrue(vc.viewModel is AppIntegrityErrorViewModel)
+        XCTAssertTrue(viewModel is AppIntegrityErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_appIntegrityNotSupportedError() throws {
         // GIVEN the authentication session returns an app integrity not supported error
-        mockSessionManager.errorFromStartSession = FirebaseAppCheckError(
+        let errorFromStartSession = FirebaseAppCheckError(
             .notSupported,
             reason: "test reason"
         )
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        let viewModel = try given(errorFromStartSession: errorFromStartSession, when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+        
         // THEN the visible view controller's view model should be the AppIntegrityErrorViewModel
-        XCTAssertTrue(vc.viewModel is AppIntegrityErrorViewModel)
+        XCTAssertTrue(viewModel is AppIntegrityErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_appIntegrityKeychainAccessError() throws {
         // GIVEN the authentication session returns an app integrity keychain access error
-        mockSessionManager.errorFromStartSession = FirebaseAppCheckError(
+        let errorFromStartSession = FirebaseAppCheckError(
             .keychainAccess,
             reason: "test reason"
         )
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        let viewModel = try given(errorFromStartSession: errorFromStartSession, when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+        
         // THEN the visible view controller's view model should be the AppIntegrityErrorViewModel
-        XCTAssertTrue(vc.viewModel is AppIntegrityErrorViewModel)
+        XCTAssertTrue(viewModel is AppIntegrityErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_appIntegrityInvalidConfigurationError() throws {
         // GIVEN the authentication session returns an app integrity invalid configuration error
-        mockSessionManager.errorFromStartSession = FirebaseAppCheckError(
+        let errorFromStartSession = FirebaseAppCheckError(
             .invalidConfiguration,
             reason: "test reason"
         )
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        let viewModel = try given(errorFromStartSession: errorFromStartSession, when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+        
         // THEN the visible view controller's view model should be the AppIntegrityErrorViewModel
-        XCTAssertTrue(vc.viewModel is AppIntegrityErrorViewModel)
+        XCTAssertTrue(viewModel is AppIntegrityErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_appIntegrityInvalidPublicKeyError() throws {
         // GIVEN the authentication session returns an app integrity invalid public key error
-        mockSessionManager.errorFromStartSession = ClientAssertionError(
+        let errorFromStartSession = ClientAssertionError(
             .invalidPublicKey,
             reason: "test reason"
         )
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        let viewModel = try given(errorFromStartSession: errorFromStartSession, when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
         // THEN the visible view controller's view model should be the AppIntegrityErrorViewModel
-        XCTAssertTrue(vc.viewModel is AppIntegrityErrorViewModel)
+        XCTAssertTrue(viewModel is AppIntegrityErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_appIntegrityCantGenerateProofOfPossessionPublicKeyJWK() throws {
         // GIVEN the authentication session returns an app integrity cant generate a proof of possession public key error
-        mockSessionManager.errorFromStartSession = ProofOfPossessionError(
+        let errorFromStartSession = ProofOfPossessionError(
             .cantGenerateAttestationPublicKeyJWK,
             reason: "test reason"
         )
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        let viewModel = try given(errorFromStartSession: errorFromStartSession, when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
         // THEN the visible view controller's view model should be the AppIntegrityErrorViewModel
-        XCTAssertTrue(vc.viewModel is AppIntegrityErrorViewModel)
+        XCTAssertTrue(viewModel is AppIntegrityErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_appIntegrityCantGenerateProofOfPossessionJWT() throws {
         // GIVEN the authentication session returns an app integrity cant create attestation proof of possession error
-        mockSessionManager.errorFromStartSession = ProofOfPossessionError(
+        let errorFromStartSession = ProofOfPossessionError(
             .cantGenerateAttestationProofOfPossessionJWT,
             reason: "test reason"
         )
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        let viewModel = try given(errorFromStartSession: errorFromStartSession, when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
         // THEN the visible view controller's view model should be the AppIntegrityErrorViewModel
-        XCTAssertTrue(vc.viewModel is AppIntegrityErrorViewModel)
+        XCTAssertTrue(viewModel is AppIntegrityErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_appIntegrityCantGenerateDemonstratingProofOfPossessionJWT() throws {
         // GIVEN the authentication session returns an app integrity cant generate a DPoP public key error
-        mockSessionManager.errorFromStartSession = ProofOfPossessionError(
+        let errorFromStartSession = ProofOfPossessionError(
             .cantGenerateDemonstratingProofOfPossessionJWT,
             reason: "test reason"
         )
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        let viewModel = try given(errorFromStartSession: errorFromStartSession, when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
         // THEN the visible view controller's view model should be the AppIntegrityErrorViewModel
-        XCTAssertTrue(vc.viewModel is AppIntegrityErrorViewModel)
+        XCTAssertTrue(viewModel is AppIntegrityErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_generic() throws {
         // GIVEN the authentication session returns a generic error
-        mockSessionManager.errorFromStartSession = LoginError(reason: .generic(description: ""))
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
-        // THEN the visible view controller's view model should be the GenericErrorViewModel
-        XCTAssertTrue(vc.viewModel is GenericErrorViewModel)
+        let errorFromStartSession = LoginError(reason: .generic(description: ""))
+        let viewModel = try given(errorFromStartSession: errorFromStartSession, when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
+        // THEN the visible view controller's view model should be the AppIntegrityErrorViewModel
+        XCTAssertTrue(viewModel is GenericErrorViewModel)
     }
     
     @MainActor
     func test_launchAuthenticationService_catchAllError() throws {
         // GIVEN the authentication session returns a generic error
-        mockSessionManager.errorFromStartSession = AuthenticationError.generic
-        // WHEN the LoginCoordinator's launchAuthenticationService method is called
-        sut.launchAuthenticationService()
-        waitForTruth(self.mockSessionManager.didCallStartSession, timeout: 20)
-        // THEN the visible view controller should be the GDSErrorScreen
-        let vc = try XCTUnwrap(navigationController.topViewController as? GDSErrorScreen)
+        let viewModel = try given(errorFromStartSession: AuthenticationError.generic, when: { sut in
+            // WHEN the LoginCoordinator's launchAuthenticationService method is called
+            sut.launchAuthenticationService()
+        })
+
         // THEN the visible view controller's view model should be the GenericErrorViewModel
-        XCTAssertTrue(vc.viewModel is GenericErrorViewModel)
+        XCTAssertTrue(viewModel is GenericErrorViewModel)
     }
     
     @MainActor

--- a/Tests/UnitTests/Login/LoginCoordinatorTests.swift
+++ b/Tests/UnitTests/Login/LoginCoordinatorTests.swift
@@ -6,24 +6,6 @@ import GDSCommon
 import SecureStore
 import XCTest
 
-class MockNavigationControllerExpectation: UINavigationController {
-    var expectation: XCTestExpectation?
-    
-    init(expectation: XCTestExpectation? = nil) {
-        self.expectation = expectation
-        super.init(nibName: nil, bundle: nil)
-    }
-    
-    required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-    }
-    
-    override func pushViewController(_ viewController: UIViewController, animated: Bool) {
-        super.pushViewController(viewController, animated: animated)
-        self.expectation?.fulfill()
-    }
-}
-
 extension LoginCoordinator {
     
     static func make(mockNavigationController: UINavigationController = UINavigationController(), mockSessionManager: SessionManager = MockSessionManager()) -> LoginCoordinator {
@@ -109,8 +91,8 @@ final class LoginCoordinatorTests: XCTestCase {
         let pushViewControllerExpectation = self.expectation(description: #function)
 
         // GIVEN the authentication session returns a sessionMismatch error
-        let mockNavigationController = MockNavigationControllerExpectation(expectation: pushViewControllerExpectation)
-        
+        let mockNavigationController = MockNavigationControllerExpectation(pushViewControllerAsFunction: { _, _ in   pushViewControllerExpectation.fulfill()
+        })
         let mockSessionManager = MockSessionManager()
         let mockSessionManagerExpectation = MockSessionManagerExpectation(sessionManager: mockSessionManager, didStartAuthSessionAsFunction: { _, _ in
             startAuthSessionExpectation.fulfill()
@@ -130,7 +112,10 @@ final class LoginCoordinatorTests: XCTestCase {
     }
     
     @MainActor
-    func given(errorFromStartSession: Error, repeats count: Int, when:(LoginCoordinator) -> Void, then: (_ count: Int, _ topViewController: UIViewController?) throws -> Void) rethrows {
+    func given(errorFromStartSession: Error,
+               repeats count: Int,
+               when: (LoginCoordinator) -> Void,
+               then: (_ count: Int, _ topViewController: UIViewController?) throws -> Void) rethrows {
         let mockNavigationController = MockNavigationControllerExpectation()
         let mockSessionManager = MockSessionManager()
         mockSessionManager.errorFromStartSession = errorFromStartSession
@@ -147,7 +132,9 @@ final class LoginCoordinatorTests: XCTestCase {
             mockSessionManager.didCallStartSession = false
             
             let pushViewControllerExpectation = self.expectation(description: #function)
-            mockNavigationController.expectation = pushViewControllerExpectation
+            mockNavigationController.pushViewControllerAsFunction = { _, _ in
+                pushViewControllerExpectation.fulfill()
+            }
             
             when(sut)
             
@@ -453,8 +440,7 @@ extension LoginCoordinatorTests {
                 // THEN the visible view controller's view model should be the RecoverableLoginErrorViewModel
                 let vc = try XCTUnwrap(vc as? GDSErrorScreen)
                 XCTAssertTrue(vc.viewModel is RecoverableLoginErrorViewModel)
-            }
-            else {
+            } else {
                 // 3rd server error should show non-recoverable error screen
                 let vc = try XCTUnwrap(vc as? GDSErrorScreen)
                 XCTAssertTrue(vc.viewModel is UnrecoverableLoginErrorViewModel)
@@ -495,8 +481,7 @@ extension LoginCoordinatorTests {
             if attempt < threeTimes {
                 let vc = try XCTUnwrap(vc as? GDSErrorScreen)
                 XCTAssertTrue(vc.viewModel is RecoverableLoginErrorViewModel)
-            }
-            else {
+            } else {
                 let vc = try XCTUnwrap(vc as? GDSErrorScreen)
                 XCTAssertTrue(vc.viewModel is UnrecoverableLoginErrorViewModel)
             }

--- a/Tests/UnitTests/Mocks/Sessions+Services/Analytics/LocalAuth/MockLocalAuthManager.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Analytics/LocalAuth/MockLocalAuthManager.swift
@@ -1,6 +1,7 @@
 import LocalAuthenticationWrapper
 @testable import OneLogin
 import SecureStore
+import XCTest
 
 final class MockLocalAuthManager: LocalAuthManaging, LocalAuthenticationContextStrings {
     var type: LocalAuthType = .touchID
@@ -36,5 +37,47 @@ final class MockLocalAuthManager: LocalAuthManaging, LocalAuthenticationContextS
             throw errorFromEnrolLocalAuth
         }
         return userDidConsentToFaceID
+    }
+}
+
+final class MockLocalAuthManagerExpectation: LocalAuthManaging, LocalAuthenticationContextStrings {
+    var type: LocalAuthType {
+        mockLocalAuthManager.type
+    }
+    
+    var deviceBiometricsType: LocalAuthType {
+        mockLocalAuthManager.deviceBiometricsType
+    }
+    
+    var oneLoginStrings: LocalAuthenticationLocalizedStrings? {
+        mockLocalAuthManager.oneLoginStrings
+    }
+    
+    var canUseAnyLocalAuth: Bool {
+        mockLocalAuthManager.canUseAnyLocalAuth
+    }
+    
+    let expectation: XCTestExpectation
+    let mockLocalAuthManager: MockLocalAuthManager
+    
+    init(mockLocalAuthManager: MockLocalAuthManager = MockLocalAuthManager(), expectation: XCTestExpectation) {
+        self.mockLocalAuthManager = mockLocalAuthManager
+        self.expectation = expectation
+    }
+    
+    func checkLevelSupported(_ requiredLevel: RequiredLocalAuthLevel) throws -> Bool {
+        return try mockLocalAuthManager.checkLevelSupported(requiredLevel)
+    }
+    
+    func hasBeenPrompted() -> Bool {
+        return mockLocalAuthManager.userPromptedForLocalAuth
+    }
+    
+    func promptForFaceIDPermission() async throws -> Bool {
+        defer {
+            expectation.fulfill()
+        }
+        
+        return try await mockLocalAuthManager.promptForFaceIDPermission()
     }
 }

--- a/Tests/UnitTests/Mocks/Sessions+Services/Analytics/MockAnalyticsService.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Analytics/MockAnalyticsService.swift
@@ -60,3 +60,51 @@ final class MockAnalyticsService: OneLoginAnalyticsService {
         hasAcceptedAnalytics = false
     }
 }
+
+final class MockAnalyticsServiceExpectation: OneLoginAnalyticsService {
+    var analyticsPreferenceStore: AnalyticsPreferenceStore {
+        mockAnalyticsService.analyticsPreferenceStore
+    }
+
+    var additionalParameters: [String : Any] {
+        get {
+            mockAnalyticsService.additionalParameters
+        }
+        set {
+            mockAnalyticsService.additionalParameters = newValue
+        }
+    }
+
+    var crashesLogged: [NSError] {
+        mockAnalyticsService.crashesLogged
+    }
+    
+    let mockAnalyticsService = MockAnalyticsService()
+    let expectation: XCTestExpectation
+    
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+    
+    func addingAdditionalParameters(_ additionalParameters: [String : Any]) -> Self {
+        _ = mockAnalyticsService.addingAdditionalParameters(additionalParameters)
+        return self
+    }
+    
+    func logCrash(_ crash: NSError) {
+        mockAnalyticsService.logCrash(crash)
+    }
+    
+    func logCrash(_ crash: any Error) {
+        mockAnalyticsService.logCrash(crash)
+        expectation.fulfill()
+    }
+    
+    func trackScreen(_ screen: any LoggableScreen, parameters: [String : Any]) {
+        mockAnalyticsService.trackScreen(screen, parameters: parameters)
+    }
+    
+    func logEvent(_ event: any Logging.LoggableEvent, parameters: [String : Any]) {
+        mockAnalyticsService.logEvent(event)
+    }
+}

--- a/Tests/UnitTests/Mocks/Sessions+Services/Analytics/MockAnalyticsService.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Analytics/MockAnalyticsService.swift
@@ -66,7 +66,7 @@ final class MockAnalyticsServiceExpectation: OneLoginAnalyticsService {
         mockAnalyticsService.analyticsPreferenceStore
     }
 
-    var additionalParameters: [String : Any] {
+    var additionalParameters: [String: Any] {
         get {
             mockAnalyticsService.additionalParameters
         }
@@ -86,7 +86,7 @@ final class MockAnalyticsServiceExpectation: OneLoginAnalyticsService {
         self.expectation = expectation
     }
     
-    func addingAdditionalParameters(_ additionalParameters: [String : Any]) -> Self {
+    func addingAdditionalParameters(_ additionalParameters: [String: Any]) -> Self {
         _ = mockAnalyticsService.addingAdditionalParameters(additionalParameters)
         return self
     }
@@ -100,11 +100,11 @@ final class MockAnalyticsServiceExpectation: OneLoginAnalyticsService {
         expectation.fulfill()
     }
     
-    func trackScreen(_ screen: any LoggableScreen, parameters: [String : Any]) {
+    func trackScreen(_ screen: any LoggableScreen, parameters: [String: Any]) {
         mockAnalyticsService.trackScreen(screen, parameters: parameters)
     }
     
-    func logEvent(_ event: any Logging.LoggableEvent, parameters: [String : Any]) {
+    func logEvent(_ event: any Logging.LoggableEvent, parameters: [String: Any]) {
         mockAnalyticsService.logEvent(event)
     }
 }

--- a/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockSessionManager.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockSessionManager.swift
@@ -134,3 +134,109 @@ final class MockSessionManager: SessionManager {
         expiryDate = expired ? .distantPast : .distantFuture
     }
 }
+
+class MockSessionManagerExpectation: SessionManager {
+    var sessionState: SessionState {
+        sessionManager.sessionState
+    }
+
+    var expiryDate: Date? {
+        sessionManager.expiryDate
+    }
+    var isEnrolling: Bool {
+        get {
+            sessionManager.isEnrolling
+        }
+        set {
+            sessionManager.isEnrolling = newValue
+        }
+    }
+    
+    var isReturningUser: Bool {
+        sessionManager.isReturningUser
+    }
+    
+    var validTokensForRefreshExchange: (idToken: String, refreshToken: String)?
+
+    var persistentID: String? {
+        sessionManager.persistentID
+    }
+    
+    var walletStoreID: String? {
+        sessionManager.walletStoreID
+    }
+
+    var user: CurrentValueSubject<(any OneLogin.User)?, Never> {
+        sessionManager.user
+    }
+    
+    var tokenProvider: TokenHolder {
+        sessionManager.tokenProvider
+    }
+    
+    typealias DidStartAuthSession = (LoginSession, @Sendable (String?) async throws -> LoginSessionConfiguration) -> Void
+    typealias DidSaveAuthSession = () -> Void
+    typealias DidResumeSession = (TokenExchangeManaging, AppIntegrityProvider) -> Void
+    
+    var didStartAuthSessionAsFunction: DidStartAuthSession
+    var didSaveAuthSessionAsFunction: DidSaveAuthSession
+    var didResumeSessionAsFunction: DidResumeSession
+
+    var localAuthentication: LocalAuthManaging {
+        sessionManager.localAuthentication
+    }
+    
+    let sessionManager: MockSessionManager
+    
+    init(sessionManager: MockSessionManager = MockSessionManager(),
+         didStartAuthSessionAsFunction: @escaping DidStartAuthSession = {_, _ in },
+         didSaveAuthSessionAsFunction: @escaping DidSaveAuthSession = { },
+         didResumeSessionAsFunction: @escaping DidResumeSession = {_, _ in}) {
+        self.sessionManager = sessionManager
+        self.didStartAuthSessionAsFunction = didStartAuthSessionAsFunction
+        self.didSaveAuthSessionAsFunction = didSaveAuthSessionAsFunction
+        self.didResumeSessionAsFunction = didResumeSessionAsFunction
+    }
+    
+    func startAuthSession(
+        _ session: any LoginSession,
+        using configuration: @Sendable (String?) async throws -> LoginSessionConfiguration
+    ) throws {
+        defer {
+            self.didStartAuthSessionAsFunction(session, configuration)
+        }
+        
+        try sessionManager.startAuthSession(session, using: configuration)
+    }
+    
+    func saveAuthSession() throws {
+        defer {
+            self.didSaveAuthSessionAsFunction()
+        }
+    
+        try sessionManager.saveAuthSession()
+    }
+    
+    func saveLoginTokens(idToken: String?, refreshToken: String?, accessToken: String?, accessTokenExpiry: Date?) throws {
+        try sessionManager.saveLoginTokens(idToken: idToken, refreshToken: refreshToken, accessToken: accessToken, accessTokenExpiry: accessTokenExpiry)
+    }
+    
+    func resumeSession(tokenExchangeManager: TokenExchangeManaging, appIntegrityProvider: AppIntegrityProvider) async throws {
+        defer {
+            self.didResumeSessionAsFunction(tokenExchangeManager, appIntegrityProvider)
+        }
+        try sessionManager.resumeSession(tokenExchangeManager: tokenExchangeManager, appIntegrityProvider: appIntegrityProvider)
+    }
+    
+    func endCurrentSession() {
+        sessionManager.endCurrentSession()
+    }
+    
+    func clearAllSessionData(presentSystemLogOut: Bool) async throws {
+        try sessionManager.clearAllSessionData(presentSystemLogOut: presentSystemLogOut)
+    }
+    
+    func clearAppForLogin() async throws {
+        try await sessionManager.clearAppForLogin()
+    }
+}

--- a/Tests/UnitTests/Mocks/UIKit/MockNavigationControllerExpectation.swift
+++ b/Tests/UnitTests/Mocks/UIKit/MockNavigationControllerExpectation.swift
@@ -1,0 +1,33 @@
+import XCTest
+
+class MockNavigationControllerExpectation: UINavigationController {
+    
+    typealias PushViewControllerAsFunction = (UIViewController, Bool) -> Void
+    typealias PresentAsFunction = (UIViewController, Bool, (() -> Void)?) -> Void
+    
+    var pushViewControllerAsFunction: PushViewControllerAsFunction
+    var presentAsFunction: PresentAsFunction
+
+    
+    init(pushViewControllerAsFunction: @escaping PushViewControllerAsFunction = { _, _ in }, presentAsFunction: @escaping PresentAsFunction = { _, _, _ in }) {
+        self.pushViewControllerAsFunction = pushViewControllerAsFunction
+        self.presentAsFunction = presentAsFunction
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        self.pushViewControllerAsFunction = { _, _ in }
+        self.presentAsFunction = { _, _, _ in }
+        super.init(coder: aDecoder)
+    }
+    
+    override func pushViewController(_ viewController: UIViewController, animated: Bool) {
+        super.pushViewController(viewController, animated: animated)
+        self.pushViewControllerAsFunction(viewController, animated)
+    }
+    
+    override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
+        super.present(viewControllerToPresent, animated: flag, completion: completion)
+        self.presentAsFunction(viewControllerToPresent, flag, completion)
+    }
+}

--- a/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
+++ b/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
@@ -27,28 +27,28 @@ class AppQualifyingServiceDelegateExpectation: AppQualifyingServiceDelegate {
     typealias DidChangeSessionState = (AppSessionState) -> Void
     typealias DidChangeServiceState = (RemoteServiceState) -> Void
     
-    let didChangeAppInfoState: DidChangeAppInfoState
-    let didChangeSessionState: DidChangeSessionState
-    let didChangeServiceState: DidChangeServiceState
+    let didChangeAppInfoStateAsFunction: DidChangeAppInfoState
+    let didChangeSessionStateAsFunction: DidChangeSessionState
+    let didChangeServiceStateAsFunction: DidChangeServiceState
     
-    init(didChangeAppInfoState: @escaping DidChangeAppInfoState = { _ in },
-         didChangeSessionState: @escaping DidChangeSessionState = { _ in },
-         didChangeServiceState: @escaping DidChangeServiceState = { _ in }) {
-        self.didChangeAppInfoState = didChangeAppInfoState
-        self.didChangeSessionState = didChangeSessionState
-        self.didChangeServiceState = didChangeServiceState
+    init(didChangeAppInfoStateAsFunction: @escaping DidChangeAppInfoState = { _ in },
+         didChangeSessionStateAsFunction: @escaping DidChangeSessionState = { _ in },
+         didChangeServiceStateAsFunction: @escaping DidChangeServiceState = { _ in }) {
+        self.didChangeAppInfoStateAsFunction = didChangeAppInfoStateAsFunction
+        self.didChangeSessionStateAsFunction = didChangeSessionStateAsFunction
+        self.didChangeServiceStateAsFunction = didChangeServiceStateAsFunction
     }
     
     func didChangeAppInfoState(state appInfoState: AppInformationState) {
-        self.didChangeAppInfoState(appInfoState)
+        self.didChangeAppInfoStateAsFunction(appInfoState)
     }
     
     func didChangeSessionState(state sessionState: AppSessionState) {
-        self.didChangeSessionState(sessionState)
+        self.didChangeSessionStateAsFunction(sessionState)
     }
     
     func didChangeServiceState(state: RemoteServiceState) {
-        self.didChangeServiceState(state)
+        self.didChangeServiceStateAsFunction(state)
     }
 }
 
@@ -183,10 +183,10 @@ extension AppQualifyingServiceTests {
         let expectation = e ?? expectation(description: #function)
         var _appState: AppInformationState?
         var _sessionState: AppSessionState?
-        
-        let appQualifyingServiceDelegateExpectation = AppQualifyingServiceDelegateExpectation(didChangeAppInfoState: { appState in
+
+        let appQualifyingServiceDelegateExpectation = AppQualifyingServiceDelegateExpectation(didChangeAppInfoStateAsFunction: { appState in
             _appState = appState
-        }, didChangeSessionState: { sessionState in
+        }, didChangeSessionStateAsFunction: { sessionState in
             _sessionState = sessionState
             expectation.fulfill()
         })
@@ -207,11 +207,11 @@ extension AppQualifyingServiceTests {
         let expectation = e ?? expectation(description: #function)
         var _appState: AppInformationState?
         var _sessionState: AppSessionState?
-        
-        let appQualifyingServiceDelegateExpectation = AppQualifyingServiceDelegateExpectation(didChangeAppInfoState: { appState in
+
+        let appQualifyingServiceDelegateExpectation = AppQualifyingServiceDelegateExpectation(didChangeAppInfoStateAsFunction: { appState in
             _appState = appState
             expectation.fulfill()
-        }, didChangeSessionState: { sessionState in
+        }, didChangeSessionStateAsFunction: { sessionState in
             _sessionState = sessionState
         })
         

--- a/Tests/UnitTests/Tabs/SettingsCoordinatorTests.swift
+++ b/Tests/UnitTests/Tabs/SettingsCoordinatorTests.swift
@@ -5,6 +5,27 @@ import Networking
 import SecureStore
 import XCTest
 
+extension SettingsCoordinator {
+
+    static func make(mockNavigationController: UINavigationController? = nil, mockSessionManager: SessionManager = MockSessionManager()) -> SettingsCoordinator {
+        
+        let root = mockNavigationController ?? UINavigationController()
+        let window = UIWindow()
+        let mockAnalyticsService = MockAnalyticsService()
+        let mockNetworkClient = NetworkClient()
+        mockNetworkClient.authorizationProvider = MockAuthenticationProvider()
+        let urlOpener = MockURLOpener()
+        window.rootViewController = root
+        window.makeKeyAndVisible()
+
+        return SettingsCoordinator(root: root,
+                                   analyticsService: mockAnalyticsService,
+                                   sessionManager: mockSessionManager,
+                                   networkingService: mockNetworkClient,
+                                   urlOpener: urlOpener)
+    }
+}
+
 @MainActor
 final class SettingsCoordinatorTests: XCTestCase {
     var mockAnalyticsService: MockAnalyticsService!
@@ -87,13 +108,23 @@ final class SettingsCoordinatorTests: XCTestCase {
         let signOutButton: UIButton = try XCTUnwrap(presentedVC.topViewController?.view[child: "instructions-button"])
         signOutButton.sendActions(for: .touchUpInside)
         // THEN clear all session data is called
-        await fulfillment(of: [exp], timeout: 5)
+        await fulfillment(of: [exp], timeout: 10)
         XCTAssertTrue(mockSessionManager.didCallClearAllSessionData)
     }
     
     func test_tapSignOut_errors() throws {
+        let pushViewControllerExpectation = self.expectation(description: #function)
+        pushViewControllerExpectation.expectedFulfillmentCount = 2
+
         // GIVEN an error is returned from clearAllSessionData
+        let mockNavigationController = MockNavigationControllerExpectation( presentAsFunction: { _, _, _ in
+            pushViewControllerExpectation.fulfill()
+        })
+        let mockSessionManager = MockSessionManager()
+        let mockSessionManagerExpectation = MockSessionManagerExpectation(sessionManager: mockSessionManager)
         mockSessionManager.errorFromClearAllSessionData = MockWalletError.cantDelete
+        let sut: SettingsCoordinator = .make(mockNavigationController: mockNavigationController, mockSessionManager: mockSessionManagerExpectation)
+
         // GIVEN the user is on the signout page
         sut.start()
         // WHEN the openSignOutPage method is called
@@ -102,9 +133,13 @@ final class SettingsCoordinatorTests: XCTestCase {
         // WHEN the user signs out
         let signOutButton: UIButton = try XCTUnwrap(presentedVC.topViewController?.view[child: "instructions-button"])
         signOutButton.sendActions(for: .touchUpInside)
+        
+        wait(for: [pushViewControllerExpectation], timeout: 10)
+
         // THEN the presented sign out error screen is shown
-        waitForTruth((self.sut.root.presentedViewController as? GDSErrorScreen)?.viewModel is SignOutErrorViewModel,
-                     timeout: 20)
+        let vc = try XCTUnwrap(sut.root.presentedViewController as? GDSErrorScreen)
+
+        XCTAssertTrue(vc.viewModel is SignOutErrorViewModel)
     }
     
     func test_showDeveloperMenu() throws {

--- a/Tests/UnitTests/Utilities/OneLoginEnrolmentManagerTests.swift
+++ b/Tests/UnitTests/Utilities/OneLoginEnrolmentManagerTests.swift
@@ -81,43 +81,74 @@ extension OneLoginEnrolmentManagerTests {
     }
 
     func test_saveSession_fails() {
+        let expectation = expectation(description: #function)
         // GIVEN the user has given FaceID permission
+        let mockLocalAuthContext = MockLocalAuthManager()
         mockLocalAuthContext.userDidConsentToFaceID = true
         // GIVEN saveSession returns an uncaught error
+        let mockSessionManager = MockSessionManager()
+        let mockSessionManagerExpectation = MockSessionManagerExpectation(sessionManager: mockSessionManager, didSaveAuthSessionAsFunction: {
+            expectation.fulfill()
+        })
+        
         mockSessionManager.errorFromSaveSession = MockError.generic
+        let mockAnalyticsService = MockAnalyticsService()
+        let sut: OneLoginEnrolmentManager = .make(mockLocalAuthContext: mockLocalAuthContext, mockSessionManager: mockSessionManagerExpectation, mockAnalyticsService: mockAnalyticsService)
+        
         // WHEN saveSession is called
         sut.saveSession()
-        waitForTruth(self.mockSessionManager.didCallSaveSession, timeout: 5)
+        
+        self.wait(for: [expectation], timeout: 5)
+        XCTAssertTrue(mockSessionManager.didCallSaveSession)
         // THEN an error is recorded in Crashlytics
         XCTAssertEqual(mockAnalyticsService.crashesLogged, [MockError.generic as NSError])
     }
 
     func test_saveSession_promptForPermission_false() {
+        let expectation = expectation(description: #function)
         // GIVEN the user has already given FaceID permission
-        mockLocalAuthContext.userDidConsentToFaceID = false
+        let mockLocalAuthManager = MockLocalAuthManager()
+        let mockLocalAuthManagerExpectation = MockLocalAuthManagerExpectation(mockLocalAuthManager: mockLocalAuthManager,
+                                                                   expectation: expectation)
+        mockLocalAuthManager.userDidConsentToFaceID = false
+        let mockAnalyticsService = MockAnalyticsService()
+        let sut: OneLoginEnrolmentManager = .make(mockLocalAuthContext: mockLocalAuthManagerExpectation, mockAnalyticsService: mockAnalyticsService)
         // WHEN saveSession is called
         sut.saveSession()
-        waitForTruth(self.mockLocalAuthContext.didCallEnrolFaceIDIfAvailable, timeout: 5)
+        wait(for: [expectation], timeout: 5)
+        XCTAssertTrue(mockLocalAuthManager.didCallEnrolFaceIDIfAvailable)
         // THEN no error is recorded in Crashlytics
         XCTAssertEqual(mockAnalyticsService.crashesLogged, [])
     }
 
     func test_saveSession_promptForPermission_cancelled() {
+        let expectation = expectation(description: #function)
         // GIVEN promptForPermission throws a cancelled error
-        mockLocalAuthContext.errorFromEnrolLocalAuth = LocalAuthenticationWrapperError.cancelled
+        let mockLocalAuthManager = MockLocalAuthManager()
+        let mockLocalAuthManagerExpectation = MockLocalAuthManagerExpectation(mockLocalAuthManager: mockLocalAuthManager,
+                                                                   expectation: expectation)
+        mockLocalAuthManager.errorFromEnrolLocalAuth = LocalAuthenticationWrapperError.cancelled
+        let mockAnalyticsService = MockAnalyticsService()
+        let sut: OneLoginEnrolmentManager = .make(mockLocalAuthContext: mockLocalAuthManagerExpectation, mockSessionManager: mockSessionManager, mockAnalyticsService: mockAnalyticsService)
         // WHEN saveSession is called
         sut.saveSession()
-        waitForTruth(self.mockLocalAuthContext.didCallEnrolFaceIDIfAvailable, timeout: 5)
+        wait(for: [expectation], timeout: 5)
+        XCTAssertTrue(mockLocalAuthManager.didCallEnrolFaceIDIfAvailable)
         // THEN no error is recorded in Crashlytics
         XCTAssertEqual(mockAnalyticsService.crashesLogged, [])
     }
 
     func test_saveSession_promptForPermission_fails() {
+        let expectation = expectation(description: #function)
         // GIVEN promptForPermission throws an uncaught error
+        let mockLocalAuthContext = MockLocalAuthManager()
         mockLocalAuthContext.errorFromEnrolLocalAuth = MockError.generic
+        let mockAnalyticsService = MockAnalyticsServiceExpectation(expectation: expectation)
+        let sut: OneLoginEnrolmentManager = .make(mockLocalAuthContext: mockLocalAuthContext, mockSessionManager: mockSessionManager, mockAnalyticsService: mockAnalyticsService)
         // WHEN saveSession is called
         sut.saveSession()
-        waitForTruth(self.mockLocalAuthContext.didCallEnrolFaceIDIfAvailable, timeout: 5)
+        wait(for: [expectation], timeout: 5)
+        XCTAssertTrue(mockLocalAuthContext.didCallEnrolFaceIDIfAvailable)
         // THEN an error is recorded in Crashlytics
         XCTAssertEqual(mockAnalyticsService.crashesLogged, [MockError.generic as NSError])
     }

--- a/Tests/UnitTests/Utilities/OneLoginEnrolmentManagerTests.swift
+++ b/Tests/UnitTests/Utilities/OneLoginEnrolmentManagerTests.swift
@@ -93,7 +93,9 @@ extension OneLoginEnrolmentManagerTests {
         
         mockSessionManager.errorFromSaveSession = MockError.generic
         let mockAnalyticsService = MockAnalyticsService()
-        let sut: OneLoginEnrolmentManager = .make(mockLocalAuthContext: mockLocalAuthContext, mockSessionManager: mockSessionManagerExpectation, mockAnalyticsService: mockAnalyticsService)
+        let sut: OneLoginEnrolmentManager = .make(mockLocalAuthContext: mockLocalAuthContext,
+                                                  mockSessionManager: mockSessionManagerExpectation,
+                                                  mockAnalyticsService: mockAnalyticsService)
         
         // WHEN saveSession is called
         sut.saveSession()
@@ -112,7 +114,8 @@ extension OneLoginEnrolmentManagerTests {
                                                                    expectation: expectation)
         mockLocalAuthManager.userDidConsentToFaceID = false
         let mockAnalyticsService = MockAnalyticsService()
-        let sut: OneLoginEnrolmentManager = .make(mockLocalAuthContext: mockLocalAuthManagerExpectation, mockAnalyticsService: mockAnalyticsService)
+        let sut: OneLoginEnrolmentManager = .make(mockLocalAuthContext: mockLocalAuthManagerExpectation,
+                                                  mockAnalyticsService: mockAnalyticsService)
         // WHEN saveSession is called
         sut.saveSession()
         wait(for: [expectation], timeout: 5)
@@ -129,7 +132,9 @@ extension OneLoginEnrolmentManagerTests {
                                                                    expectation: expectation)
         mockLocalAuthManager.errorFromEnrolLocalAuth = LocalAuthenticationWrapperError.cancelled
         let mockAnalyticsService = MockAnalyticsService()
-        let sut: OneLoginEnrolmentManager = .make(mockLocalAuthContext: mockLocalAuthManagerExpectation, mockSessionManager: mockSessionManager, mockAnalyticsService: mockAnalyticsService)
+        let sut: OneLoginEnrolmentManager = .make(mockLocalAuthContext: mockLocalAuthManagerExpectation,
+                                                  mockSessionManager: mockSessionManager,
+                                                  mockAnalyticsService: mockAnalyticsService)
         // WHEN saveSession is called
         sut.saveSession()
         wait(for: [expectation], timeout: 5)
@@ -144,7 +149,9 @@ extension OneLoginEnrolmentManagerTests {
         let mockLocalAuthContext = MockLocalAuthManager()
         mockLocalAuthContext.errorFromEnrolLocalAuth = MockError.generic
         let mockAnalyticsService = MockAnalyticsServiceExpectation(expectation: expectation)
-        let sut: OneLoginEnrolmentManager = .make(mockLocalAuthContext: mockLocalAuthContext, mockSessionManager: mockSessionManager, mockAnalyticsService: mockAnalyticsService)
+        let sut: OneLoginEnrolmentManager = .make(mockLocalAuthContext: mockLocalAuthContext,
+                                                  mockSessionManager: mockSessionManager,
+                                                  mockAnalyticsService: mockAnalyticsService)
         // WHEN saveSession is called
         sut.saveSession()
         wait(for: [expectation], timeout: 5)

--- a/Tests/UnitTests/Utilities/Session/PersistentSessionManagerTests.swift
+++ b/Tests/UnitTests/Utilities/Session/PersistentSessionManagerTests.swift
@@ -8,6 +8,35 @@ import MockNetworking
 import SecureStore
 import XCTest
 
+struct SessionBoundDataExpectation: SessionBoundData {
+    let expectation: XCTestExpectation
+        
+    func clearSessionData() {
+        self.expectation.fulfill()
+    }
+}
+
+extension PersistentSessionManager {
+    
+    static func make(mockEncryptedStore: MockSecureStoreService = MockSecureStoreService(),
+                     mockUnprotectedStore: MockDefaultsStore = MockDefaultsStore(),
+                     mockAnalyticsService: OneLoginAnalyticsService = MockAnalyticsService(),
+                     mockWalletSDK: MockWalletSDKWrapper = MockWalletSDKWrapper()) -> PersistentSessionManager {
+        
+        let mockAccessControlEncryptedStore = MockSecureStoreService()
+        let mockLocalAuthentication = MockLocalAuthManager()
+        
+        return PersistentSessionManager(
+            accessControlEncryptedStore: mockAccessControlEncryptedStore,
+            encryptedStore: mockEncryptedStore,
+            unprotectedStore: mockUnprotectedStore,
+            localAuthentication: mockLocalAuthentication,
+            analyticsService: mockAnalyticsService,
+            walletSDK: mockWalletSDK
+        )
+    }
+}
+
 final class PersistentSessionManagerTests: XCTestCase {
     private var mockAccessControlEncryptedStore: MockSecureStoreService!
     private var mockEncryptedStore: MockSecureStoreService!
@@ -376,10 +405,19 @@ extension PersistentSessionManagerTests {
     
     @MainActor
     func test_startSession_noPersistentID_NotReturningUser_WalletNotEmptyError() async throws {
+        let expectation = expectation(description: #function)
+        let mockAnalyticsService = MockAnalyticsServiceExpectation(expectation: expectation)
+
         // Given I am unable to re-authenticate because I have no persistent session ID
+        let mockEncryptedStore = MockSecureStoreService()
         mockEncryptedStore.deleteItem(itemName: OLString.persistentSessionID)
         // AND the wallet is not empty
+        let mockWalletSDK = MockWalletSDKWrapper()
         mockWalletSDK.isEmpty = false
+        let sut: PersistentSessionManager = .make(mockEncryptedStore: mockEncryptedStore,
+                                                  mockAnalyticsService: mockAnalyticsService,
+                                                  mockWalletSDK: mockWalletSDK)
+        
         // AND there aren't any errors logged
         XCTAssertEqual(mockAnalyticsService.crashesLogged.count, 0)
         // WHEN I start a session
@@ -389,8 +427,9 @@ extension PersistentSessionManagerTests {
                 using: MockLoginSessionConfiguration.oneLoginSessionConfiguration
             )
             
+            await fulfillment(of: [expectation], timeout: 5.0)
             // THEN a secure wallet data deleted error should be logged because wallet is expected to be empty
-            waitForTruth(self.mockAnalyticsService.crashesLogged.count == 1, timeout: 5)
+            XCTAssertTrue(mockAnalyticsService.crashesLogged.count == 1)
             XCTAssertTrue(mockAnalyticsService.crashesLogged.first as? PersistentSessionError == PersistentSessionError(.noSessionExists,
                                                                                                                         reason: "reason : secure wallet data deleted"))
         } catch {
@@ -400,12 +439,24 @@ extension PersistentSessionManagerTests {
     
     @MainActor
     func test_startSession_clearAppForLogin_exceptAnalyticsPreference() async throws {
+        let didCall_deleteSessionBoundData = expectation(description: #function)
+
+        let sessionBoundDataExpectation = SessionBoundDataExpectation(expectation: didCall_deleteSessionBoundData)
+        
+        let mockEncryptedStore = MockSecureStoreService()
+        let mockUnprotectedStore = MockDefaultsStore()
+        
         let mockAnalyticsPrefernceStore = UserDefaultsPreferenceStore()
         mockAnalyticsPrefernceStore.hasAcceptedAnalytics = true
         
+        let sut: PersistentSessionManager = .make(mockEncryptedStore: mockEncryptedStore,
+                                                  mockUnprotectedStore: mockUnprotectedStore,
+                                                  mockAnalyticsService: mockAnalyticsService,
+                                                  mockWalletSDK: mockWalletSDK)
+
         // GIVEN I am a returning user who previously accepted analytics
         sut.registerSessionBoundData([
-            self,
+            sessionBoundDataExpectation,
             mockEncryptedStore,
             mockUnprotectedStore,
             mockAnalyticsPrefernceStore
@@ -421,7 +472,8 @@ extension PersistentSessionManagerTests {
         )
         
         // THEN my session data is cleared
-        waitForTruth(self.didCall_deleteSessionBoundData, timeout: 5)
+        await fulfillment(of: [didCall_deleteSessionBoundData], timeout: 5.0)
+
         XCTAssertTrue(mockEncryptedStore.savedItems.isEmpty)
         XCTAssertTrue(mockUnprotectedStore.savedData.isEmpty)
         


### PR DESCRIPTION
# Reduce the time it takes to run unit tests

<blockquote>
**Note:**  This branch is based off `fix/DCMAW-0000-use-test-delegate-when-under-testing` in #791 . This can be merged once #791 has.
</blockquote>

The changes proposed by this PR have a primary goal to significantly reduce the [execution time of unit tests](https://github.com/govuk-one-login/mobile-ios-one-login-app/pull/742) in order to reduce the feedback loop, deploy changes faster and save costs.

I have taken a sample using a development MacBook of the runtime when executing unit tests before and after the proposed changes in this PR.

| _ | execution time | 
|:--------:|:--------:|
| Before | 3m 08s |
| After | 1m 13s | 
| Change | down by 61% (~2 minutes saved) | 

**Before** 

<img width="1912" height="1242" alt="before" src="https://github.com/user-attachments/assets/8f48f7c1-5f4d-4ac5-8520-66bdfd6bf6b9" />


**After**

<img width="1912" height="1242" alt="after" src="https://github.com/user-attachments/assets/3db2fa9c-9a86-41ef-9e84-c3230bb178c5" />


# Changes

The PR aims to make minimal changes to the main source code thus the vast majority of changes modify test source code.  However, there are a few exceptions: 

* This code change modifies the `SettingsCoordinator` to make it possible to inject the `root` navigation controller from tests. The functionality should otherwise be the same. Any unexpected behaviour is a defect. Here a video showing the app works as expected with `SettingsCoordinator` after the changes:

https://github.com/user-attachments/assets/c3cc5d6b-9acf-4a9b-a4e0-dbb2d57d02aa


As to the changes as they relate to the test source code and tangibly reduce the execution time. They all hinge on one code change. Replace any `waitForTruth` calls that are based on an `NSPredicate` [which is periodically evaluated](https://developer.apple.com/documentation/xctest/xctestcase/expectation(for:evaluatedwith:handler:))
    with an XCTestExpectation [that can be fulfilled](https://developer.apple.com/documentation/xctest/xctestcase/expectation(description:)). This significantly reduces the time it takes since the expectation is fulfilled at almost the time it takes for the async code to execute. Whereas the periodic evaluation operates on 1 second intervals with an expected minimum of 1 second. As a result, each test under `LoginCoordinatorTests` takes milliseconds as opposed to 1 second each.

### Before
<img width="1800" height="1182" alt="before" src="https://github.com/user-attachments/assets/a2c3cba9-db95-4072-a478-fe740ddf1bf9" />

### After
<img width="1800" height="1182" alt="after" src="https://github.com/user-attachments/assets/8dcf2c48-bf97-4085-8490-9217323f0db5" />

# Where to focus the review

The vast majority of code changes do not change any of the test assertions, other than a few rare cases where it was deemed necessary.

* Please double check the changes on each test case to ensure no accidental changes to the tests have been made.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [ ] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
