### PR TITLE
fix: DCMAW-20958 ensure LoginUI tests pass

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -5393,7 +5393,7 @@
 			repositoryURL = "https://github.com/govuk-one-login/mobile-ios-ui";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.10.0;
+				minimumVersion = 1.10.1;
 			};
 		};
 		1E7F940D2F153B2900CC2CF9 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -210,10 +210,10 @@
     {
       "identity" : "mobile-ios-ui",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/govuk-one-login/mobile-ios-ui.git",
+      "location" : "https://github.com/govuk-one-login/mobile-ios-ui",
       "state" : {
-        "revision" : "a34b22e1fd6260069cd30dc71eabed0ddfcae609",
-        "version" : "1.10.0"
+        "revision" : "5592c9efaa40a2e3065e20b56677fc9a7bc1a1ba",
+        "version" : "1.10.1"
       }
     },
     {

--- a/Sources/Screens/Errors/RecoverableLoginErrorViewModel.swift
+++ b/Sources/Screens/Errors/RecoverableLoginErrorViewModel.swift
@@ -32,7 +32,8 @@ struct RecoverableLoginErrorViewModel: GDSCentreAlignedViewModel {
                     icon: .error,
                     errorTitle: GDSTextViewModel(title: GDSLocalisedString(stringKey: "app_signInErrorTitle"),
                                                  titleFont: .largeTitleBold,
-                                                 alignment: .center)
+                                                 alignment: .center,
+                                                 accessibilityIdentifier: "error-screen-title")
                 ),
                 
                 GDSTextViewModel(title: GDSLocalisedString(stringKey: "app_signInErrorRecoverableBody"),
@@ -48,6 +49,7 @@ struct RecoverableLoginErrorViewModel: GDSCentreAlignedViewModel {
                                        
                                        action()
                                    }),
+                                   accessibilityIdentifier: "error-screen-button-0",
                                    verticalPadding: .bottom(DesignSystem.Spacing.default),
                                    horizontalPadding: .horizontal(DesignSystem.Spacing.default))
             ],

--- a/Sources/Screens/Intro/OneLoginIntroViewModel.swift
+++ b/Sources/Screens/Intro/OneLoginIntroViewModel.swift
@@ -32,9 +32,11 @@ struct OneLoginIntroViewModel: GDSCentreAlignedViewModel {
                 GDSTextViewModel(title: "app_nameString",
                                  titleFont: .largeTitleBold,
                                  alignment: .center,
+                                 accessibilityIdentifier: "intro-title",
                                  verticalPadding: .bottom(DesignSystem.Spacing.default)),
                 GDSTextViewModel(title: GDSLocalisedString(stringKey: "app_signInBody", "app_nameString"),
                                  alignment: .center,
+                                 accessibilityIdentifier: "intro-body",
                                  verticalPadding: .top(.zero))
             ],
             movableFooter: [
@@ -50,6 +52,7 @@ struct OneLoginIntroViewModel: GDSCentreAlignedViewModel {
                                        let task = signinAction()
                                        await task?.value
                                    }),
+                                   accessibilityIdentifier: "intro-button",
                                    verticalPadding: .bottom(DesignSystem.Spacing.default),
                                    horizontalPadding: .horizontal(DesignSystem.Spacing.default))
             ],

--- a/Tests/UITests/ScreenObjects/App/LoadingScreen.swift
+++ b/Tests/UITests/ScreenObjects/App/LoadingScreen.swift
@@ -14,7 +14,8 @@ struct LoadingScreen: ScreenObject {
     func waitForHomeScreen() -> HomeScreen {
         let homeScreen = HomeScreen(app: app)
         
-        XCTAssertTrue(homeScreen.tabBarsFirstMatch.waitForExistence(timeout: .timeout), "\(homeScreen) does no exist")
+        XCTAssertTrue(homeScreen.tabBarsFirstMatch.waitForExistence(timeout: .timeout), "Failed to get matching snapshot: "
+                      + "No matches found for Elements matching predicate '\(homeScreen.tabBarsFirstMatch) IN identifiers'")
         
         return homeScreen
     }

--- a/Tests/UITests/ScreenObjects/App/LoginModal.swift
+++ b/Tests/UITests/ScreenObjects/App/LoginModal.swift
@@ -50,7 +50,8 @@ struct LoginModal: ScreenObject {
         
         let errorScreen = ErrorScreen(app: app)
         
-        XCTAssertTrue(errorScreen.title.waitForExistence(timeout: .timeout))
+        XCTAssertTrue(errorScreen.title.waitForExistence(timeout: .timeout), "Failed to get matching snapshot: "
+                      + "No matches found for Elements matching predicate '\(errorScreen.title) IN identifiers' from input \(app.staticTexts)")
         
         return errorScreen
     }
@@ -60,7 +61,8 @@ struct LoginModal: ScreenObject {
         
         let errorScreen = ErrorScreen(app: app)
         
-        XCTAssertTrue(errorScreen.title.waitForExistence(timeout: .timeout))
+        XCTAssertTrue(errorScreen.title.waitForExistence(timeout: .timeout), "Failed to get matching snapshot: "
+                      + "No matches found for Elements matching predicate '\(errorScreen.title) IN identifiers' from input \(app.staticTexts)")
         
         return errorScreen
     }
@@ -75,7 +77,8 @@ struct LoginModal: ScreenObject {
             secondModalScreen.loginButton
         ]
         browserElements.forEach {
-            XCTAssertTrue($0.waitForExistence(timeout: .timeout), "\($0) exists")
+            XCTAssertTrue($0.waitForExistence(timeout: .timeout), "Failed to get matching snapshot: "
+                          + "No matches found for Elements matching predicate '\($0.title) IN identifiers'")
         }
         return secondModalScreen
     }
@@ -90,7 +93,8 @@ struct LoginModal: ScreenObject {
             secondModalScreen.loginButton
         ]
         browserElements.forEach {
-            XCTAssertTrue($0.waitForExistence(timeout: .timeout), "\($0) exists")
+            XCTAssertTrue($0.waitForExistence(timeout: .timeout), "Failed to get matching snapshot: "
+                          + "No matches found for Elements matching predicate '\($0.title) IN identifiers'")
         }
         return secondModalScreen
     }


### PR DESCRIPTION
# [iOS | Tech Debt | Ensure Login UI Tests still pass when using the Design System](https://govukverify.atlassian.net/browse/DCMAW-20958)

This code change uses the latest changes in DesignSystem that allows setting the accessibility identifier to GDSButton and GDSTextView.

Since the move to the DesignSystem for the login flow, i.e. https://github.com/govuk-one-login/mobile-ios-one-login-app/pull/828 the tests have been failing due to the missing accessibility identifiers.

This code change also improves on the error messages to allow for better diagnostics.

# Testing

<img width="1912" height="1242" alt="Screenshot 2026-06-15 at 12 55 13" src="https://github.com/user-attachments/assets/5db18d31-ca73-4dc4-bba5-15cad6059094" />

# Do not merge

This PR depends on https://github.com/govuk-one-login/mobile-ios-ui/pull/105 to be merged first.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
