### PR TITLE
Revert "feat: DCMAW-20314 fix a case of user stuck in a login loop (#…

### DIFF
--- a/Sources/Utilities/Storage/Session/PersistentSessionManager.swift
+++ b/Sources/Utilities/Storage/Session/PersistentSessionManager.swift
@@ -7,7 +7,6 @@ import GDSUtilities
 import LocalAuthenticationWrapper
 import Logging
 import SecureStore
-import WalletStore
 
 // swiftlint:disable:next type_body_length
 final class PersistentSessionManager: SessionManager {
@@ -219,13 +218,6 @@ final class PersistentSessionManager: SessionManager {
                                                                          reason: "secure wallet data deleted"))
                     }
                     try await clearAllSessionData(presentSystemLogOut: true)
-                } catch let error as WalletStoreError where error.kind == .failedToDeleteProofKeys {
-                    do {
-                        try await clearSessionData(in: self.sessionBoundData.reversed(), presentSystemLogOut: true)
-                    } catch {
-                        analyticsService.logCrash(error)
-                    }
-                    throw PersistentSessionError(.cannotDeleteData, originalError: error)
                 } catch {
                     throw PersistentSessionError(.cannotDeleteData, originalError: error)
                 }
@@ -390,16 +382,15 @@ final class PersistentSessionManager: SessionManager {
     }
     
     func clearAppForLogin() async throws {
-        let excludingUserDefaultsPreferenceStore = sessionBoundData.filter { type(of: $0 ) != UserDefaultsPreferenceStore.self }
-        try await self.clearSessionData(in: excludingUserDefaultsPreferenceStore, presentSystemLogOut: false)
+        for each in sessionBoundData where type(of: each) != UserDefaultsPreferenceStore.self {
+            try await each.clearSessionData()
+        }
+        
+        endCurrentSession()
     }
 
     func clearAllSessionData(presentSystemLogOut: Bool) async throws {
-        try await self.clearSessionData(in: sessionBoundData, presentSystemLogOut: presentSystemLogOut)
-    }
-    
-    private func clearSessionData(in sessionData: [SessionBoundData], presentSystemLogOut: Bool) async throws {
-        for each in sessionData {
+        for each in sessionBoundData {
             try await each.clearSessionData()
         }
         
@@ -409,7 +400,7 @@ final class PersistentSessionManager: SessionManager {
             NotificationCenter.default.post(name: .systemLogUserOut)
         }
     }
-
+    
     func registerSessionBoundData(_ data: [SessionBoundData]) {
         sessionBoundData = data
     }

--- a/Tests/UnitTests/Login/WebAuthenticationServiceTests.swift
+++ b/Tests/UnitTests/Login/WebAuthenticationServiceTests.swift
@@ -225,60 +225,6 @@ struct WebAuthenticationServiceTests {
         }
         
         #expect(error?.kind == .cannotDeleteData)
-        #expect(mockAnalyticsService.crashesLogged.count == 2)
-    }
-    
-    /// GIVEN I am "a returning user", who is "NOT authenticated" due to a `nil` `persistentId`
-    /// AND `WalletSessionBoundData` throws `WalletError(.failedToDeleteProofKeys)` when `clearAllSessionData` is called
-    /// WHEN I start a web session
-    /// AND a `WalletError(.failedToDeleteProofKeys)` is thrown
-    /// AND `clearSessionData` is called for the unprotected store
-    /// AND `clearSessionData` resolves the `WalletError(.failedToDeleteProofKeys)`
-    /// WHEN I a make a second attempt to start a web session
-    /// THEN no error is thrown
-    /// AND a single error has been logged as a crash in analytics
-    ///
-    /// - SeeAlso: https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/6652264520/DCMAW-20314+Technical+Report+Users+stuck+in+a+login+loop
-    @Test func test_startWebSession_success_for_second_attempt() async throws {
-        let mockAnalyticsService = MockAnalyticsService()
-        var clearSessionDataResult: WalletSessionBoundDataStub.ClearSessionDataResult = .failedToDeleteProofKeys
-        
-        var sut: WebAuthenticationService!
-        
-        let error = await #expect(throws: PersistentSessionError.self) {
-            try await confirmation { confirmation in
-
-                let walletSessionData = WalletSessionBoundDataStub(clearSessionDataAsFunction: {
-                    switch clearSessionDataResult {
-                    case .failedToDeleteProofKeys:
-                        throw WalletError(.failedToDeleteProofKeys)
-                    case .success:
-                        return
-                    }
-                })
-
-                let mockUnprotectedStore = MockDefaultsStoreExpectation(clearSessionDataAsFunction: {
-                    confirmation()
-                    clearSessionDataResult = .success
-                })
-
-                let persistentSessionManager: PersistentSessionManager =
-                try .makeReturningUnauthenticatedUser(mockAnalyticsService: mockAnalyticsService,
-                                                      mockUnprotectedStore: mockUnprotectedStore,
-                                                      walletSessionData: walletSessionData)
-                
-                sut = await .make(sessionManager: persistentSessionManager,
-                                  mockAnalyticsService: mockAnalyticsService)
-                
-                try await sut.startWebSession(appIntegrityProvider: AppIntegrityProviderStub())
-            }
-        }
-        #expect(error?.kind == .cannotDeleteData)
-        
-        await #expect(throws: Never.self) {
-            try await sut.startWebSession(appIntegrityProvider: AppIntegrityProviderStub())
-        }
-        
         #expect(mockAnalyticsService.crashesLogged.count == 1)
     }
     
