### PR TITLE
feat: DCMAW-20314 fix a case of user stuck in a login loop

### DIFF
--- a/Sources/Utilities/Storage/Session/PersistentSessionManager.swift
+++ b/Sources/Utilities/Storage/Session/PersistentSessionManager.swift
@@ -7,6 +7,7 @@ import GDSUtilities
 import LocalAuthenticationWrapper
 import Logging
 import SecureStore
+import WalletStore
 
 // swiftlint:disable:next type_body_length
 final class PersistentSessionManager: SessionManager {
@@ -202,6 +203,18 @@ final class PersistentSessionManager: SessionManager {
         (try? localAuthentication.canUseAnyLocalAuth) ?? false && isReturningUser
     }
     
+    private func clear(sessionData: [SessionBoundData], presentSystemLogOut: Bool) async throws {
+        for each in sessionData {
+            try await each.clearSessionData()
+        }
+        
+        endCurrentSession()
+        
+        if presentSystemLogOut {
+            NotificationCenter.default.post(name: .systemLogUserOut)
+        }
+    }
+
     func startAuthSession(
         _ session: any LoginSession,
         using configuration: @Sendable (String?) async throws -> LoginSessionConfiguration
@@ -218,6 +231,13 @@ final class PersistentSessionManager: SessionManager {
                                                                          reason: "secure wallet data deleted"))
                     }
                     try await clearAllSessionData(presentSystemLogOut: true)
+                } catch let error as WalletStoreError where error.kind == .failedToDeleteProofKeys {
+                    do {
+                        try await clear(sessionData: self.sessionBoundData.reversed(), presentSystemLogOut: true)
+                    } catch {
+                        analyticsService.logCrash(error)
+                    }
+                    throw PersistentSessionError(.cannotDeleteData, originalError: error)
                 } catch {
                     throw PersistentSessionError(.cannotDeleteData, originalError: error)
                 }
