### PR TITLE
feat: DCMAW-21004 keymanagerserivce handle case of failure to init

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -218,6 +218,7 @@
 		8E9587DA2F45E6E80073A475 /* AppIntegrityErrorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9587D92F45E6E80073A475 /* AppIntegrityErrorViewModelTests.swift */; };
 		8E9A51852FDAEA4500F4C93A /* LoginSessionConfiguration+OneLoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9A51842FDAEA4500F4C93A /* LoginSessionConfiguration+OneLoginTests.swift */; };
 		8EA9FDBB2F3CE17E00C52D4D /* AppIntegrityErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EA9FDBA2F3CE17E00C52D4D /* AppIntegrityErrorViewModel.swift */; };
+		99AEB1C52FFCFB2E00F834BB /* PersistentSessionManager+Mocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99AEB1C42FFCFB2E00F834BB /* PersistentSessionManager+Mocks.swift */; };
 		AB24C1132DB94A5F0080141C /* LocalAuthSettingsErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB24C1122DB948520080141C /* LocalAuthSettingsErrorViewModel.swift */; };
 		AB327B112D36BEAD00AC169E /* CRIOrchestrator in Frameworks */ = {isa = PBXBuildFile; productRef = AB327B102D36BEAD00AC169E /* CRIOrchestrator */; };
 		AB51B3752D771E9500348FB6 /* WelcomeTileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB51B3742D771E9500348FB6 /* WelcomeTileViewModel.swift */; };
@@ -861,6 +862,7 @@
 		8E9587D92F45E6E80073A475 /* AppIntegrityErrorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntegrityErrorViewModelTests.swift; sourceTree = "<group>"; };
 		8E9A51842FDAEA4500F4C93A /* LoginSessionConfiguration+OneLoginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoginSessionConfiguration+OneLoginTests.swift"; sourceTree = "<group>"; };
 		8EA9FDBA2F3CE17E00C52D4D /* AppIntegrityErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntegrityErrorViewModel.swift; sourceTree = "<group>"; };
+		99AEB1C42FFCFB2E00F834BB /* PersistentSessionManager+Mocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistentSessionManager+Mocks.swift"; sourceTree = "<group>"; };
 		AB24C1122DB948520080141C /* LocalAuthSettingsErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAuthSettingsErrorViewModel.swift; sourceTree = "<group>"; };
 		AB51B3742D771E9500348FB6 /* WelcomeTileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeTileViewModel.swift; sourceTree = "<group>"; };
 		AB51B3762D78824F00348FB6 /* WelcomeTileViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeTileViewModelTests.swift; sourceTree = "<group>"; };
@@ -2710,6 +2712,7 @@
 				C8BADD262B87AEEA00385FE7 /* MockSecureStoreService.swift */,
 				41C0F5B82C8F45DA0055C571 /* MockSecureTokenStore.swift */,
 				C8BADD2E2B889CB900385FE7 /* MockSessionManager.swift */,
+				99AEB1C42FFCFB2E00F834BB /* PersistentSessionManager+Mocks.swift */,
 			);
 			path = Storage;
 			sourceTree = "<group>";
@@ -3759,6 +3762,7 @@
 				D08B0B5C2BD8046200769CEA /* HomeCoordinatorTests.swift in Sources */,
 				413C58762BF261D300171C06 /* HomeViewControllerTests.swift in Sources */,
 				D0BE24452BEBCB5000759529 /* JWTVerifierTests.swift in Sources */,
+				99AEB1C52FFCFB2E00F834BB /* PersistentSessionManager+Mocks.swift in Sources */,
 				C34BD12A2DDF229100D379C8 /* LocalAuthBiometricsErrorViewModelTests.swift in Sources */,
 				C8486FE72C60E66400DE514C /* LocalAuthServiceWalletTests.swift in Sources */,
 				ABFE5EF52DBA66500093E86E /* LocalAuthSettingsErrorViewModelTests.swift in Sources */,