@@ -309,11 +255,6 @@ struct WebAuthenticationServiceTests {
 }
 
 struct WalletSessionBoundDataStub: SessionBoundData {
-    enum ClearSessionDataResult {
-        case failedToDeleteProofKeys
-        case success
-    }
-    
     typealias ClearSessionDataAsFunction = () async throws -> Void
     
     var clearSessionDataAsFunction: ClearSessionDataAsFunction

--- a/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockDefaultsStore.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockDefaultsStore.swift
@@ -24,36 +24,3 @@ class MockDefaultsStore: DefaultsStoring, SessionBoundData {
         savedData = [:]
     }
 }
-
-struct MockDefaultsStoreExpectation: DefaultsStoring, SessionBoundData {
-    typealias ClearSessionDataAsFunction = () throws -> Void
-    
-    let mockDefaultsStore: MockDefaultsStore
-    let clearSessionDataAsFunction: ClearSessionDataAsFunction
-
-    init(mockDefaultsStore: MockDefaultsStore = MockDefaultsStore(), clearSessionDataAsFunction: @escaping ClearSessionDataAsFunction = { }) {
-        self.mockDefaultsStore = mockDefaultsStore
-        self.clearSessionDataAsFunction = clearSessionDataAsFunction
-    }
-    
-    func set(_ value: Any?, forKey defaultName: String) {
-        self.mockDefaultsStore.set(value, forKey: defaultName)
-    }
-    
-    func value(forKey key: String) -> Any? {
-        return self.mockDefaultsStore.value(forKey: key)
-    }
-    
-    func bool(forKey: String) -> Bool {
-        return self.mockDefaultsStore.bool(forKey: forKey)
-    }
-    
-    func removeObject(forKey defaultName: String) {
-        self.mockDefaultsStore.removeObject(forKey: defaultName)
-    }
-    
-    func clearSessionData() throws {
-        try self.mockDefaultsStore.clearSessionData()
-        try self.clearSessionDataAsFunction()
-    }
-}


### PR DESCRIPTION
# Reverts iOS | Users stuck in a login loop

This reverts commit [5c0ed19](https://github.com/govuk-one-login/mobile-ios-one-login-app/commit/5c0ed19121fea857599d526bbb8fa9452af12867) generated by https://github.com/govuk-one-login/mobile-ios-one-login-app/pull/833

# Testing

TestFlight Staging Build 1.25.0 (2) that includes the fix failed to pass.

A release (i.e. 1.22.0) of the app that is affected by this defect was updated to 1.25.0 and was still affected.

https://github.com/user-attachments/assets/86aabd62-3672-4073-967d-68ce73f50f29


# Checklist

## Before raising your pull request:
- [ ] Commit messages that conform to conventional commit messages
- [ ] Ran the app locally ensuring it builds 
- [ ] Ran the tests locally ensuring they pass on Build
- [ ] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
