### PR TITLE
chore: DCMAW-20015 update OrientationLockingTabBar version

### DIFF
--- a/Sources/Qualification/QualifyingCoordinator.swift
+++ b/Sources/Qualification/QualifyingCoordinator.swift
@@ -1,5 +1,6 @@
 import Authentication
 import Coordination
+import DesignSystem
 import GDSCommon
 import Logging
 import Networking
@@ -158,7 +159,7 @@ extension QualifyingCoordinator {
             updateStream.continuation.yield(tabManagerCoordinator)
         } else {
             let tabManagerCoordinator = TabManagerCoordinator(
-                root: OrientationLockingTabBarController(),
+                root: GDSOrientationLockingTabBarController(),
                 analyticsService: analyticsService,
                 networkingService: networkingService,
                 sessionManager: sessionManager

--- a/Tests/UnitTests/Qualification/QualifyingCoordinatorTests.swift
+++ b/Tests/UnitTests/Qualification/QualifyingCoordinatorTests.swift
@@ -1,4 +1,5 @@
 import Coordination
+import DesignSystem
 import GDSCommon
 import Networking
 @testable import OneLogin

--- a/Tests/UnitTests/Qualification/QualifyingCoordinatorTests.swift
+++ b/Tests/UnitTests/Qualification/QualifyingCoordinatorTests.swift
@@ -124,7 +124,7 @@ extension QualifyingCoordinatorTests {
             .compactMap { $0 as? TabManagerCoordinator }
             .first)
         XCTAssertIdentical(window.rootViewController, tabManagerCoordinator.root)
-        XCTAssert(window.rootViewController is OrientationLockingTabBarController)
+        XCTAssert(window.rootViewController is GDSOrientationLockingTabBarController)
     }
     
     @MainActor


### PR DESCRIPTION
# chore: DCMAW-20015 update OrientationLockingTabBar version

This PR updates the OrientationLockingTabBar to be used from DesignSystem instead of GDSCommon

This PR requires:
https://github.com/govuk-one-login/mobile-id-check-ios-sdk/pull/444
https://github.com/govuk-one-login/mobile-ios-ui/pull/89

I have tested to check vendor screen is not rotating (rotation lock is OFF, forgot to show it in the video :))

https://github.com/user-attachments/assets/3ef0aaa3-015e-49fd-8d6c-d0f236f287ed


# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
