### PR TITLE
fix: update Xcode to 24.1 and OS to 26.4.1

### DIFF
--- a/.github/workflows/config-test.yml
+++ b/.github/workflows/config-test.yml
@@ -41,7 +41,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.VENDOR_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.VENDOR_ACCESS_KEY }}
         run: |
-          ./scripts-configs/spm/aws_code_artifact_login.sh /Applications/Xcode_26.1.1.app
+          ./scripts-configs/spm/aws_code_artifact_login.sh /Applications/Xcode_26.4.1.app
 
       - name: Build App, Run Build Configuration Tests
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.VENDOR_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.VENDOR_ACCESS_KEY }}
         run: |
-          ./scripts-configs/spm/aws_code_artifact_login.sh /Applications/Xcode_26.1.1.app
+          ./scripts-configs/spm/aws_code_artifact_login.sh /Applications/Xcode_26.4.1.app
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # pin@v6.1.1

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -54,7 +54,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.VENDOR_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.VENDOR_ACCESS_KEY }}
         run: |
-          ./scripts-configs/spm/aws_code_artifact_login.sh /Applications/Xcode_26.1.1.app
+          ./scripts-configs/spm/aws_code_artifact_login.sh /Applications/Xcode_26.4.1.app
 
       - name: Bundler install
         run: bundle install

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -37,7 +37,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.VENDOR_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.VENDOR_ACCESS_KEY }}
         run: |
-          ./scripts-configs/spm/aws_code_artifact_login.sh /Applications/Xcode_26.1.1.app
+          ./scripts-configs/spm/aws_code_artifact_login.sh /Applications/Xcode_26.4.1.app
 
       - name: Build App, Run UI Tests
         env:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -33,7 +33,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.VENDOR_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.VENDOR_ACCESS_KEY }}
         run: |
-          ./scripts-configs/spm/aws_code_artifact_login.sh /Applications/Xcode_26.1.1.app
+          ./scripts-configs/spm/aws_code_artifact_login.sh /Applications/Xcode_26.4.1.app
 
       - name: Build App, Run Unit Tests and Send Coverage Report for Branch
         env:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,14 +16,14 @@ require 'securerandom'
 ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "600"
 
 default_platform(:ios)
-xcode_select("/Applications/Xcode_26.1.1.app")
+xcode_select("/Applications/Xcode_26.4.1.app")
 
 platform :ios do
   desc "Build for testing"
   lane :buildForTesting do |options|
     run_tests(
       workspace: "OneLogin.xcworkspace",
-      device: "iPhone 17 (26.1)",
+      device: "iPhone 17 (26.4.1)",
       scheme: options[:scheme],
       configuration: options[:configuration],
       xcodebuild_formatter: "xcpretty",
@@ -35,7 +35,7 @@ platform :ios do
   desc "Run Tests without Sonar Coverage"
   lane :testWithoutBuildingWithoutCoverage do |options|
     run_tests(
-      device: "iPhone 17 (26.1)",
+      device: "iPhone 17 (26.4.1)",
       scheme: options[:scheme],
       xcodebuild_formatter: "xcpretty",
       xctestrun: options[:xctestrun],
@@ -48,7 +48,7 @@ platform :ios do
   lane :testWithoutCoverage do |options|
     run_tests(
       workspace: "OneLogin.xcworkspace",
-      device: "iPhone 17 (26.1)",
+      device: "iPhone 17 (26.4.1)",
       scheme: options[:scheme],
       configuration: options[:configuration],
       xcodebuild_formatter: "xcpretty",
@@ -61,7 +61,7 @@ platform :ios do
   lane :testWithoutCoverageForUITests do |options|
     run_tests(
       workspace: "OneLogin.xcworkspace",
-      device: "iPhone 17 (26.1)",
+      device: "iPhone 17 (26.4.1)",
       scheme: options[:scheme],
       configuration: options[:configuration],
       xcodebuild_formatter: "xcpretty",
@@ -77,7 +77,7 @@ platform :ios do
   lane :test do |options|
     run_tests(
       workspace: "OneLogin.xcworkspace",
-      device: "iPhone 17 (26.1)",
+      device: "iPhone 17 (26.4.1)",
       scheme: options[:scheme],
       configuration: options[:configuration],
       xcodebuild_formatter: "xcpretty",
@@ -103,7 +103,7 @@ platform :ios do
   desc "Run Tests and Output Code Coverage"
   lane :testWithoutBuilding do |options|
     run_tests(
-      device: "iPhone 17 (26.1)",
+      device: "iPhone 17 (26.4.1)",
       scheme: options[:scheme],
       xcodebuild_formatter: "xcpretty",
       xctestrun: options[:xctestrun],


### PR DESCRIPTION
# fix: update Xcode to 24.1 and OS to 26.4.1

This PR updates Xcode and OS version used to run tests

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
