### PR TITLE
feat: DCMAW-21030 fix a case of a user stuck in a login loop

### DIFF
--- a/AppIntegrity/Sources/AppIntegrity/FirebaseAppIntegrityService.swift
+++ b/AppIntegrity/Sources/AppIntegrity/FirebaseAppIntegrityService.swift
@@ -156,7 +156,7 @@ public final class FirebaseAppIntegrityService: AppIntegrityProvider {
         }
     }
     
-    init(
+    public init(
         vendor: AppCheckVendor,
         attestationProofOfPossessionProvider: ProofOfPossessionProvider,
         attestationProofOfPossessionTokenGenerator: ProofOfPossessionTokenGenerator,

--- a/AppIntegrity/Sources/AppIntegrity/Protocols/AppCheckVendor.swift
+++ b/AppIntegrity/Sources/AppIntegrity/Protocols/AppCheckVendor.swift
@@ -1,6 +1,6 @@
 import FirebaseAppCheck
 
-protocol AppCheckVendor {
+public protocol AppCheckVendor {
     static func setAppCheckProviderFactory(_ factory: AppCheckProviderFactory?)
     static func appCheck() -> Self
 

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -256,6 +256,7 @@
 		8E9587DA2F45E6E80073A475 /* AppIntegrityErrorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9587D92F45E6E80073A475 /* AppIntegrityErrorViewModelTests.swift */; };
 		8E9A51852FDAEA4500F4C93A /* LoginSessionConfiguration+OneLoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9A51842FDAEA4500F4C93A /* LoginSessionConfiguration+OneLoginTests.swift */; };
 		8EA9FDBB2F3CE17E00C52D4D /* AppIntegrityErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EA9FDBA2F3CE17E00C52D4D /* AppIntegrityErrorViewModel.swift */; };
+		9996E02F30064DF900AB019B /* FirebaseAppIntegrityService+Mocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9996E02E30064DF400AB019B /* FirebaseAppIntegrityService+Mocks.swift */; };
 		99AEB1C52FFCFB2E00F834BB /* PersistentSessionManager+Mocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99AEB1C42FFCFB2E00F834BB /* PersistentSessionManager+Mocks.swift */; };
 		AB24C1132DB94A5F0080141C /* LocalAuthSettingsErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB24C1122DB948520080141C /* LocalAuthSettingsErrorViewModel.swift */; };
 		AB327B112D36BEAD00AC169E /* CRIOrchestrator in Frameworks */ = {isa = PBXBuildFile; productRef = AB327B102D36BEAD00AC169E /* CRIOrchestrator */; };
@@ -893,6 +894,7 @@
 		8E9587D92F45E6E80073A475 /* AppIntegrityErrorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntegrityErrorViewModelTests.swift; sourceTree = "<group>"; };
 		8E9A51842FDAEA4500F4C93A /* LoginSessionConfiguration+OneLoginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoginSessionConfiguration+OneLoginTests.swift"; sourceTree = "<group>"; };
 		8EA9FDBA2F3CE17E00C52D4D /* AppIntegrityErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntegrityErrorViewModel.swift; sourceTree = "<group>"; };
+		9996E02E30064DF400AB019B /* FirebaseAppIntegrityService+Mocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FirebaseAppIntegrityService+Mocks.swift"; sourceTree = "<group>"; };
 		99AEB1C42FFCFB2E00F834BB /* PersistentSessionManager+Mocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistentSessionManager+Mocks.swift"; sourceTree = "<group>"; };
 		AB24C1122DB948520080141C /* LocalAuthSettingsErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAuthSettingsErrorViewModel.swift; sourceTree = "<group>"; };
 		ABBD21AB2C6E1D6B00B0C959 /* MockAppInfoService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAppInfoService.swift; sourceTree = "<group>"; };
@@ -2325,6 +2327,7 @@
 				ABBD21AB2C6E1D6B00B0C959 /* MockAppInfoService.swift */,
 				1E4738EB2EC7320C00803940 /* MockAppIntegrityProvider.swift */,
 				8E3C5A3C2F9FBF8500389C50 /* AppIntegrityProviderStub.swift */,
+				9996E02E30064DF400AB019B /* FirebaseAppIntegrityService+Mocks.swift */,
 				C8603B1E2D9EC3F400B4AD28 /* MockCRIORchestrator.swift */,
 				7CDC2EC32C8B247300EAA592 /* MockHelloWorldService.swift */,
 				1E88606E2EC4A9E100364BCF /* MockRefreshTokenExchangeManager.swift */,
@@ -3736,6 +3739,7 @@
 				C8C385562DA939D300520E69 /* MockAuthenticationProvider.swift in Sources */,
 				C8C385572DA939D300520E69 /* MockAuthenticationService.swift in Sources */,
 				C8603B1F2D9EC40400B4AD28 /* MockCRIORchestrator.swift in Sources */,
+				9996E02F30064DF900AB019B /* FirebaseAppIntegrityService+Mocks.swift in Sources */,
 				C811D65A2EA056A3009909A8 /* AppIntegrityDPoPJWTTests.swift in Sources */,
 				C8B825C52B98D3FA00336146 /* MockDefaultsStore.swift in Sources */,
 				7CDC2EC42C8B247300EAA592 /* MockHelloWorldService.swift in Sources */,

--- a/Sources/Extensions/CustomTypes/AppIntegrityProvider+OneLogin.swift
+++ b/Sources/Extensions/CustomTypes/AppIntegrityProvider+OneLogin.swift
@@ -25,7 +25,7 @@ extension AppIntegrityProvider where Self == FirebaseAppIntegrityService {
                 attestationProofOfPossessionProvider: attestationProvider,
                 attestationProofOfPossessionTokenGenerator: attestationPoPTokenGenerator,
                 demonstratingProofOfPossessionTokenGenerator: demonstratingPoPTokenGenerator,
-                attestationStore: SecureAttestationStore(),
+                attestationStore: SecureAttestationStore.make(),
                 networkClient: NetworkClient(),
                 baseURL: AppEnvironment.mobileBaseURL
             )

--- a/Sources/Utilities/Storage/SecureAttestationStore.swift
+++ b/Sources/Utilities/Storage/SecureAttestationStore.swift
@@ -11,7 +11,42 @@ enum AttestationStorageError: Error {
     case cantRetrieveAttestationJWT
 }
 