@@ -390,15 +410,7 @@ final class PersistentSessionManager: SessionManager {
     }
 
     func clearAllSessionData(presentSystemLogOut: Bool) async throws {
-        for each in sessionBoundData {
-            try await each.clearSessionData()
-        }
-        
-        endCurrentSession()
-        
-        if presentSystemLogOut {
-            NotificationCenter.default.post(name: .systemLogUserOut)
-        }
+        try await self.clear(sessionData: sessionBoundData, presentSystemLogOut: presentSystemLogOut)
     }
     
     func registerSessionBoundData(_ data: [SessionBoundData]) {

--- a/Sources/Utilities/Storage/Session/PersistentSessionManager.swift
+++ b/Sources/Utilities/Storage/Session/PersistentSessionManager.swift
@@ -203,18 +203,6 @@ final class PersistentSessionManager: SessionManager {
         (try? localAuthentication.canUseAnyLocalAuth) ?? false && isReturningUser
     }
     
-    private func clear(sessionData: [SessionBoundData], presentSystemLogOut: Bool) async throws {
-        for each in sessionData {
-            try await each.clearSessionData()
-        }
-        
-        endCurrentSession()
-        
-        if presentSystemLogOut {
-            NotificationCenter.default.post(name: .systemLogUserOut)
-        }
-    }
-
     func startAuthSession(
         _ session: any LoginSession,
         using configuration: @Sendable (String?) async throws -> LoginSessionConfiguration
@@ -233,7 +221,7 @@ final class PersistentSessionManager: SessionManager {
                     try await clearAllSessionData(presentSystemLogOut: true)
                 } catch let error as WalletStoreError where error.kind == .failedToDeleteProofKeys {
                     do {
-                        try await clear(sessionData: self.sessionBoundData.reversed(), presentSystemLogOut: true)
+                        try await clearSessionData(in: self.sessionBoundData.reversed(), presentSystemLogOut: true)
                     } catch {
                         analyticsService.logCrash(error)
                     }
@@ -402,17 +390,26 @@ final class PersistentSessionManager: SessionManager {
     }
     
     func clearAppForLogin() async throws {
-        for each in sessionBoundData where type(of: each) != UserDefaultsPreferenceStore.self {
+        let excludingUserDefaultsPreferenceStore = sessionBoundData.filter { type(of: $0 ) != UserDefaultsPreferenceStore.self }
+        try await self.clearSessionData(in: excludingUserDefaultsPreferenceStore, presentSystemLogOut: false)
+    }
+
+    func clearAllSessionData(presentSystemLogOut: Bool) async throws {
+        try await self.clearSessionData(in: sessionBoundData, presentSystemLogOut: presentSystemLogOut)
+    }
+    
+    private func clearSessionData(in sessionData: [SessionBoundData], presentSystemLogOut: Bool) async throws {
+        for each in sessionData {
             try await each.clearSessionData()
         }
         
         endCurrentSession()
+        
+        if presentSystemLogOut {
+            NotificationCenter.default.post(name: .systemLogUserOut)
+        }
     }
 
-    func clearAllSessionData(presentSystemLogOut: Bool) async throws {
-        try await self.clear(sessionData: sessionBoundData, presentSystemLogOut: presentSystemLogOut)
-    }
-    
     func registerSessionBoundData(_ data: [SessionBoundData]) {
         sessionBoundData = data
     }

--- a/Tests/UnitTests/Login/WebAuthenticationServiceTests.swift
+++ b/Tests/UnitTests/Login/WebAuthenticationServiceTests.swift
@@ -225,6 +225,60 @@ struct WebAuthenticationServiceTests {
         }
         
         #expect(error?.kind == .cannotDeleteData)
+        #expect(mockAnalyticsService.crashesLogged.count == 2)
+    }
+    
+    /// GIVEN I am "a returning user", who is "NOT authenticated" due to a `nil` `persistentId`
+    /// AND `WalletSessionBoundData` throws `WalletError(.failedToDeleteProofKeys)` when `clearAllSessionData` is called
+    /// WHEN I start a web session
+    /// AND a `WalletError(.failedToDeleteProofKeys)` is thrown
+    /// AND `clearSessionData` is called for the unprotected store
+    /// AND `clearSessionData` resolves the `WalletError(.failedToDeleteProofKeys)`
+    /// WHEN I a make a second attempt to start a web session
+    /// THEN no error is thrown
+    /// AND a single error has been logged as a crash in analytics
+    ///
+    /// - SeeAlso: https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/6652264520/DCMAW-20314+Technical+Report+Users+stuck+in+a+login+loop
+    @Test func test_startWebSession_success_for_second_attempt() async throws {
+        let mockAnalyticsService = MockAnalyticsService()
+        var clearSessionDataResult: WalletSessionBoundDataStub.ClearSessionDataResult = .failedToDeleteProofKeys
+        
+        var sut: WebAuthenticationService!
+        
+        let error = await #expect(throws: PersistentSessionError.self) {
+            try await confirmation { confirmation in
+
+                let walletSessionData = WalletSessionBoundDataStub(clearSessionDataAsFunction: {
+                    switch clearSessionDataResult {
+                    case .failedToDeleteProofKeys:
+                        throw WalletError(.failedToDeleteProofKeys)
+                    case .success:
+                        return
+                    }
+                })
+
+                let mockUnprotectedStore = MockDefaultsStoreExpectation(clearSessionDataAsFunction: {
+                    confirmation()
+                    clearSessionDataResult = .success
+                })
+
+                let persistentSessionManager: PersistentSessionManager =
+                try .makeReturningUnauthenticatedUser(mockAnalyticsService: mockAnalyticsService,
+                                                      mockUnprotectedStore: mockUnprotectedStore,
+                                                      walletSessionData: walletSessionData)
+                
+                sut = await .make(sessionManager: persistentSessionManager,
+                                  mockAnalyticsService: mockAnalyticsService)
+                
+                try await sut.startWebSession(appIntegrityProvider: AppIntegrityProviderStub())
+            }
+        }
+        #expect(error?.kind == .cannotDeleteData)
+        
+        await #expect(throws: Never.self) {
+            try await sut.startWebSession(appIntegrityProvider: AppIntegrityProviderStub())
+        }
+        
         #expect(mockAnalyticsService.crashesLogged.count == 1)
     }
     
@@ -255,6 +309,11 @@ struct WebAuthenticationServiceTests {
 }
 
 struct WalletSessionBoundDataStub: SessionBoundData {
+    enum ClearSessionDataResult {
+        case failedToDeleteProofKeys
+        case success
+    }
+    
     typealias ClearSessionDataAsFunction = () async throws -> Void
     
     var clearSessionDataAsFunction: ClearSessionDataAsFunction

--- a/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockDefaultsStore.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockDefaultsStore.swift
@@ -24,3 +24,36 @@ class MockDefaultsStore: DefaultsStoring, SessionBoundData {
         savedData = [:]
     }
 }
+
+struct MockDefaultsStoreExpectation: DefaultsStoring, SessionBoundData {
+    typealias ClearSessionDataAsFunction = () throws -> Void
+    
+    let mockDefaultsStore: MockDefaultsStore
+    let clearSessionDataAsFunction: ClearSessionDataAsFunction
+
+    init(mockDefaultsStore: MockDefaultsStore = MockDefaultsStore(), clearSessionDataAsFunction: @escaping ClearSessionDataAsFunction = { }) {
+        self.mockDefaultsStore = mockDefaultsStore
+        self.clearSessionDataAsFunction = clearSessionDataAsFunction
+    }
+    
+    func set(_ value: Any?, forKey defaultName: String) {
+        self.mockDefaultsStore.set(value, forKey: defaultName)
+    }
+    
+    func value(forKey key: String) -> Any? {
+        return self.mockDefaultsStore.value(forKey: key)
+    }
+    
+    func bool(forKey: String) -> Bool {
+        return self.mockDefaultsStore.bool(forKey: forKey)
+    }
+    
+    func removeObject(forKey defaultName: String) {
+        self.mockDefaultsStore.removeObject(forKey: defaultName)
+    }
+    
+    func clearSessionData() throws {
+        try self.mockDefaultsStore.clearSessionData()
+        try self.clearSessionDataAsFunction()
+    }
+}


### PR DESCRIPTION
# [iOS | Users stuck in a login loop ](https://govukverify.atlassian.net/browse/DCMAW-20314)

This PR fixes a case where a user is stuck in a loop between two screens:

“You need to sign in again”
“There was a problem signing you in”

by clearing the session data for the user even when wallet throws an error.  Without this change, **the user has no choice but to delete the app**.

# Discussion

This PR proposes that in the case where `WalletSessionData` throws `.cannotDeleteData` , the rest of the `SessionBoundData` proceeds with deletion of the rest of the user data, including the `UserDefaults` which, **as far as I can tell**, is actually the backing store for the [SecureStoreService](https://github.com/govuk-one-login/mobile-ios-secure-store/blob/3.0.0/Sources/SecureStore/SecureStoreService.swift#L13) which throws the error when failing to decrypt a stored entry. For a more in depth explanation, see [DCMAW-20314: Technical Report: Users stuck in a login loop](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/6652264520/DCMAW-20314+Technical+Report+Users+stuck+in+a+login+loop)

# Changes

## `WebAuthenticationService` error handling

This required a **change in the current implementation** of the `WebAuthenticationService`; more specifically, in case a `PersistentSessionError` of  `.cannotDeleteData` case is thrown, the `WebAuthenticationService` **will clear all session data only this time opting not to fail early  in case of an error**, like `startAuthSession` does for a returning  user that is NOT authenticated.

The intent of this change is to recover from an invalid state by  primarily clearing the data in the `UserDefaultsStore`, which is what the `SecureStoreService` uses as its backing store, which throws a `WalletError` of `.failedToDeleteProofKeys` case due to failing to decrypt the value, as it was read by the `UserDefaultsStore`, in the case of a backup that has been restored which resulted in the encryption key to go missing.

The behaviour is otherwise unchanged, including logging and throwing the error as it was previously handled by the `default` case.

## `UserDefaults` and `clearAllSessionData(presentSystemLogOut:)`
In order to be able to test that `clearSessionData` is [called on](https://github.com/govuk-one-login/mobile-ios-one-login-app/compare/fix/DCMAW-20314-user-stuck-in-a-login-loop?expand=1#diff-56138c3a6ba90730645170a31a2030a44e239fe859f259aa96a911066ae40896R250) the `UserDefaults`, changed `registerSessionBoundData` to clear the `unprotectedStore` in place of the user defaults given that `unprotectedStore` is a reference to `UserDefaults.standard`.

# Where to focus the review

* Should the scope of the catch go further to `WalletError` of `.failedToDeleteProofKeys` kind or should it be kept at a high level to the `PersistentSessionError` of `.cannotDeleteData` kind? The former will make the change surgically more precise without risking any unattended side effects. The latter broadens the scope so that the code can recover from any reason a `PersistentSessionError` is thrown for `.cannotDeleteData`. As a side note, as far as I can see, limiting the scope to `WalletError` of `.failedToDeleteProofKeys`, will require bringing in `Storage` as a dependency where the `WalletStore` (i.e. `.failedToDeleteProofKeys`) enum is defined.

* Even though the proposed code change will remedy the situation, by removing all user session data, is there a chance that the app will be left in a different state that is also invalid? **Should** removing all user session data instead **be done in reverse**? i.e. where `WalletSessionData` is deleted last, thus more likely to succeed given that the storage (i.e. `UserDefaults`) of `SecureStoreService` has now been cleared? 

* Even tho this change alters the behaviour of the app, only for the case of `.cannotDeleteData`, it still represents a significant change compared to how the app already behaves. That is, "remove all user session data (including the persistent session and Wallet data) from the device" but do so "atomically" where wallet data is the first one to be attempted. Should that fail, do not proceed with the deletion. What risks does that carry?

# Testing

Once this change has been deployed to staging and a build is available on TestFlight, will need to follow the "Steps to reproduce" as described in the ticket to confirm the fix.

Do you have any suggestions of either other unit tests or manual testing that should be done as part of running a regression test suite?

# Related Reading

[DCMAW-20314: Technical Report: Users stuck in a login loop](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/6652264520/DCMAW-20314+Technical+Report+Users+stuck+in+a+login+loop)

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