--- a/Tests/UnitTests/Login/WebAuthenticationServiceTests.swift
+++ b/Tests/UnitTests/Login/WebAuthenticationServiceTests.swift
@@ -240,6 +240,38 @@ struct WebAuthenticationServiceTests {
         #expect(mockAnalyticsService.crashesLogged.count == 1)
     }
     
+    /// GIVEN I am "a returning user", who is "NOT enrolling" and "NOT authenticated" due to a `nil` `expiryDate`
+    /// AND `SecureStoreService` throws `SecureStoreError(.cantRetrieveKey)` when `saveItem` is called as part of `PersistentSessionManager.saveAuthSession()`
+    /// WHEN I start a web session
+    /// THEN an error is logged as a crash in analytics
+    /// AND the error is thrown
+    @Test
+    func test_startWebSession_throws_cannotRetrieveKey() async throws {
+        let mockAnalyticsService = MockAnalyticsService()
+
+        let mockEncryptedStore = MockSecureStoreService()
+        
+        let sessionManager: PersistentSessionManager = try .makeNonReturningNonEnrollingUnauthenticatedUserWithoutSavedExpiryDate(
+            mockAnalyticsService: mockAnalyticsService,
+            mockEncryptedStore: mockEncryptedStore
+        )
+        
+        mockEncryptedStore.errorFromSaveItem = SecureStoreError(.cantRetrieveKey)
+        
+        let sut: WebAuthenticationService = await .make(
+            sessionManager: sessionManager,
+            mockAnalyticsService: mockAnalyticsService
+        )
+        
+        let error = await #expect(throws: SecureStoreError.self) {
+            try await sut.startWebSession(appIntegrityProvider: AppIntegrityProviderStub())
+        }
+        
+        #expect(error?.kind == .cantRetrieveKey)
+        
+        #expect(mockAnalyticsService.crashesLogged.count == 1)
+    }
+    
     @Test
     func test_startWebSession_success() async throws {
         let sessionManager: PersistentSessionManager = .make()
@@ -307,83 +339,5 @@ extension WebAuthenticationService {
         mockLoginSession.errorFromFinalise = error
         
         return .make(window: window, mockLoginSession: mockLoginSession)
-    }
-}
-
-extension PersistentSessionManager {
-    /// Creates a `PersistentSessionManager` with the following conditions:
-    /// * `persistentID = nil` i.e. not stored in the `encryptedStore`
-    /// * `isReturningUser = true`
-    /// *  `walletSDK.isEmpty = true`
-    ///
-    /// A call to `startAuthSession(:using:)` assumes this is "a returning user" that cannot authenticate due to
-    /// the missing `persistendId` results  in call to `clearAllSessionData` to delete my session & Wallet data.
-    static func makeReturningUnauthenticatedUser(mockAnalyticsService: MockAnalyticsService = MockAnalyticsService(),
-                                                 mockEncryptedStore: MockSecureStoreService = MockSecureStoreService(),
-                                                 mockUnprotectedStore: (any DefaultsStoring & SessionBoundData) = MockDefaultsStore(),
-                                                 walletSessionData: SessionBoundData = WalletSessionBoundDataStub(),
-                                                 refreshTokenExchangeManager: TokenExchangeManaging = MockRefreshTokenExchangeManager(),
-                                                 analyticsPreferenceStore: (any AnalyticsPreferenceStore & SessionBoundData) = MockAnalyticsPreferenceStore()
-    ) throws -> PersistentSessionManager {
-        mockUnprotectedStore.set(
-            true,
-            forKey: OLString.returningUser
-        )
-        
-        let walletSDK = MockWalletSDKWrapper()
-        walletSDK.isEmpty = true
-        
-        return try .make(encryptedStore: mockEncryptedStore,
-                         unprotectedStore: mockUnprotectedStore,
-                         analyticsService: mockAnalyticsService,
-                         walletSDK: walletSDK,
-                         walletSessionData: walletSessionData,
-                         refreshTokenExchangeManager: refreshTokenExchangeManager,
-                         serialTaskQueue: SerialTaskQueue(),
-                         analyticsPreferenceStore: analyticsPreferenceStore)
-    }
-    
-    /// Creates a `PersistentSessionManager` with the following conditions:
-    /// * `isEnrolling = false`
-    /// * `isReturningUser = true`
-    /// * `persistentID = [random uuid]`
-    /// *  `walletSDK.isEmpty = true`
-    ///
-    /// A call to `startAuthSession(:using:)` assumes this is "a returning user" with a `sessionState` that is `.nonePresent` due to a missing `expiryDate`.
-    static func makeNonReturningNonEnrollingUnauthenticatedUserWithoutSavedExpiryDate(
-        mockAnalyticsService: MockAnalyticsService = MockAnalyticsService(),
-        accessControlEncryptedSecureStoreMigrator: MockSecureStoreService = MockSecureStoreService(),
-        mockEncryptedStore: MockSecureStoreService = MockSecureStoreService(),
-        mockUnprotectedStore: (any DefaultsStoring & SessionBoundData) = MockDefaultsStore(),
-        walletSessionData: SessionBoundData = WalletSessionBoundDataStub(),
-        refreshTokenExchangeManager: TokenExchangeManaging = MockRefreshTokenExchangeManager(),
-        analyticsPreferenceStore: (any AnalyticsPreferenceStore & SessionBoundData) = MockAnalyticsPreferenceStore()
-    ) throws -> PersistentSessionManager {
-        mockUnprotectedStore.set(
-            true,
-            forKey: OLString.returningUser
-        )
-
-        try mockEncryptedStore.saveItem(
-            item: UUID().uuidString,
-            itemName: OLString.persistentSessionID
-        )
-        
-        let walletSDK = MockWalletSDKWrapper()
-        walletSDK.isEmpty = true
-        
-        let persistentSessionManager: PersistentSessionManager = try .make(
-                         accessControlEncryptedSecureStoreMigrator: accessControlEncryptedSecureStoreMigrator,
-                         encryptedStore: mockEncryptedStore,
-                         unprotectedStore: mockUnprotectedStore,
-                         analyticsService: mockAnalyticsService,
-                         walletSDK: walletSDK,
-                         walletSessionData: walletSessionData,
-                         refreshTokenExchangeManager: refreshTokenExchangeManager,
-                         serialTaskQueue: SerialTaskQueue(),
-                         analyticsPreferenceStore: analyticsPreferenceStore)
-        
-        persistentSessionManager.isEnrolling = false
-        return persistentSessionManager
     }
 }