+/// Use a ``SecureAttestationStore`` to store the ``attestationJWT`` and ``attestationExpired`` date.
+///
+/// The ``SecureAttestationStore`` guarantees that data is stored securely (i.e. encrypted) and is only accessible (i.e. decrypted) when requested.
+///
+/// - SeeAlso: ``SecureStorable``
 final class SecureAttestationStore: AttestationStorage {
+    
+    /// Returns a new ``SecureAttestationStore`` with the given `secureStore`.
+    /// The ``SecureAttestationStore`` instance guarantees that any existing data stored in the given `secureStore`  is accessible.
+    ///
+    /// In case the ``attestationJWT`` in the given ``secureStore`` is not accessible (i.e. cannot be decrypted), the returned instance will **delete** all data associated with the underlying `secureStore`
+    ///
+    /// - parameter secureStore: an instance of the ``SecureStorable``;  by **default** the secure store is created  using a
+    ///     ``SecureStorageConfiguration`` with an `id` of ``OLString/attestationStore`` and ``accessControlLevel`` that is ``AccessControlLevel/open``
+    /// - SeeAlso: ``SecureStoreService/readItem``
+    public static func make(secureStore: SecureStorable = SecureStoreService(
+        configuration: SecureStorageConfiguration(
+            id: OLString.attestationStore,
+            accessControlLevel: .open
+        )
+    )) -> SecureAttestationStore {
+        
+        let secureAttestationStore = SecureAttestationStore(secureStore: secureStore)
+        
+        let attestationJWT = Result {
+            try secureAttestationStore.attestationJWT
+        }
+        
+        if case .failure(let error as SecureStoreError) = attestationJWT, error.kind == .cantDecryptData,
+            let originalError = error.originalError as? NSError, originalError.code == errSecParam {
+                secureAttestationStore.removeAllData()
+        }
+        
+        return secureAttestationStore
+    }
+    
     private let secureStore: SecureStorable
     
     var attestationExpired: Bool {
@@ -22,12 +57,16 @@ final class SecureAttestationStore: AttestationStorage {
         return expiryDate < .now
     }
     
+    /// Returns the `attestationJWT` or throws an error in case that:
+    /// * no `attestationJWT` is present
+    /// * the `attestationJWT` cannot be decrypted
     var attestationJWT: String {
         get throws {
             try secureStore.readItem(itemName: AttestationStorageKey.clientAttestationJWT.rawValue)
         }
     }
     
+    /// Creates a new ``SecureAttestationStore`` with the given `secureStore`.
     init(
         secureStore: SecureStorable = SecureStoreService(
             configuration: SecureStorageConfiguration(
@@ -51,6 +90,12 @@ final class SecureAttestationStore: AttestationStorage {
             id: AttestationStorageKey.attestationExpiry.rawValue,
             attestationExpiry
         )
+    }
+    
+    func removeAllData() {
+        AttestationStorageKey.allCases.forEach {
+            secureStore.deleteItem(itemName: $0.rawValue)
+        }
     }
     
     func delete() throws {

--- a/Sources/Utilities/Storage/SecureAttestationStore.swift
+++ b/Sources/Utilities/Storage/SecureAttestationStore.swift
@@ -21,7 +21,8 @@ final class SecureAttestationStore: AttestationStorage {
     /// Returns a new ``SecureAttestationStore`` with the given `secureStore`.
     /// The ``SecureAttestationStore`` instance guarantees that any existing data stored in the given `secureStore`  is accessible.
     ///
-    /// In case the ``attestationJWT`` in the given ``secureStore`` is not accessible (i.e. cannot be decrypted), the returned instance will **delete** all data associated with the underlying `secureStore`
+    /// In case the ``attestationJWT`` in the given ``secureStore`` is not accessible (i.e. cannot be decrypted),
+    /// the returned instance will **delete** all data associated with the underlying `secureStore`
     ///
     /// - parameter secureStore: an instance of the ``SecureStorable``;  by **default** the secure store is created  using a
     ///     ``SecureStorageConfiguration`` with an `id` of ``OLString/attestationStore`` and ``accessControlLevel`` that is ``AccessControlLevel/open``

--- a/Sources/Utilities/Storage/Session/PersistentSessionManager.swift
+++ b/Sources/Utilities/Storage/Session/PersistentSessionManager.swift
@@ -27,8 +27,10 @@ final class PersistentSessionManager: SessionManager {
         
         let encryptedSecureStoreMigrator = encryptedStore ?? EncryptedSecureStoreMigrator(analyticsService: analyticsService)
         let manager = PersistentSessionManager(
-            accessControlEncryptedStore: accessControlEncryptedSecureStoreMigrator,
             encryptedStore: encryptedSecureStoreMigrator,
+            storeKeyService: SecureTokenStore(
+                accessControlEncryptedStore: accessControlEncryptedSecureStoreMigrator
+            ),
             unprotectedStore: unprotectedStore,
             localAuthentication: LocalAuthenticationWrapper(localAuthStrings: .oneLogin),
             analyticsService: analyticsService,
@@ -50,7 +52,6 @@ final class PersistentSessionManager: SessionManager {
         return manager
     }
     
-    private let accessControlEncryptedStore: SecureStorable
     private let encryptedStore: SecureStorable
     private let storeKeyService: TokenStore
     private let unprotectedStore: DefaultsStoring
@@ -70,15 +71,15 @@ final class PersistentSessionManager: SessionManager {
     let serialTaskQueue: SerialTaskQueue
     
     convenience init(
-        accessControlEncryptedStore: SecureStorable,
         encryptedStore: SecureStorable,
+        storeKeyService: SecureTokenStore,
         analyticsService: OneLoginAnalyticsService,
         tokenExchangeManager: TokenExchangeManaging,
         serialTaskQueue: SerialTaskQueue = SerialTaskQueue(),
     ) {
         self.init(
-            accessControlEncryptedStore: accessControlEncryptedStore,
             encryptedStore: encryptedStore,
+            storeKeyService: storeKeyService,
             unprotectedStore: UserDefaults.standard,
             localAuthentication: LocalAuthenticationWrapper(localAuthStrings: .oneLogin),
             analyticsService: analyticsService,
@@ -88,8 +89,8 @@ final class PersistentSessionManager: SessionManager {
     }
     
     init(
-        accessControlEncryptedStore: SecureStorable,
         encryptedStore: SecureStorable,
+        storeKeyService: SecureTokenStore,
         unprotectedStore: DefaultsStoring,
         localAuthentication: LocalAuthManaging,
         analyticsService: OneLoginAnalyticsService,
@@ -97,11 +98,8 @@ final class PersistentSessionManager: SessionManager {
         tokenExchangeManager: TokenExchangeManaging,
         serialTaskQueue: SerialTaskQueue = SerialTaskQueue()
     ) {
-        self.accessControlEncryptedStore = accessControlEncryptedStore
         self.encryptedStore = encryptedStore
-        self.storeKeyService = SecureTokenStore(
-            accessControlEncryptedStore: accessControlEncryptedStore
-        )
+        self.storeKeyService = storeKeyService
         self.unprotectedStore = unprotectedStore
         self.localAuthentication = localAuthentication
         

--- a/Tests/UnitTests/Login/WebAuthenticationServiceTests.swift
+++ b/Tests/UnitTests/Login/WebAuthenticationServiceTests.swift
@@ -209,7 +209,7 @@ final class WebAuthenticationServiceXCTests: XCTestCase {
 
 struct WebAuthenticationServiceTests {
     /// GIVEN I am "a returning user", who is "NOT authenticated" due to a `nil` `persistentId`
-    /// AND `WalletSessionBoundData` throws `WalletStoreError(.failedToDeleteProofKeys)` when `clearAllSessionData` is called
+    /// AND `WalletSessionBoundData` throws `WalletStoreError(.failedToDeleteProofKeys)` in case`clearAllSessionData` is called
     /// WHEN I start a web session
     /// THEN an error is logged as a crash in analytics
     /// AND the error is thrown
@@ -240,7 +240,7 @@ struct WebAuthenticationServiceTests {
     }
     
     /// GIVEN I am "a returning user", who is "NOT enrolling" and "NOT authenticated" due to a `nil` `expiryDate`
-    /// AND `SecureStoreService` throws `SecureStoreError(.cantRetrieveKey)` when `saveItem` is called as part of `PersistentSessionManager.saveAuthSession()`
+    /// AND `SecureStoreService` throws `SecureStoreError(.cantRetrieveKey)` in case`saveItem` is called as part of `PersistentSessionManager.saveAuthSession()`
     /// WHEN I start a web session
     /// THEN an error is logged as a crash in analytics
     /// AND the error is thrown
@@ -250,7 +250,7 @@ struct WebAuthenticationServiceTests {
 
         let mockEncryptedStore = MockSecureStoreService()
         
-        let sessionManager: PersistentSessionManager = try .makeNonReturningNonEnrollingUnauthenticatedUserWithoutSavedExpiryDate(
+        let sessionManager: PersistentSessionManager = try .makeReturningNonEnrollingUnauthenticatedUserWithoutSavedExpiryDate(
             mockAnalyticsService: mockAnalyticsService,
             mockEncryptedStore: mockEncryptedStore
         )
@@ -297,6 +297,109 @@ struct WebAuthenticationServiceTests {
         #expect(mockAnalyticsService.crashesLogged.count == 1)
     }
 
+    /// This is a case where a as part of instantiating a `KeyManagerService`, a new set of keys is created
+    /// that is tied to the Secure Enclave (i.e. `kSecAttrTokenID: kSecAttrTokenIDSecureEnclave`).
+    ///
+    /// A SE key pair provides strong guarantees so that:
+    /// * It is never exported to a backup
+    /// * The key pair is deleted as soon as the device is erased
+    ///
+    /// In this case:
+    /// 1. a backup from an existing device, with previously encrypted data (i.e. , AttestationJWT)
+    /// 2. a restore on the device is performed
+    /// 3. the data is restored
+    /// 4. the key is not restored
+    ///
+    /// When attempting to **decrypt** the data, an `errSecParam` (aka -50) will be thrown
+    @Test("""
+         GIVEN I am "a returning user", who is "NOT enrolling" and "NOT authenticated" due to a `nil` `expiryDate`
+         AND `AttestationStorage` is not expired throws `SecureStoreError(.cantDecryptData)` with an
+             in case `tokenHeaders` are required as part of `LoginSession.performLoginFlow(configuration:)`
+         WHEN I start a web session, a login will be performed
+         THEN an error is logged as a crash in analytics
+         AND the error is thrown
+        """)
+    func test_errorFromAttestationJWT_onReturningUser() async throws {
+        let mockAnalyticsService = MockAnalyticsService()
+
+        let sessionManager: PersistentSessionManager = try .makeReturningNonEnrollingUnauthenticatedUserWithoutSavedExpiryDate()
+
+        let sut: WebAuthenticationService = await .make(
+            sessionManager: sessionManager,
+            mockLoginSession: MockAppAuthSession(performLoginFlowAsFunction: { configuration in
+                _ = try await configuration.tokenHeaders()
+                return try MockTokenResponse().getJSONData()
+            }),
+            mockAnalyticsService: mockAnalyticsService
+        )
+
+        let errorFromAttestationJWT = SecureStoreError(.cantDecryptData,
+                                                       originalError: NSError(domain: NSOSStatusErrorDomain, code: -50))
+
+        let error = await #expect(throws: SecureStoreError.self) {
+            try await sut.startWebSession(appIntegrityProvider: FirebaseAppIntegrityService.makeNonExpired(errorFromAttestationJWT: errorFromAttestationJWT))
+        }
+
+        #expect(error?.kind == .cantDecryptData)
+
+        let originalError = try #require(error?.originalError as? NSError)
+        #expect(originalError.code == errSecParam)
+        #expect(originalError.code == -50)
+
+        #expect(mockAnalyticsService.crashesLogged.count == 1)
+    }
+    
+    /// This is a case where a as part of instantiating a `KeyManagerService`, a new set of keys is created
+    /// that is tied to the Secure Enclave (i.e. `kSecAttrTokenID: kSecAttrTokenIDSecureEnclave`).
+    ///
+    /// A SE key pair provides strong guarantees so that:
+    /// * It is never exported to a backup
+    /// * The key pair is deleted as soon as the device is erased
+    ///
+    /// In this case:
+    /// 1. a backup from an existing device, with previously encrypted data (i.e. , AttestationJWT)
+    /// 2. a restore on the device is performed
+    /// 3. the data is restored
+    /// 4. the key is not restored
+    ///
+    /// When attempting to **decrypt** the data, an `errSecParam` (aka -50) will be thrown
+    @Test("""
+         GIVEN I am "a new user", who is "NOT enrolling"
+         AND `AttestationStorage` is not expired throws `SecureStoreError(.cantDecryptData)` with an
+             in case `tokenHeaders` are required as part of `LoginSession.performLoginFlow(configuration:)`
+         WHEN I start a web session, a login will be performed
+         THEN an error is logged as a crash in analytics
+         AND the error is thrown
+        """)
+    func test_errorFromAttestationJWT_onNewUser() async throws {
+        let mockAnalyticsService = MockAnalyticsService()
+
+        let sessionManager: PersistentSessionManager = .make()
+
+        let sut: WebAuthenticationService = await .make(
+            sessionManager: sessionManager,
+            mockLoginSession: MockAppAuthSession(performLoginFlowAsFunction: { configuration in
+                _ = try await configuration.tokenHeaders()
+                return try MockTokenResponse().getJSONData()
+            }),
+            mockAnalyticsService: mockAnalyticsService
+        )
+
+        let errorFromAttestationJWT = SecureStoreError(.cantDecryptData,
+                                                       originalError: NSError(domain: NSOSStatusErrorDomain, code: -50))
+
+        let error = await #expect(throws: SecureStoreError.self) {
+            try await sut.startWebSession(appIntegrityProvider: FirebaseAppIntegrityService.makeNonExpired(errorFromAttestationJWT: errorFromAttestationJWT))
+        }
+
+        #expect(error?.kind == .cantDecryptData)
+
+        let originalError = try #require(error?.originalError as? NSError)
+        #expect(originalError.code == errSecParam)
+        #expect(originalError.code == -50)
+
+        #expect(mockAnalyticsService.crashesLogged.count == 1)
+    }
 }
 
 struct WalletSessionBoundDataStub: SessionBoundData {
@@ -311,13 +414,11 @@ struct WalletSessionBoundDataStub: SessionBoundData {
 
 @MainActor
 extension WebAuthenticationService {
-    static func make(window: UIWindow? = nil,
-                     sessionManager: SessionManager = MockSessionManager(),
-                     mockLoginSession: MockLoginSession? = nil,
+    static func make(sessionManager: SessionManager = MockSessionManager(),
+                     mockLoginSession: LoginSession? = nil,
                      mockAnalyticsService: MockAnalyticsService = MockAnalyticsService()) -> WebAuthenticationService {
         
-        let window = window ?? UIWindow()
-        let mockLoginSession = mockLoginSession ?? MockLoginSession(window: window)
+        let mockLoginSession = mockLoginSession ?? MockAppAuthSession()
         
         return WebAuthenticationService(sessionManager: sessionManager,
                                         session: mockLoginSession,
@@ -337,6 +438,6 @@ extension WebAuthenticationService {
         let mockLoginSession = MockLoginSession(window: window)
         mockLoginSession.errorFromFinalise = error
         
-        return .make(window: window, mockLoginSession: mockLoginSession)
+        return .make(mockLoginSession: mockLoginSession)
     }
 }

--- a/Tests/UnitTests/Login/WebAuthenticationServiceTests.swift
+++ b/Tests/UnitTests/Login/WebAuthenticationServiceTests.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import AppIntegrity
 import Authentication
 import GDSAnalytics

--- a/Tests/UnitTests/Mocks/Sessions+Services/Authentication/MockLoginSession.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Authentication/MockLoginSession.swift
@@ -66,9 +66,9 @@ final class MockAppAuthSession: LoginSession {
     var finaliseAsFunction: FinaliseAsFunction
 
     convenience init() {
-        self.init(performLoginFlowAsFunction: { configuration in
+        self.init(performLoginFlowAsFunction: { _ in
             return try MockTokenResponse().getJSONData()
-        }, finaliseAsFunction: { _ in })
+        })
     }
     
     convenience init(performLoginFlowAsFunction: @escaping PerformLoginFlowAsFunction) {

--- a/Tests/UnitTests/Mocks/Sessions+Services/Authentication/MockLoginSession.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Authentication/MockLoginSession.swift
@@ -56,3 +56,35 @@ final class MockLoginSessionNoRefresh: LoginSession {
         }
     }
 }
+
+final class MockAppAuthSession: LoginSession {
+    
+    typealias PerformLoginFlowAsFunction = (LoginSessionConfiguration) async throws -> TokenResponse
+    typealias FinaliseAsFunction = (URL) throws -> Void
+    
+    var performLoginFlowAsFunction: PerformLoginFlowAsFunction
+    var finaliseAsFunction: FinaliseAsFunction
+
+    convenience init() {
+        self.init(performLoginFlowAsFunction: { configuration in
+            return try MockTokenResponse().getJSONData()
+        }, finaliseAsFunction: { _ in })
+    }
+    
+    convenience init(performLoginFlowAsFunction: @escaping PerformLoginFlowAsFunction) {
+        self.init(performLoginFlowAsFunction: performLoginFlowAsFunction, finaliseAsFunction: { _ in })
+    }
+    
+    init(performLoginFlowAsFunction: @escaping PerformLoginFlowAsFunction, finaliseAsFunction: @escaping FinaliseAsFunction) {
+        self.performLoginFlowAsFunction = performLoginFlowAsFunction
+        self.finaliseAsFunction = finaliseAsFunction
+    }
+
+    func performLoginFlow(configuration: LoginSessionConfiguration) async throws -> TokenResponse {
+        return try await self.performLoginFlowAsFunction(configuration)
+    }
+
+    func finalise(redirectURL: URL) throws {
+        try self.finaliseAsFunction(redirectURL)
+    }
+}

--- a/Tests/UnitTests/Mocks/Sessions+Services/FirebaseAppIntegrityService+Mocks.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/FirebaseAppIntegrityService+Mocks.swift
@@ -1,6 +1,6 @@
 import AppIntegrity
-import Foundation
 import FirebaseAppCheck
+import Foundation
 import MockNetworking
 import Networking
 @testable import OneLogin
@@ -166,15 +166,15 @@ class MockAttestationStore: AttestationStorage {
     }
     var mockStorage = [String: Any]()
 
-    convenience init(attestationExpired: Bool = false, attestationJWT: String = "", mockStorage: [String : Any] = [String: Any]()) {
+    convenience init(attestationExpired: Bool = false, attestationJWT: String = "", mockStorage: [String: Any] = [String: Any]()) {
         self.init(attestationExpired: attestationExpired, attestationJWTAsFunction: Self.attestationJWT(attestationJWT), mockStorage: mockStorage)
     }
 
-    convenience init(attestationExpired: Bool = false, errorFromAttestationJWT error: Error, mockStorage: [String : Any] = [String: Any]()) {
+    convenience init(attestationExpired: Bool = false, errorFromAttestationJWT error: Error, mockStorage: [String: Any] = [String: Any]()) {
         self.init(attestationExpired: attestationExpired, attestationJWTAsFunction: Self.errorFromAttestationJWT(error), mockStorage: mockStorage)
     }
 
-    init(attestationExpired: Bool = false, attestationJWTAsFunction: @escaping AttestationJWTAsFunction, mockStorage: [String : Any] = [String: Any]()) {
+    init(attestationExpired: Bool = false, attestationJWTAsFunction: @escaping AttestationJWTAsFunction, mockStorage: [String: Any] = [String: Any]()) {
         self.attestationExpired = attestationExpired
         self.attestationJWTAsFunction = attestationJWTAsFunction
         self.mockStorage = mockStorage

--- a/Tests/UnitTests/Mocks/Sessions+Services/FirebaseAppIntegrityService+Mocks.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/FirebaseAppIntegrityService+Mocks.swift
@@ -1,0 +1,235 @@
+import AppIntegrity
+import Foundation
+import FirebaseAppCheck
+import MockNetworking
+import Networking
+@testable import OneLogin
+
+extension FirebaseAppIntegrityService {
+    
+    static func makeNonExpired(errorFromAttestationJWT: Error) -> FirebaseAppIntegrityService {
+        
+        let mockAttestationStore = MockAttestationStore(attestationExpired: false, errorFromAttestationJWT: errorFromAttestationJWT)
+
+        return make(attestationStore: mockAttestationStore)
+    }
+    
+    static func make(attestationProofOfPossessionProvider: ProofOfPossessionProvider = MockProofOfPossessionProvider(),
+                     attestationProofOfPossessionTokenGenerator: ProofOfPossessionTokenGenerator = MockProofOfPossessionTokenGenerator(),
+                     demonstratingProofOfPossessionTokenGenerator: ProofOfPossessionTokenGenerator = MockProofOfPossessionTokenGenerator(),
+                     attestationStore: AttestationStorage = MockAttestationStore(),
+                     networkClient: AppIntegrityNetworkClient = MockAppIntegrityNetworkClient.mock(),
+                     baseURL: URL = URL(string: "https://mobile.account.gov.uk")!
+    ) -> FirebaseAppIntegrityService {
+        
+        return FirebaseAppIntegrityService(
+            vendor: MockAppCheckVendor(),
+            attestationProofOfPossessionProvider: attestationProofOfPossessionProvider,
+            attestationProofOfPossessionTokenGenerator: attestationProofOfPossessionTokenGenerator,
+            demonstratingProofOfPossessionTokenGenerator: demonstratingProofOfPossessionTokenGenerator,
+            attestationStore: attestationStore,
+            networkClient: networkClient,
+            baseURL: baseURL)
+    }
+}
+
+final class MockProofOfPossessionProvider: ProofOfPossessionProvider {
+    
+    static func dataFromPublicKey(_ data: Data = Data()) -> PublicKeyAsFunction {
+        return { data }
+    }
+
+    static func errorFromPublicKey(_ error: Error) -> PublicKeyAsFunction {
+        return {
+            throw error
+        }
+    }
+
+    static func dataFromSign(_ data: Data = Data()) -> SignAsFunction {
+        return { data }
+    }
+
+    typealias SignAsFunction = () -> (Data)
+    typealias PublicKeyAsFunction = () throws -> (Data)
+    var publicKeyAsFunction: PublicKeyAsFunction
+    var signAsFunction: SignAsFunction
+
+    convenience init() {
+        self.init(publicKeyAsFunction: Data("""
+                {
+                  "jwk": {
+                    "kty": EC",
+                    "use": "sig",
+                    "crv": "P-256",
+                    "x": "18wHLeIgW9wVN6VD1Txgpqy2LszYkMf6J8njVAibvhM",
+                    "y": "-V4dS4UaLMgP_4fY4j8ir7cl1TXlFdAgcx55o7TkcSA"
+                  }
+                }
+            """.utf8), signAsFunction: Data())
+    }
+    init(publicKeyAsFunction: @escaping @autoclosure PublicKeyAsFunction, signAsFunction: @escaping @autoclosure SignAsFunction) {
+        self.publicKeyAsFunction = publicKeyAsFunction
+        self.signAsFunction = signAsFunction
+    }
+    
+    var publicKey: Data {
+        get throws {
+            try publicKeyAsFunction()
+        }
+    }
+    
+    func sign(data: Data) -> Data {
+        signAsFunction()
+    }
+}
+
+class MockProofOfPossessionTokenGenerator: ProofOfPossessionTokenGenerator {
+    
+    static func token(header: [String: Any] = [:], payload: [String: Any] = [:]) -> TokenJWTAsFunction {
+        return { "\(header.merging(payload) { $1 })" }
+    }
+
+    static func errorFromToken(_ error: Error) -> TokenJWTAsFunction {
+        return {
+            throw error
+        }
+    }
+
+    typealias TokenJWTAsFunction = () throws -> (String)
+    var tokenAsFunction: TokenJWTAsFunction
+    
+    convenience init() {
+        self.init(tokenAsFunction: Self.token())
+    }
+    
+    convenience init(error: Error) {
+        self.init(tokenAsFunction: Self.errorFromToken(error))
+    }
+    
+    init(tokenAsFunction: @escaping TokenJWTAsFunction) {
+        self.tokenAsFunction = tokenAsFunction
+    }
+
+    var token: String {
+        get throws {
+            return try tokenAsFunction()
+        }
+    }
+}
+
+class MockAppIntegrityNetworkClient: AppIntegrityNetworkClient, NetworkClientProtocol {
+    
+    static func mock() -> MockAppIntegrityNetworkClient {
+        
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        
+        return MockAppIntegrityNetworkClient(session: session)
+    }
+
+    let session: URLSession
+    
+    init(session: URLSession) {
+        self.session = session
+    }
+    
+    func makeRequest(_ request: NetworkRequest) async throws -> Data {
+        return try await session.data(for: request.urlRequest).0
+    }
+    
+    func request(_ request: URLRequest) -> RequestBuilder {
+        return RequestBuilder(client: self, request: request)
+    }
+}
+
+class MockAttestationStore: AttestationStorage {
+    
+    static func attestationJWT(_ attestationJWT: String = "") -> AttestationJWTAsFunction {
+        return { attestationJWT }
+    }
+
+    static func errorFromAttestationJWT(_ error: Error) -> AttestationJWTAsFunction {
+        return {
+            throw error
+        }
+    }
+
+    typealias AttestationJWTAsFunction = () throws -> (String)
+    var attestationJWTAsFunction: AttestationJWTAsFunction
+
+    var attestationExpired: Bool = true
+    var attestationJWT: String {
+        get throws {
+            try attestationJWTAsFunction()
+        }
+    }
+    var mockStorage = [String: Any]()
+
+    convenience init(attestationExpired: Bool = false, attestationJWT: String = "", mockStorage: [String : Any] = [String: Any]()) {
+        self.init(attestationExpired: attestationExpired, attestationJWTAsFunction: Self.attestationJWT(attestationJWT), mockStorage: mockStorage)
+    }
+
+    convenience init(attestationExpired: Bool = false, errorFromAttestationJWT error: Error, mockStorage: [String : Any] = [String: Any]()) {
+        self.init(attestationExpired: attestationExpired, attestationJWTAsFunction: Self.errorFromAttestationJWT(error), mockStorage: mockStorage)
+    }
+
+    init(attestationExpired: Bool = false, attestationJWTAsFunction: @escaping AttestationJWTAsFunction, mockStorage: [String : Any] = [String: Any]()) {
+        self.attestationExpired = attestationExpired
+        self.attestationJWTAsFunction = attestationJWTAsFunction
+        self.mockStorage = mockStorage
+    }
+
+    
+    func store(
+        clientAttestation assertionJWT: String,
+        attestationExpiry assertionExpiry: Date
+    ) {
+        mockStorage["attestationJWT"] = assertionJWT
+        mockStorage["attestationExpiry"] = assertionExpiry
+    }
+}
+
+final class MockAppCheckVendor: AppCheckVendor {
+    static func limitedUseToken(_ appCheckToken: AppCheckToken = AppCheckToken(token: "abc", expirationDate: .distantFuture)) -> LimitedUseTokenAsFunction {
+        return { appCheckToken }
+    }
+
+    static func errorFromLimitedUseToken(_ error: Error) -> LimitedUseTokenAsFunction {
+        return {
+            throw error
+        }
+    }
+
+    private(set) static var factory: (any AppCheckProviderFactory)?
+
+    static func setAppCheckProviderFactory(_ factory: (any AppCheckProviderFactory)?) {
+        self.factory = factory
+    }
+    
+    static func appCheck() -> Self {
+        guard let vendor = MockAppCheckVendor() as? Self else {
+            preconditionFailure("Expected MockAppCheckVendor to conform to AppCheckVendor")
+        }
+        return vendor
+    }
+    
+    typealias LimitedUseTokenAsFunction = () async throws -> (AppCheckToken)
+    var limitedUseTokenAsFunction: LimitedUseTokenAsFunction
+
+    convenience init(appCheckToken: AppCheckToken = AppCheckToken(token: "abc", expirationDate: .distantFuture)) {
+        self.init(limitedUseTokenAsFunction: Self.limitedUseToken(appCheckToken))
+    }
+    
+    convenience init(error: Error) {
+        self.init(limitedUseTokenAsFunction: Self.errorFromLimitedUseToken(error))
+    }
+    
+    init(limitedUseTokenAsFunction: @escaping LimitedUseTokenAsFunction) {
+        self.limitedUseTokenAsFunction = limitedUseTokenAsFunction
+    }
+
+    func limitedUseToken() async throws -> AppCheckToken {
+        return try await limitedUseTokenAsFunction()
+    }
+}

--- a/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockSecureStoreService.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockSecureStoreService.swift
@@ -2,7 +2,30 @@
 import SecureStore
 
 final class MockSecureStoreService: SecureStorable, SessionBoundData {
+
+    /// This type can be used to track the number of calls made to a function
+    /// - SeeAlso: ``mockClearSessionDataCounter`` on creating a mock with a counter to count the number of times ``SecureStorable/clearSessionData()`` is called
+    /// - SeeAlso: ``mockDeleteCounter`` on creating a mock with a counter to count the number of times ``SecureStorable/delete()`` is called
+    class Counter {
+        var count = 0
+        
+        func increment() {
+            self.count = +1
+        }
+        
+        /// Returns true if a function has been called at least once
+        func called() -> Bool {
+            return count > 0
+        }
+    }
     
+    /// Returns a new mock that can be used as the `AccessControlEncryptedStore` and has stored tokens under the ``OLString/storedTokens``.
+    ///
+    /// - Parameters:
+    ///     - idToken: the id token; ``MockJWTs/genericToken`` by default
+    ///     - refreshToken: the id token; ``MockJWTs/genericToken`` by default
+    ///     - accessToken: the id token; ``MockJWTs/genericToken`` by default
+    /// - SeeAlso: ``PersistentSessionManager`` which uses an `AccessControlEncryptedStore`
     static func makeWithStoredTokens(idToken: String = MockJWTs.genericToken,
                                      refreshToken: String = MockJWTs.genericToken,
                                      accessToken: String = MockJWTs.genericToken
@@ -21,55 +44,129 @@ final class MockSecureStoreService: SecureStorable, SessionBoundData {
         return mockAccessControlEncryptedStore
     }
     
-    var savedItems = [String: String]()
-    var didCallDeleteStore = false
-    var didCallClearSessionData = false
+    /// Returns a Mock and a counter than can be used to assert the ``SecureStorable/clearSessionData`` has been called
+    static func mockClearSessionDataCounter() -> (mockSecureStoreService: MockSecureStoreService, clearSessionDataCounter: Counter) {
+        let clearSessionDataCounter = Counter()
+        
+        return (MockSecureStoreService(
+            clearSessionDataAsFunction: clearSessionDataCount(counter: clearSessionDataCounter)), clearSessionDataCounter)
+    }
+
+    /// Returns a Mock and a counter than can be used to assert the ``SecureStorable/delete`` has been called
+    static func mockDeleteCounter() -> (mockSecureStoreService: MockSecureStoreService, deleteCounter: Counter) {
+        let deleteCounter = Counter()
+        
+        return (MockSecureStoreService(deleteAsFunction: deleteCount(counter: deleteCounter)), deleteCounter)
+    }
+
+    enum ReadItemResult {
+        case error
+        case success
+    }
     
-    var errorFromSaveItem: Error?
-    var errorFromReadItem: SecureStoreError?
-    var errorFromClearSessionData: Error?
-    var returnFromCheckItemExists = true
-    
-    func checkItemExists(itemName: String) -> Bool {
-        if savedItems[itemName] != nil {
-            return true
+    static func errorFromReadItem(_ error: SecureStore.SecureStoreError) -> ReadItemAsFunction {
+        func readItemAsFunction(itemName: String) throws(SecureStore.SecureStoreError) -> String {
+            throw error
         }
-        return false
+
+        return readItemAsFunction
+    }
+    
+    static func errorFromSaveItem(_ error: SecureStore.SecureStoreError) -> SaveItemAsFunction {
+        func saveItemAsFunction(item: String, itemName: String) throws -> Void {
+            throw error
+        }
+
+        return saveItemAsFunction
+    }
+
+    static func deleteCount(counter: Counter) -> DeleteAsFunction {
+        return {
+            counter.increment()
+        }
+    }
+
+    static func clearSessionDataCount(counter: Counter) -> ClearSessionDataAsFunction {
+        return {
+            counter.increment()
+        }
+    }
+
+    typealias SaveItemAsFunction = (String, String) throws -> Void
+    typealias ReadItemAsFunction = (String) throws(SecureStore.SecureStoreError) -> String
+    typealias DeleteItemAsFunction = (String) -> Void
+    typealias DeleteAsFunction = () throws -> Void
+    typealias ClearSessionDataAsFunction = () -> Void
+    
+    var saveItemAsFunction: SaveItemAsFunction
+    var readItemAsFunction: ReadItemAsFunction
+    var deleteItemAsFunction: DeleteItemAsFunction
+    var deleteAsFunction: DeleteAsFunction
+    var clearSessionDataAsFunction: ClearSessionDataAsFunction
+    
+    var savedItems = [String: String]()
+
+    init(saveItemAsFunction: @escaping SaveItemAsFunction = { _, _ in },
+         readItemAsFunction: @escaping ReadItemAsFunction =  { _ in "" },
+         deleteItemAsFunction: @escaping DeleteItemAsFunction = { _ in },
+         deleteAsFunction: @escaping DeleteAsFunction = { },
+         clearSessionDataAsFunction: @escaping ClearSessionDataAsFunction = { } ) {
+        self.saveItemAsFunction = saveItemAsFunction
+        self.readItemAsFunction = readItemAsFunction
+        self.deleteItemAsFunction = deleteItemAsFunction
+        self.deleteAsFunction = deleteAsFunction
+        self.clearSessionDataAsFunction = clearSessionDataAsFunction
     }
     
     func saveItem(item: String, itemName: String) throws {
-        if let errorFromSaveItem {
-            throw errorFromSaveItem
-        } else {
-            savedItems[itemName] = item
-        }
+        self.savedItems[itemName] = item
+        try self.saveItemAsFunction(item, itemName)
     }
     
-    func readItem(itemName: String) throws(SecureStoreError) -> String {
-        if let errorFromReadItem {
-            throw errorFromReadItem
-        } else {
-            guard let savedItem = savedItems[itemName] else {
-                throw SecureStoreError(.unableToRetrieveFromUserDefaults)
-            }
-            return savedItem
+    func readItem(itemName: String) throws(SecureStore.SecureStoreError) -> String {
+        _ = try self.readItemAsFunction(itemName)
+        
+        guard let savedItem = self.savedItems[itemName] else {
+            throw SecureStoreError(.unableToRetrieveFromUserDefaults)
         }
+        return savedItem
+
     }
     
     func deleteItem(itemName: String) {
-        savedItems[itemName] = nil
+        self.deleteItemAsFunction(itemName)
+        self.savedItems[itemName] = nil
     }
     
     func delete() throws {
-        didCallDeleteStore = true
-        savedItems = [:]
+        self.savedItems = [:]
+        try self.deleteAsFunction()
     }
     
-    func clearSessionData() throws {
-        if let errorFromClearSessionData {
-            throw errorFromClearSessionData
+    func checkItemExists(itemName: String) -> Bool {
+        return self.savedItems[itemName] != nil
+    }
+
+    
+    func clearSessionData() async throws {
+        self.savedItems = [:]
+        self.clearSessionDataAsFunction()
+    }
+    
+    // MARK: Helpers    
+    var _errorFromSaveItem: SecureStoreError?
+    var errorFromSaveItem: SecureStoreError? {
+        get {
+            _errorFromSaveItem
         }
-        didCallClearSessionData = true
-        savedItems = [:]
+        set {
+            switch newValue {
+            case .none:
+                _errorFromSaveItem = nil
+                self.saveItemAsFunction = { _, _ in }
+            case .some(let error):
+                self.saveItemAsFunction = Self.errorFromSaveItem(error)
+            }
+        }
     }
 }

--- a/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockSecureStoreService.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockSecureStoreService.swift
@@ -73,10 +73,12 @@ final class MockSecureStoreService: SecureStorable, SessionBoundData {
     }
     
     static func errorFromSaveItem(_ error: SecureStore.SecureStoreError) -> SaveItemAsFunction {
+        // swiftlint:disable redundant_void_return
         func saveItemAsFunction(item: String, itemName: String) throws -> Void {
             throw error
         }
-
+        // swiftlint:enable redundant_void_return
+        
         return saveItemAsFunction
     }
 
@@ -109,8 +111,8 @@ final class MockSecureStoreService: SecureStorable, SessionBoundData {
     init(saveItemAsFunction: @escaping SaveItemAsFunction = { _, _ in },
          readItemAsFunction: @escaping ReadItemAsFunction =  { _ in "" },
          deleteItemAsFunction: @escaping DeleteItemAsFunction = { _ in },
-         deleteAsFunction: @escaping DeleteAsFunction = { },
-         clearSessionDataAsFunction: @escaping ClearSessionDataAsFunction = { } ) {
+         deleteAsFunction: @escaping DeleteAsFunction = {},
+         clearSessionDataAsFunction: @escaping ClearSessionDataAsFunction = {}) {
         self.saveItemAsFunction = saveItemAsFunction
         self.readItemAsFunction = readItemAsFunction
         self.deleteItemAsFunction = deleteItemAsFunction

--- a/Tests/UnitTests/Mocks/Sessions+Services/Storage/PersistentSessionManager+Mocks.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Storage/PersistentSessionManager+Mocks.swift
@@ -11,6 +11,7 @@ extension PersistentSessionManager {
     /// A call to `startAuthSession(:using:)` assumes this is "a returning user" that cannot authenticate due to
     /// the missing `persistendId` results  in call to `clearAllSessionData` to delete my session & Wallet data.
     static func makeReturningUnauthenticatedUser(mockAnalyticsService: MockAnalyticsService = MockAnalyticsService(),
+                                                 accessControlEncryptedSecureStoreMigrator: MockSecureStoreService = MockSecureStoreService(),
                                                  mockEncryptedStore: MockSecureStoreService = MockSecureStoreService(),
                                                  mockUnprotectedStore: (any DefaultsStoring & SessionBoundData) = MockDefaultsStore(),
                                                  walletSessionData: SessionBoundData = WalletSessionBoundDataStub(),
@@ -25,7 +26,8 @@ extension PersistentSessionManager {
         let walletSDK = MockWalletSDKWrapper()
         walletSDK.isEmpty = true
 
-        return try .make(encryptedStore: mockEncryptedStore,
+        return try .make(accessControlEncryptedSecureStoreMigrator: accessControlEncryptedSecureStoreMigrator,
+                         encryptedStore: mockEncryptedStore,
                          unprotectedStore: mockUnprotectedStore,
                          analyticsService: mockAnalyticsService,
                          walletSDK: walletSDK,
@@ -42,7 +44,7 @@ extension PersistentSessionManager {
     /// *  `walletSDK.isEmpty = true`
     ///
     /// A call to `startAuthSession(:using:)` assumes this is "a returning user" with a `sessionState` that is `.nonePresent` due to a missing `expiryDate`.
-    static func makeNonReturningNonEnrollingUnauthenticatedUserWithoutSavedExpiryDate(
+    static func makeReturningNonEnrollingUnauthenticatedUserWithoutSavedExpiryDate(
         mockAnalyticsService: MockAnalyticsService = MockAnalyticsService(),
         accessControlEncryptedSecureStoreMigrator: MockSecureStoreService = MockSecureStoreService(),
         mockEncryptedStore: MockSecureStoreService = MockSecureStoreService(),

--- a/Tests/UnitTests/Service/NetworkingServiceTests.swift
+++ b/Tests/UnitTests/Service/NetworkingServiceTests.swift
@@ -309,8 +309,8 @@ extension NetworkingSerivceTests {
         mockUnprotectedStore.savedData = [OLString.returningUser: true]
         
         return PersistentSessionManager(
-            accessControlEncryptedStore: mockAccessControlEncryptedStore,
             encryptedStore: mockEncryptedStore,
+            storeKeyService: SecureTokenStore(accessControlEncryptedStore: mockAccessControlEncryptedStore),
             unprotectedStore: mockUnprotectedStore,
             localAuthentication: mockLocalAuthentication,
             analyticsService: MockAnalyticsService(),

--- a/Tests/UnitTests/Utilities/AccessControlEncryptedSecureStoreManagerTests.swift
+++ b/Tests/UnitTests/Utilities/AccessControlEncryptedSecureStoreManagerTests.swift
@@ -131,10 +131,16 @@ struct AccessControlEncryptedSecureStoreManagerTests {
     
     @Test("delete deletes both stores")
     func delete() throws {
+        let (mockV12EncryptedSecureStore, mockV12EncryptedSecureStoreDelete) = MockSecureStoreService.mockDeleteCounter()
+        let (mockV13EncryptedSecureStore, mockV13EncryptedSecureStoreDelete) = MockSecureStoreService.mockDeleteCounter()
+
+        let sut: AccessControlEncryptedSecureStoreMigrator = .make(v12EncryptedSecureStore: mockV12EncryptedSecureStore,
+                                                                   v13EncryptedSecureStore: mockV13EncryptedSecureStore)
+
         try sut.delete()
         
-        #expect(mockV12AccessControlEncryptedSecureStore.didCallDeleteStore)
-        #expect(mockV13AccessControlEncryptedSecureStore.didCallDeleteStore)
+        #expect(mockV12EncryptedSecureStoreDelete.called())
+        #expect(mockV13EncryptedSecureStoreDelete.called())
     }
     
     @Test("clearSessionData deletes items from both stores")
@@ -152,5 +158,23 @@ struct AccessControlEncryptedSecureStoreManagerTests {
         #expect(throws: SecureStoreError(.unableToRetrieveFromUserDefaults)) {
             try sut.readItem()
         }
+    }
+}
+
+extension AccessControlEncryptedSecureStoreMigrator {
+    
+    static func make(v12EncryptedSecureStore mockV12EncryptedSecureStore: SecureStorable = MockSecureStoreService(),
+                     v13EncryptedSecureStore mockV13EncryptedSecureStore: SecureStorable = MockSecureStoreService(),
+                     migrationStore mockMigrationStore: DefaultsStoring = MockDefaultsStore(),
+                     analyticsService mockAnalyticsService: OneLoginAnalyticsService = MockAnalyticsService(),
+    ) -> AccessControlEncryptedSecureStoreMigrator {
+        
+        return AccessControlEncryptedSecureStoreMigrator(
+            v12AccessControlEncryptedSecureStore: mockV12EncryptedSecureStore,
+            v13AccessControlEncryptedSecureStore: mockV13EncryptedSecureStore,
+            migrationStore: mockMigrationStore,
+            analyticsService: mockAnalyticsService
+        )
+
     }
 }

--- a/Tests/UnitTests/Utilities/EncryptedSecureStoreManagerTests.swift
+++ b/Tests/UnitTests/Utilities/EncryptedSecureStoreManagerTests.swift
@@ -130,10 +130,16 @@ struct EncryptedSecureStoreManagerTests {
     
     @Test("delete deletes both stores")
     func delete() throws {
+        let (mockV12EncryptedSecureStore, mockV12EncryptedSecureStoreDelete) = MockSecureStoreService.mockDeleteCounter()
+        let (mockV13EncryptedSecureStore, mockV13EncryptedSecureStoreDelete) = MockSecureStoreService.mockDeleteCounter()
+
+        let sut: EncryptedSecureStoreMigrator = .make(v12EncryptedSecureStore: mockV12EncryptedSecureStore,
+                                                      v13EncryptedSecureStore: mockV13EncryptedSecureStore)
+        
         try sut.delete()
         
-        #expect(mockV12EncryptedSecureStore.didCallDeleteStore)
-        #expect(mockV13EncryptedSecureStore.didCallDeleteStore)
+        #expect(mockV12EncryptedSecureStoreDelete.called())
+        #expect(mockV13EncryptedSecureStoreDelete.called())
     }
     
     @Test("clearSessionData deletes items from both stores")
@@ -151,5 +157,22 @@ struct EncryptedSecureStoreManagerTests {
         #expect(throws: SecureStoreError(.unableToRetrieveFromUserDefaults)) {
             try sut.readItem(itemName: OLString.persistentSessionID)
         }
+    }
+}
+
+extension EncryptedSecureStoreMigrator {
+    
+    static func make(v12EncryptedSecureStore mockV12EncryptedSecureStore: SecureStorable = MockSecureStoreService(),
+                     v13EncryptedSecureStore mockV13EncryptedSecureStore: SecureStorable = MockSecureStoreService(),
+                     migrationStore mockMigrationStore: DefaultsStoring = MockDefaultsStore(),
+                     analyticsService mockAnalyticsService: OneLoginAnalyticsService = MockAnalyticsService(),
+    ) -> EncryptedSecureStoreMigrator {
+        
+        return EncryptedSecureStoreMigrator(
+            v12EncryptedSecureStore: mockV12EncryptedSecureStore,
+            v13EncryptedSecureStore: mockV13EncryptedSecureStore,
+            migrationStore: mockMigrationStore,
+            analyticsService: mockAnalyticsService
+        )
     }
 }

--- a/Tests/UnitTests/Utilities/SecureAttestationStoreTests.swift
+++ b/Tests/UnitTests/Utilities/SecureAttestationStoreTests.swift
@@ -1,6 +1,7 @@
 import AppIntegrity
 import Foundation
 @testable import OneLogin
+import SecureStore
 import Testing
 
 struct SecureAttestationStoreTests: ~Copyable {
@@ -55,5 +56,63 @@ struct SecureAttestationStoreTests: ~Copyable {
             itemName: AttestationStorageKey.attestationExpiry.rawValue
         )
         #expect(sut.attestationExpired)
+    }
+    
+    @Test
+    func test_attestionJWT_throwsCantDecryptDataError() async throws {
+        let errorFromAttestationJWT = SecureStoreError(.cantDecryptData,
+                                                       originalError: NSError(domain: NSOSStatusErrorDomain, code: -50))
+
+        let mockSecureStoreService = MockSecureStoreService()
+        try mockSecureStoreService.saveDate(id: AttestationStorageKey.attestationExpiry.rawValue, Date.distantFuture)
+        mockSecureStoreService.readItemAsFunction = MockSecureStoreService.errorFromReadItem(errorFromAttestationJWT)
+        let sut = SecureAttestationStore(secureStore: mockSecureStoreService)
+
+        let error = await #expect(throws: SecureStoreError.self) {
+            try await sut.attestationJWT
+        }
+        
+        #expect(error?.kind == .cantDecryptData)
+        
+        let originalError = try #require(error?.originalError as? NSError)
+        #expect(originalError.code == errSecParam)
+        #expect(originalError.code == -50)
+    }
+    
+    /// This is a case where as part of instantiating a `SecureAttestationStore`, on the first call to get the `attestationJWT`,
+    /// there is a chance the `secureStore` dependency will throw a
+    /// `SecureStoreError(.cantDecryptData, originalError: NSError(domain: NSOSStatusErrorDomain, code: -50))`
+    ///
+    /// This tests verifies that the `SecureAttestationStore` instanced return by `.make()` does not throw a `SecureStoreError(.cantDecryptData)`
+    @Test
+    func test_attestionJWT_doesNotThrowCantDecryptdataError() async throws {
+        let errorFromAttestationJWT: SecureStoreError = SecureStoreError(.cantDecryptData,
+                                                       originalError: NSError(domain: NSOSStatusErrorDomain, code: -50))
+
+        var readItemResult: MockSecureStoreService.ReadItemResult = .error
+        
+        func readItemAsFunction(itemName: String) throws(SecureStore.SecureStoreError) -> String {
+            switch readItemResult {
+            case .error:
+                throw errorFromAttestationJWT
+            case .success:
+                return "any"
+            }
+        }
+        
+        let mockSecureStoreService = MockSecureStoreService(readItemAsFunction: readItemAsFunction, deleteItemAsFunction: { _ in
+            readItemResult = .success
+        })
+        
+        try mockSecureStoreService.saveDate(id: AttestationStorageKey.attestationExpiry.rawValue, Date.distantFuture)
+                
+        let sut = SecureAttestationStore.make(secureStore: mockSecureStoreService)
+        #expect(sut.attestationExpired)
+
+        let error = await #expect(throws: SecureStoreError.self) {
+            try await sut.attestationJWT
+        }
+        
+        #expect(error?.kind != .cantDecryptData)
     }
 }

--- a/Tests/UnitTests/Utilities/Session/PersistentSessionManagerXCTests.swift
+++ b/Tests/UnitTests/Utilities/Session/PersistentSessionManagerXCTests.swift
@@ -19,6 +19,14 @@ struct SessionBoundDataExpectation: SessionBoundData {
 }
 
 extension PersistentSessionManager {
+    
+    /// Creates a `PersistentSessionManager` with the following conditions:
+    /// * `isEnrolling = false`
+    /// * `persistentID = nil` i.e. not stored in the `encryptedStore`
+    /// * `isReturningUser = false`
+    /// *  `walletSDK.isEmpty = true`
+    ///
+    /// A call to `startAuthSession(:using:)` assumes this is "a new user" with a `sessionState` that is `.nonePresent` due to a missing `expiryDate`.
     static func make(mockAccessControlEncryptedStore: MockSecureStoreService = MockSecureStoreService(),
                      mockLocalAuthentication: MockLocalAuthManager = MockLocalAuthManager(),
                      mockEncryptedStore: MockSecureStoreService = MockSecureStoreService(),
@@ -28,8 +36,8 @@ extension PersistentSessionManager {
                      refreshTokenExchangeManager: TokenExchangeManaging = MockRefreshTokenExchangeManager()) -> PersistentSessionManager {
                 
         return PersistentSessionManager(
-            accessControlEncryptedStore: mockAccessControlEncryptedStore,
             encryptedStore: mockEncryptedStore,
+            storeKeyService: SecureTokenStore(accessControlEncryptedStore: mockAccessControlEncryptedStore),
             unprotectedStore: mockUnprotectedStore,
             localAuthentication: mockLocalAuthentication,
             analyticsService: mockAnalyticsService,
@@ -65,8 +73,8 @@ final class PersistentSessionManagerXCTests: XCTestCase {
         mockWalletSDK = MockWalletSDKWrapper()
         
         sut = PersistentSessionManager(
-            accessControlEncryptedStore: mockAccessControlEncryptedStore,
             encryptedStore: mockEncryptedStore,
+            storeKeyService: SecureTokenStore(accessControlEncryptedStore: mockAccessControlEncryptedStore),
             unprotectedStore: mockUnprotectedStore,
             localAuthentication: mockLocalAuthentication,
             analyticsService: mockAnalyticsService,
@@ -565,12 +573,20 @@ extension PersistentSessionManagerXCTests {
     
     @MainActor
     func test_saveSession_doesNotRefreshSecureStoreManager() async throws {
-        // GIVEN I am a new user
-        mockUnprotectedStore.savedData = [OLString.returningUser: false]
+        
+        let (mockAccessControlEncryptedStore, mockAccessControlEncryptedStoreClearSessionData) = MockSecureStoreService.mockClearSessionDataCounter()
         try mockAccessControlEncryptedStore.saveItem(
             item: "storedTokens",
             itemName: OLString.storedTokens
         )
+        
+        let (mockEncryptedStore, mockEncryptedStoreClearSessionData) = MockSecureStoreService.mockClearSessionDataCounter()
+        let mockUnprotectedStore = MockDefaultsStore()
+        // GIVEN I am a new user
+        let sut: PersistentSessionManager = .make(mockAccessControlEncryptedStore: mockAccessControlEncryptedStore,
+                                                  mockEncryptedStore: mockEncryptedStore,
+                                                  mockUnprotectedStore: mockUnprotectedStore)
+        
         // AND I have logged in
         try await sut.startAuthSession(
             MockLoginSession(window: UIWindow()),
@@ -579,8 +595,8 @@ extension PersistentSessionManagerXCTests {
         // WHEN I attempt to save my session
         try sut.saveAuthSession()
         // THEN the secure store manager is not refreshed
-        XCTAssertFalse(mockAccessControlEncryptedStore.didCallClearSessionData)
-        XCTAssertFalse(mockEncryptedStore.didCallClearSessionData)
+        XCTAssertFalse(mockAccessControlEncryptedStoreClearSessionData.called())
+        XCTAssertFalse(mockEncryptedStoreClearSessionData.called())
         // THEN the session data is updated in the store
         XCTAssertEqual(mockEncryptedStore.savedItems, [
                 OLString.refreshTokenExpiry: "1719397758.0",
@@ -994,7 +1010,7 @@ struct PersistentSessionManagerTests {
         let mockAccessControlEncryptedStore: MockSecureStoreService = try .makeWithStoredTokens()
         let mockRefreshTokenExchangeManager = MockRefreshTokenExchangeManagerGuarantor()
         
-        let sut: PersistentSessionManager = try .makeNonReturningNonEnrollingUnauthenticatedUserWithoutSavedExpiryDate(
+        let sut: PersistentSessionManager = try .makeReturningNonEnrollingUnauthenticatedUserWithoutSavedExpiryDate(
                                                     accessControlEncryptedSecureStoreMigrator: mockAccessControlEncryptedStore,
                                                     refreshTokenExchangeManager: mockRefreshTokenExchangeManager)
         


### PR DESCRIPTION
# [iOS | Tech Debt | SecureStoreError(.cantDecryptData) | NSOStatusErrorDomain (-50) | KeyManagerService](https://govukverify.atlassian.net/browse/DCMAW-21030)

> [!IMPORTANT]
> There are no steps to reproduce this defect. This change has not been tested on a device.

This PR fixes a case where a user is stuck in a loop between two screens:

“You need to sign in again”
“Sorry, there's a problem”

when the app attempts to add an attestation header as part of a token exchange. Without this change, the user has no choice but to delete the app.

<img width="293" height="600" alt="test_signInWarningScreen 1" src="https://github.com/user-attachments/assets/6c4d780e-355e-407b-be48-60bf2cd1ec80" /> <img width="293" height="633" alt="test_genericError 1" src="https://github.com/user-attachments/assets/8c1db52d-6655-4f8a-add5-71cf9c71dfc2" />

# Preface

Here is the stack trace as identified after a code review:

- [LoginCoordinator.start()](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.26.0/Sources/Login/LoginCoordinator.swift#L67)
- [LoginCoordinator.authenticate](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.26.0/Sources/Login/LoginCoordinator.swift#L91)
- [LoginCoordinator.launchAuthenticationService](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.26.0/Sources/Login/LoginCoordinator.swift#L98C27-L98C42)
- [LoginCoordinator.triggerAuthFlow](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.26.0/Sources/Login/LoginCoordinator.swift#L116)
- - [WebAuthenticationService.startWebSession()](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.26.0/Sources/Login/WebAuthenticationService.swift#L26) // [FirebaseAppIntegrityService](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.26.0/Sources/Extensions/CustomTypes/AppIntegrityProvider%2BOneLogin.swift#L24) used to provide attestation header is created here. The attestation is stored in the [SecureAttestationStore](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.26.0/Sources/Utilities/Storage/SecureAttestationStore.swift)
- - - [PersistentSessionManager.startAuthSession()](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.26.0/Sources/Utilities/Storage/Session/PersistentSessionManager.swift#L243) // In this case, `persistentID` is nil because it can't be decrypted, wallet data is cleared without throwing an error)
- - - -[AppAuthSession.performLoginFlow()](https://github.com/govuk-one-login/mobile-ios-authentication/blob/main/Sources/Authentication/AppAuthSession.swift#L59) // user logs in succesfully
- - - - [AppAuthSession.performLoginFlow()](https://github.com/govuk-one-login/mobile-ios-authentication/blob/main/Sources/Authentication/AppAuthSession.swift#L65C27-L65C56) // Token exchange is attempted
- - - - [AppAuthSession.finaliseLoginWithAuthResponse()](https://github.com/govuk-one-login/mobile-ios-authentication/blob/main/Sources/Authentication/AppAuthSession.swift#L115)
- - - - [AppAuthSession.handleAuthResponseCreateTokenRequest()](https://github.com/govuk-one-login/mobile-ios-authentication/blob/main/Sources/Authentication/AppAuthSession.swift#L152) // attempt to evaluate token headers
- - - - - [LoginSessionConfiguration+OneLogin.oneLoginSessionConfiguration()](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.26.0/Sources/Extensions/CustomTypes/LoginSessionConfiguration%2BOneLogin.swift#L25) // Attempt to get token headers from integrityAssertions
- - - - - [FirebaseAppIntegrityService.integrityAssertions](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.26.0/AppIntegrity/Sources/AppIntegrity/FirebaseAppIntegrityService.swift#L241) // Attempts to read attestation in case it has either expired or has never been fetched before.
- - - - - - [SecureAttestationStore](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.26.0/Sources/Utilities/Storage/SecureAttestationStore.swift#L27)
- - - - - - - [SecureStoreService.readItem](https://github.com/govuk-one-login/mobile-ios-secure-store/blob/4.0.0/Sources/SecureStore/SecureStoreService.swift#L35) // Attempts to decrypt attestation
- - - - - - - - [KeyManagerService.decryptDataWithPrivateKey()](https://github.com/govuk-one-login/mobile-ios-secure-store/blob/main/Sources/SecureStore/KeyManagerService.swift#L197) // The new key pair that was created for the instance of the KeyManagerService is not the same as the one used to encrypt the data before the backup.
- - - - - - - - [KeyManagerService.biometricErrorHandling()](https://github.com/govuk-one-login/mobile-ios-secure-store/blob/main/Sources/SecureStore/SecureStoreError/SecureStoreError.swift#L58) // throws ``SecureStoreError(
                    .cantDecryptData)`` with original error -50.
...
- [LoginCoordinator.catch](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.26.0/Sources/Login/LoginCoordinator.swift#L108)
- [LoginCoordinator.showGenericErrorScreen](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.26.0/Sources/Login/LoginCoordinator.swift#L300)


# Changes

> [!TIP]
> This PR includes 2 commits. 
> 1. [The first one](https://github.com/govuk-one-login/mobile-ios-one-login-app/pull/875/changes/5b7f6047b28e50cf9afafa83f6ae28f6b59fb13f), does not modify the source code in any way that it alters its behaviour. It merely adds a new function, [SecureAttestationStore.make()](https://github.com/govuk-one-login/mobile-ios-one-login-app/pull/875/changes/5b7f6047b28e50cf9afafa83f6ae28f6b59fb13f#diff-6c2d8f430ec91670e705f386ba5a828c2bd1aee1d165190addc6ca6a40b50ce9R29), that the second commit uses to fix the defect. Other than that, the commit includes Tests, Mocks and makes minor changes (e.g. elevate access to the [AppCheckVendor](https://github.com/govuk-one-login/mobile-ios-one-login-app/pull/875/changes/5b7f6047b28e50cf9afafa83f6ae28f6b59fb13f#diff-5706497a63689b6917dcb7e7f4056829d83d5069ea8974e176efa58828f994e4R159) allow testing of the [FirebaseAppIntegrityService.swift](https://github.com/govuk-one-login/mobile-ios-one-login-app/pull/875/changes/5b7f6047b28e50cf9afafa83f6ae28f6b59fb13f#diff-5706497a63689b6917dcb7e7f4056829d83d5069ea8974e176efa58828f994e4R159).
> 2. [The second commit](https://github.com/govuk-one-login/mobile-ios-one-login-app/pull/875/changes/528896028e02e243a3b8e16d21c7ef7ba9d84b0d), uses the `SecureAttestationStore.make()` to fix the defect.

This PR effectively [makes a single](https://github.com/govuk-one-login/mobile-ios-one-login-app/commit/528896028e02e243a3b8e16d21c7ef7ba9d84b0d) but crucial code change in the source code that fixes a case of a user stuck in a login loop. More specifically, in case the underlying **attestation data** cannot be decrypted deletes it.

# Discussion

> [!IMPORTANT]
> I don't believe any users are currently affected by this defect. That is because, when the `persistentId` is evaluated to `nil` (due to the -50 underlying error) the `PersistentSessionManager` attempts to clear the Wallet session data, which in turns throws an error. This is a [known defect ](https://github.com/govuk-one-login/mobile-ios-one-login-app/pull/833). I expect once WalletSDK has fixed the issue, we will encounter this defect and the occurrences will increase up to the number of users that have restored their device from a backup.

This PR makes the following proposals:
1. Detect a case of cantDecryptData as early as possible (i.e. when the `SecureAttestationStore` is created) so as to avoid any unexpected behaviour in the app (as in this case)
2. In the case the data cannot be decrypted, delete it (attestation and expiry date) associated with the `SecureAttestationStore` so as the app works as expected.

# Where to focus the review
There are a couple of things that are hard to test within the codebase and would benefit from the code review.
* The `FirebaseAppIntegrityService` instance created by the `AppIntegrityProvider.firebaseAppCheck()` cannot be tested due to the fact that the `AppCheckVendor` instance is evaluated to `AppCheck.appCheck()`. That would require importing `Firebase` et. al. directly to OneLogin. **I am not sure we want that direct dependency**. As a result, the `FirebaseAppIntegrityService` instance that is provided by the `FirebaseAppIntegrityService+Mocks.swift` is **not the same** as the one used by the codebase. Having said that, the **only change**  in the `FirebaseAppIntegrityService` that needs to be made is to ensure that it it uses the `attestationStore` as returned by `SecureAttestationStore.make()`. We should aim to make the `AppIntegrityProvider.firebaseAppCheck()` testable so as to prevent any future regressions.
* Test coverage has been added to the instance returned by `SecureAttestationStore.make()`. However, given how the instance returned changes the post-conditions (i.e. both the attestationJWT and expiry date are removed) and the high coupling of the `SecureAttestationStore` (e.g. used to create token headers), it's worth reviewing the code to ensure the invariants of the `SecureAttestationStore` are preserved. e.g. notice how the `SecureStoreService` throws a `SecureStoreError(.unableToRetrieveFromUserDefaults)` in case either the `attestationJWT` or the `attestationExpired` is missing.

Looking at the `FirebaseAppIntegrityService/clientAssertions`. The `FirebaseAppIntegrityService` guards on `hasExpiredAttestation`. The `hasExpiredAttestation` property is read from `SecureAttestationStore/attestationExpired`. In case the expiry date is missing, `FirebaseAppIntegrityService` will treat the attestation as expired. 

As far as I can see:
* In case the `attestationExpired` is **missing**, the error is swallowed and the `attestationJWT` is considered to have expired.
* In this case, the attestation has expired  and the `attestationJWT` will fetched again.

# Testing

> [!IMPORTANT]
> As of this moment, there are no steps to reproduce this within the app. Instead, this PR is the product of a code review that lead to two test cases written that hint at how it is possible for a user to get stuck in this loop.

The following tests have been added:

* test_errorFromAttestationJWT_onNewUser
* test_errorFromAttestationJWT_onReturningUser

As well as:

* test_attestionJWT_throwsCantDecryptDataError
* test_attestionJWT_doesNotThrowCantDecryptdataError
 
The `test_attestionJWT_doesNotThrowCantDecryptdataError` test was written against the instance of the `SecureAttestationStore` as returned by its initialiser, which caused it to fail. Changing the instance to the one returned by the `SecureAttestationStore.make()`, introduced in this PR, made the test pass.

<img width="875" height="598" alt="DCMAW-21030_failure" src="https://github.com/user-attachments/assets/01b4137f-d134-435e-a169-7a53d2ce6245" />

<img width="875" height="598" alt="DCMAW-21030_success" src="https://github.com/user-attachments/assets/8784909e-338c-4fc6-9ea3-cdafa955302c" />


# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
