### PR TITLE
hotfix:  DCMAW-21585 & DCMAW-21661 move dPoP assertion as part of the autoclosure

### DIFF
--- a/Sources/Extensions/CustomTypes/LoginSessionConfiguration+OneLogin.swift
+++ b/Sources/Extensions/CustomTypes/LoginSessionConfiguration+OneLogin.swift
@@ -13,7 +13,6 @@ extension LoginSessionConfiguration {
         // Integrity assertions should be sent if the feature flag is enabled
         // OR the user has a valid client attestation which can be used in the flow even in a potential Firebase outage
         let shouldAttestIntegrity = env.appIntegrityEnabled || !integrityService.hasExpiredAttestation
-        let dPoPAssertion = try integrityService.dPoPAssertion
         return await .init(
             authorizationEndpoint: env.stsAuthorize,
             tokenEndpoint: env.stsToken,
@@ -24,7 +23,7 @@ extension LoginSessionConfiguration {
             locale: env.isLocaleWelsh ? .cy : .en,
             persistentSessionId: persistentSessionID,
             tokenHeaders: shouldAttestIntegrity ? try await OneLoginAppIntegrityService(integrityService: integrityService)
-                .clientAssertions().merging(dPoPAssertion) { current, _ in current } : nil
+                .clientAssertions().merging(try integrityService.dPoPAssertion) { current, _ in current } : nil
         )
     }
 }


### PR DESCRIPTION
# DCMAW-21585 & DCMAW-21661 move DPoP as part of the auto closure

The error we were getting was: `Code=-61440 "invalid_dpop_proof: Invalid iat in DPoP JWT"` which meant that the DPoP issued timestamp was not accepted by the server. 

That was because we were setting the IAT to now when we were calculating it on the variable (when the login session configuration was created), and then 8 minutes later when the user provided the OTP the old DPoP was used. 

The token is now computed in the auto closure, and the request will be sent soon after.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