--- a/Tests/UnitTests/Mocks/Sessions+Services/Storage/PersistentSessionManager+Mocks.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Storage/PersistentSessionManager+Mocks.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Logging
+@testable import OneLogin
+
+extension PersistentSessionManager {
+    /// Creates a `PersistentSessionManager` with the following conditions:
+    /// * `persistentID = nil` i.e. not stored in the `encryptedStore`
+    /// * `isReturningUser = true`
+    /// *  `walletSDK.isEmpty = true`
+    ///
+    /// A call to `startAuthSession(:using:)` assumes this is "a returning user" that cannot authenticate due to
+    /// the missing `persistendId` results  in call to `clearAllSessionData` to delete my session & Wallet data.
+    static func makeReturningUnauthenticatedUser(mockAnalyticsService: MockAnalyticsService = MockAnalyticsService(),
+                                                 mockEncryptedStore: MockSecureStoreService = MockSecureStoreService(),
+                                                 mockUnprotectedStore: (any DefaultsStoring & SessionBoundData) = MockDefaultsStore(),
+                                                 walletSessionData: SessionBoundData = WalletSessionBoundDataStub(),
+                                                 refreshTokenExchangeManager: TokenExchangeManaging = MockRefreshTokenExchangeManager(),
+                                                 analyticsPreferenceStore: (any AnalyticsPreferenceStore & SessionBoundData) = MockAnalyticsPreferenceStore()
+    ) throws -> PersistentSessionManager {
+        mockUnprotectedStore.set(
+            true,
+            forKey: OLString.returningUser
+        )
+
+        let walletSDK = MockWalletSDKWrapper()
+        walletSDK.isEmpty = true
+
+        return try .make(encryptedStore: mockEncryptedStore,
+                         unprotectedStore: mockUnprotectedStore,
+                         analyticsService: mockAnalyticsService,
+                         walletSDK: walletSDK,
+                         walletSessionData: walletSessionData,
+                         refreshTokenExchangeManager: refreshTokenExchangeManager,
+                         serialTaskQueue: SerialTaskQueue(),
+                         analyticsPreferenceStore: analyticsPreferenceStore)
+    }
+
+    /// Creates a `PersistentSessionManager` with the following conditions:
+    /// * `isEnrolling = false`
+    /// * `isReturningUser = true`
+    /// * `persistentID = [random uuid]`
+    /// *  `walletSDK.isEmpty = true`
+    ///
+    /// A call to `startAuthSession(:using:)` assumes this is "a returning user" with a `sessionState` that is `.nonePresent` due to a missing `expiryDate`.
+    static func makeNonReturningNonEnrollingUnauthenticatedUserWithoutSavedExpiryDate(
+        mockAnalyticsService: MockAnalyticsService = MockAnalyticsService(),
+        accessControlEncryptedSecureStoreMigrator: MockSecureStoreService = MockSecureStoreService(),
+        mockEncryptedStore: MockSecureStoreService = MockSecureStoreService(),
+        mockUnprotectedStore: (any DefaultsStoring & SessionBoundData) = MockDefaultsStore(),
+        walletSessionData: SessionBoundData = WalletSessionBoundDataStub(),
+        refreshTokenExchangeManager: TokenExchangeManaging = MockRefreshTokenExchangeManager(),
+        analyticsPreferenceStore: (any AnalyticsPreferenceStore & SessionBoundData) = MockAnalyticsPreferenceStore()
+    ) throws -> PersistentSessionManager {
+        mockUnprotectedStore.set(
+            true,
+            forKey: OLString.returningUser
+        )
+
+        try mockEncryptedStore.saveItem(
+            item: UUID().uuidString,
+            itemName: OLString.persistentSessionID
+        )
+
+        let walletSDK = MockWalletSDKWrapper()
+        walletSDK.isEmpty = true
+
+        let persistentSessionManager: PersistentSessionManager = try .make(
+                         accessControlEncryptedSecureStoreMigrator: accessControlEncryptedSecureStoreMigrator,
+                         encryptedStore: mockEncryptedStore,
+                         unprotectedStore: mockUnprotectedStore,
+                         analyticsService: mockAnalyticsService,
+                         walletSDK: walletSDK,
+                         walletSessionData: walletSessionData,
+                         refreshTokenExchangeManager: refreshTokenExchangeManager,
+                         serialTaskQueue: SerialTaskQueue(),
+                         analyticsPreferenceStore: analyticsPreferenceStore)
+
+        persistentSessionManager.isEnrolling = false
+        return persistentSessionManager
+    }
+}


### PR DESCRIPTION
# [iOS | Tech Debt | SecureStoreError(.cantRetrieveKey) | KeyManagerService](https://govukverify.atlassian.net/browse/DCMAW-21004)

This code change merely expands the test coverage of the app to demonstrate the scenario is an accepted behaviour.

Specifically, when an a `SecureStoreError(.cantRetrieveKey)` error is thrown as part of an attempt to start a session, that error will indeed lead to failure to start the session and an analytic will be logged.

# Do not merge

Depends on PR
* https://github.com/govuk-one-login/mobile-ios-one-login-app/pull/865

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
