### PR TITLE
feat: DCMAW-21061 update tests based on the changes to GDSUtilities.

### DIFF
--- a/AppIntegrity/Package.swift
+++ b/AppIntegrity/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/govuk-one-login/mobile-ios-utilities",
-            branch: "feat/DCMAW-21061-standardise-gdserror"
+            from: "2.0.0"
         )
     ],
     targets: [

--- a/AppIntegrity/Package.swift
+++ b/AppIntegrity/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/govuk-one-login/mobile-ios-utilities",
-            from: "1.0.0"
+            branch: "feat/DCMAW-21061-standardise-gdserror"
         )
     ],
     targets: [

--- a/AppIntegrity/Tests/AppIntegrity/AppIntegrityErrorTests.swift
+++ b/AppIntegrity/Tests/AppIntegrity/AppIntegrityErrorTests.swift
@@ -4,26 +4,26 @@ import Testing
 struct AppIntegrityErrorTests {
     // swiftlint:disable line_length
     static let allFirebaseAppCheckErrors = [
-        (error: FirebaseAppCheckError(.unknown, reason: "unknown firebase app check service error"), debugDescription: "unknown firebase app check service error"),
-        (error: FirebaseAppCheckError(.network, reason: "network error in firebase app check service"), debugDescription: "network error in firebase app check service"),
-        (error: FirebaseAppCheckError(.invalidConfiguration, reason: "invalid configuration for firebase app check service"), debugDescription: "invalid configuration for firebase app check service"),
-        (error: FirebaseAppCheckError(.keychainAccess, reason: "keychain access error in firebase app check service"), debugDescription: "keychain access error in firebase app check service"),
-        (error: FirebaseAppCheckError(.notSupported, reason: "firebase app check service not supported on this platform"), debugDescription: "firebase app check service not supported on this platform"),
-        (error: FirebaseAppCheckError(.generic, reason: "generic firebase app check service error"), debugDescription: "generic firebase app check service error")
+        (error: FirebaseAppCheckError(.unknown), debugDescription: "Error Domain=FirebaseAppCheckErrorType Code=1000 \"unknown firebase app check service error\""),
+        (error: FirebaseAppCheckError(.network), debugDescription: "Error Domain=FirebaseAppCheckErrorType Code=1001 \"network error in firebase app check service\""),
+        (error: FirebaseAppCheckError(.invalidConfiguration), debugDescription: "Error Domain=FirebaseAppCheckErrorType Code=1002 \"invalid configuration for firebase app check service\""),
+        (error: FirebaseAppCheckError(.keychainAccess), debugDescription: "Error Domain=FirebaseAppCheckErrorType Code=1003 \"keychain access error in firebase app check service\""),
+        (error: FirebaseAppCheckError(.notSupported), debugDescription: "Error Domain=FirebaseAppCheckErrorType Code=1004 \"firebase app check service not supported on this platform\""),
+        (error: FirebaseAppCheckError(.generic), debugDescription: "Error Domain=FirebaseAppCheckErrorType Code=1005 \"generic firebase app check service error\"")
 
     ]
     
     static let allClientAssertionErrors = [
-        (error: ClientAssertionError(.invalidPublicKey, reason: "invalid client attestation public key"), debugDescription: "invalid client attestation public key"),
-        (error: ClientAssertionError(.invalidToken, reason: "invalid firebase app check token"), debugDescription: "invalid firebase app check token"),
-        (error: ClientAssertionError(.serverError, reason: "server error"), debugDescription: "server error"),
-        (error: ClientAssertionError(.cantDecodeClientAssertion, reason: "cant decode client attestation"), debugDescription: "cant decode client attestation")
+        (error: ClientAssertionError(.invalidPublicKey), debugDescription: "Error Domain=ClientAssertionErrorType Code=1001 \"invalid client attestation public key\""),
+        (error: ClientAssertionError(.invalidToken), debugDescription: "Error Domain=ClientAssertionErrorType Code=1002 \"invalid firebase app check token\""),
+        (error: ClientAssertionError(.serverError), debugDescription: "Error Domain=ClientAssertionErrorType Code=2001 \"server error\""),
+        (error: ClientAssertionError(.cantDecodeClientAssertion), debugDescription: "Error Domain=ClientAssertionErrorType Code=3001 \"cant decode client attestation\"")
     ]
     
     static let allProofOfPossessionErrors = [
-        (error: ProofOfPossessionError(.cantGenerateAttestationPublicKeyJWK, reason: "cant generate attestation public key JWK"), debugDescription: "cant generate attestation public key JWK"),
-        (error: ProofOfPossessionError(.cantGenerateAttestationProofOfPossessionJWT, reason: "cant generate attestation proof of possession JWT"), debugDescription: "cant generate attestation proof of possession JWT"),
-        (error: ProofOfPossessionError(.cantGenerateDemonstratingProofOfPossessionJWT, reason: "can't generate demonstrating public key dictionary JWT"), debugDescription: "can't generate demonstrating public key dictionary JWT")
+        (error: ProofOfPossessionError(.cantGenerateAttestationPublicKeyJWK), debugDescription: "Error Domain=ProofOfPossessionErrorType Code=1002 \"cant generate attestation public key JWK\""),
+        (error: ProofOfPossessionError(.cantGenerateAttestationProofOfPossessionJWT), debugDescription: "Error Domain=ProofOfPossessionErrorType Code=1003 \"cant generate attestation proof of possession JWT\""),
+        (error: ProofOfPossessionError(.cantGenerateDemonstratingProofOfPossessionJWT), debugDescription: "Error Domain=ProofOfPossessionErrorType Code=1001 \"can't generate demonstrating public key dictionary JWT\"")
     ]
     // swiftlint:enable line_length
 

--- a/AppIntegrity/Tests/AppIntegrity/AppIntegrityErrorTests.swift
+++ b/AppIntegrity/Tests/AppIntegrity/AppIntegrityErrorTests.swift
@@ -1,44 +1,78 @@
 @testable import AppIntegrity
+import GDSUtilities
 import Testing
 
 struct AppIntegrityErrorTests {
+    
+    struct Case<Kind: GDSErrorKind>: Sendable {
+        let error: AppIntegrityError<Kind>
+        let debugDescription: String
+        let kind: String
+    }
+
     // swiftlint:disable line_length
     static let allFirebaseAppCheckErrors = [
-        (error: FirebaseAppCheckError(.unknown), debugDescription: "Error Domain=FirebaseAppCheckErrorType Code=1000 \"unknown firebase app check service error\""),
-        (error: FirebaseAppCheckError(.network), debugDescription: "Error Domain=FirebaseAppCheckErrorType Code=1001 \"network error in firebase app check service\""),
-        (error: FirebaseAppCheckError(.invalidConfiguration), debugDescription: "Error Domain=FirebaseAppCheckErrorType Code=1002 \"invalid configuration for firebase app check service\""),
-        (error: FirebaseAppCheckError(.keychainAccess), debugDescription: "Error Domain=FirebaseAppCheckErrorType Code=1003 \"keychain access error in firebase app check service\""),
-        (error: FirebaseAppCheckError(.notSupported), debugDescription: "Error Domain=FirebaseAppCheckErrorType Code=1004 \"firebase app check service not supported on this platform\""),
-        (error: FirebaseAppCheckError(.generic), debugDescription: "Error Domain=FirebaseAppCheckErrorType Code=1005 \"generic firebase app check service error\"")
-
+        Case(error: FirebaseAppCheckError(.unknown), debugDescription: "Error Domain=FirebaseAppCheckErrorType Code=1000 \"unknown firebase app check service error\"", kind: "unknown"),
+        Case(error: FirebaseAppCheckError(.network), debugDescription: "Error Domain=FirebaseAppCheckErrorType Code=1001 \"network error in firebase app check service\"", kind: "network"),
+        Case(error: FirebaseAppCheckError(.invalidConfiguration), debugDescription: "Error Domain=FirebaseAppCheckErrorType Code=1002 \"invalid configuration for firebase app check service\"", kind: "invalidConfiguration"),
+        Case(error: FirebaseAppCheckError(.keychainAccess), debugDescription: "Error Domain=FirebaseAppCheckErrorType Code=1003 \"keychain access error in firebase app check service\"", kind: "keychainAccess"),
+        Case(error: FirebaseAppCheckError(.notSupported), debugDescription: "Error Domain=FirebaseAppCheckErrorType Code=1004 \"firebase app check service not supported on this platform\"", kind: "notSupported"),
+        Case(error: FirebaseAppCheckError(.generic), debugDescription: "Error Domain=FirebaseAppCheckErrorType Code=1005 \"generic firebase app check service error\"", kind: "generic")
     ]
     
     static let allClientAssertionErrors = [
-        (error: ClientAssertionError(.invalidPublicKey), debugDescription: "Error Domain=ClientAssertionErrorType Code=1001 \"invalid client attestation public key\""),
-        (error: ClientAssertionError(.invalidToken), debugDescription: "Error Domain=ClientAssertionErrorType Code=1002 \"invalid firebase app check token\""),
-        (error: ClientAssertionError(.serverError), debugDescription: "Error Domain=ClientAssertionErrorType Code=2001 \"server error\""),
-        (error: ClientAssertionError(.cantDecodeClientAssertion), debugDescription: "Error Domain=ClientAssertionErrorType Code=3001 \"cant decode client attestation\"")
+        Case(error: ClientAssertionError(.invalidPublicKey), debugDescription: "Error Domain=ClientAssertionErrorType Code=1001 \"invalid client attestation public key\"", kind: "invalidPublicKey"),
+        Case(error: ClientAssertionError(.invalidToken), debugDescription: "Error Domain=ClientAssertionErrorType Code=1002 \"invalid firebase app check token\"", kind: "invalidToken"),
+        Case(error: ClientAssertionError(.serverError), debugDescription: "Error Domain=ClientAssertionErrorType Code=2001 \"server error\"", kind: "serverError"),
+        Case(error: ClientAssertionError(.cantDecodeClientAssertion), debugDescription: "Error Domain=ClientAssertionErrorType Code=3001 \"cant decode client attestation\"", kind: "cantDecodeClientAssertion")
     ]
     
     static let allProofOfPossessionErrors = [
-        (error: ProofOfPossessionError(.cantGenerateAttestationPublicKeyJWK), debugDescription: "Error Domain=ProofOfPossessionErrorType Code=1002 \"cant generate attestation public key JWK\""),
-        (error: ProofOfPossessionError(.cantGenerateAttestationProofOfPossessionJWT), debugDescription: "Error Domain=ProofOfPossessionErrorType Code=1003 \"cant generate attestation proof of possession JWT\""),
-        (error: ProofOfPossessionError(.cantGenerateDemonstratingProofOfPossessionJWT), debugDescription: "Error Domain=ProofOfPossessionErrorType Code=1001 \"can't generate demonstrating public key dictionary JWT\"")
+        Case(error: ProofOfPossessionError(.cantGenerateAttestationPublicKeyJWK), debugDescription: "Error Domain=ProofOfPossessionErrorType Code=1002 \"cant generate attestation public key JWK\"", kind: "cantGenerateAttestationPublicKeyJWK"),
+        Case(error: ProofOfPossessionError(.cantGenerateAttestationProofOfPossessionJWT), debugDescription: "Error Domain=ProofOfPossessionErrorType Code=1003 \"cant generate attestation proof of possession JWT\"", kind: "cantGenerateAttestationProofOfPossessionJWT"),
+        Case(error: ProofOfPossessionError(.cantGenerateDemonstratingProofOfPossessionJWT), debugDescription: "Error Domain=ProofOfPossessionErrorType Code=1001 \"can't generate demonstrating public key dictionary JWT\"", kind: "cantGenerateDemonstratingProofOfPossessionJWT")
     ]
     // swiftlint:enable line_length
 
-    @Test("assert debugDescription matches reason", arguments: AppIntegrityErrorTests.allFirebaseAppCheckErrors)
-    func test_debugDescription(sut: FirebaseAppCheckError, debugDescription: String) async throws {
-        #expect(sut.debugDescription == debugDescription)
+    @Test("assert debugDescription", arguments: AppIntegrityErrorTests.allFirebaseAppCheckErrors)
+    func test_debugDescription_FirebaseAppCheckError(testCase: Case<FirebaseAppCheckErrorType>) async throws {
+        #expect(testCase.error.debugDescription == testCase.debugDescription)
     }
     
-    @Test("assert debugDescription matches reason", arguments: AppIntegrityErrorTests.allClientAssertionErrors)
-    func test_debugDescription(sut: ClientAssertionError, debugDescription: String) async throws {
-        #expect(sut.debugDescription == debugDescription)
+    @Test("assert debugDescription", arguments: AppIntegrityErrorTests.allClientAssertionErrors)
+    func test_debugDescription_ClientAssertionError(testCase: Case<ClientAssertionErrorType>) async throws {
+        #expect(testCase.error.debugDescription == testCase.debugDescription)
     }
 
-    @Test("assert debugDescription matches reason", arguments: AppIntegrityErrorTests.allProofOfPossessionErrors)
-    func test_debugDescription(sut: ProofOfPossessionError, debugDescription: String) async throws {
-        #expect(sut.debugDescription == debugDescription)
+    @Test("assert debugDescription", arguments: AppIntegrityErrorTests.allProofOfPossessionErrors)
+    func test_debugDescription_ProofOfPossessionError(testCase: Case<ProofOfPossessionErrorType>) async throws {
+        #expect(testCase.error.debugDescription == testCase.debugDescription)
+    }
+
+    /// // swiftlint:disable line_length
+    /// The `kind` found in the `userInfo` **must** hold a unique String identifier that describes the error as reported on analytics
+    /// - Seealso: https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3787195450/GOV.UK+One+Login+app+-+Error+handling#App-integrity-check-failures
+    /// // swiftlint:enable line_length
+    @Test("assert kind", arguments: AppIntegrityErrorTests.allFirebaseAppCheckErrors)
+    func test_kind_FirebaseAppCheckError(testCase: Case<FirebaseAppCheckErrorType>) async throws {
+        #expect(testCase.error.errorUserInfo["kind"] as? String == testCase.kind)
+    }
+    
+    /// // swiftlint:disable line_length
+    /// The `kind` found in the `userInfo` **must** hold a unique String identifier that describes the error as reported on analytics
+    /// - Seealso: https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3787195450/GOV.UK+One+Login+app+-+Error+handling#App-integrity-check-failures
+    /// // swiftlint:enable line_length
+    @Test("assert kind", arguments: AppIntegrityErrorTests.allClientAssertionErrors)
+    func test_kind_ClientAssertionError(testCase: Case<ClientAssertionErrorType>) async throws {
+        #expect(testCase.error.errorUserInfo["kind"] as? String == testCase.kind)
+    }
+
+    /// // swiftlint:disable line_length
+    /// The `kind` found in the `userInfo` **must** hold a unique String identifier that describes the error as reported on analytics
+    /// - Seealso: https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3787195450/GOV.UK+One+Login+app+-+Error+handling#App-integrity-check-failures
+    /// // swiftlint:enable line_length
+    @Test("assert kind", arguments: AppIntegrityErrorTests.allProofOfPossessionErrors)
+    func test_kind_ProofOfPossessionError(testCase: Case<ProofOfPossessionErrorType>) async throws {
+        #expect(testCase.error.errorUserInfo["kind"] as? String == testCase.kind)
     }
 }

--- a/AppIntegrity/Tests/AppIntegrity/FirebaseAppIntegrityServiceTests.swift
+++ b/AppIntegrity/Tests/AppIntegrity/FirebaseAppIntegrityServiceTests.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 @testable import AppIntegrity
 import FirebaseAppCheck
 import FirebaseCore

--- a/AppIntegrity/Tests/AppIntegrity/FirebaseAppIntegrityServiceTests.swift
+++ b/AppIntegrity/Tests/AppIntegrity/FirebaseAppIntegrityServiceTests.swift
@@ -147,78 +147,84 @@ struct FirebaseAppIntegrityServiceTests: ~Copyable {
     func testAppCheckUnknownError() async throws {
         mockVendor.errorFromLimitedUseToken = NSError(domain: AppCheckErrorDomain, code: 0)
         
-        do {
+        let error = await #expect(throws: FirebaseAppCheckError.self) {
             _ = try await sut.clientAssertions
-        } catch let error as FirebaseAppCheckError {
-            #expect(error.kind == .unknown)
-            #expect(error.errorUserInfo["originalError"] as? String ==
-                    "The operation couldn’t be completed. (com.firebase.appCheck error 0.)")
         }
+
+        #expect(error?.kind == .unknown)
+        let underlyingError = try #require(error?.errorUserInfo[NSUnderlyingErrorKey] as? NSError)
+        #expect(underlyingError.localizedDescription ==
+                "The operation couldn’t be completed. (com.firebase.appCheck error 0.)")
     }
     
     @Test("AppCheck vendor throws network error from limitedUseToken")
     func testAppCheckNetworkError() async throws {
         mockVendor.errorFromLimitedUseToken = NSError(domain: AppCheckErrorDomain, code: 1)
         
-        do {
+        let error = await #expect(throws: FirebaseAppCheckError.self) {
             _ = try await sut.clientAssertions
-        } catch let error as FirebaseAppCheckError {
-            #expect(error.kind == .network)
-            #expect(error.errorUserInfo["originalError"] as? String ==
-                    "The operation couldn’t be completed. (com.firebase.appCheck error 1.)")
         }
+
+        #expect(error?.kind == .network)
+        let underlyingError = try #require(error?.errorUserInfo[NSUnderlyingErrorKey] as? NSError)
+        #expect(underlyingError.localizedDescription ==
+                "The operation couldn’t be completed. (com.firebase.appCheck error 1.)")
     }
     
     @Test("AppCheck vendor throws invalid configuration error from limitedUseToken")
     func testAppCheckInvalidconfigurationError() async throws {
         mockVendor.errorFromLimitedUseToken = NSError(domain: AppCheckErrorDomain, code: 2)
         
-        do {
+        let error = await #expect(throws: FirebaseAppCheckError.self) {
             _ = try await sut.clientAssertions
-        } catch let error as FirebaseAppCheckError {
-            #expect(error.kind == .invalidConfiguration)
-            #expect(error.errorUserInfo["originalError"] as? String ==
-                    "The operation couldn’t be completed. (com.firebase.appCheck error 2.)")
         }
+
+        #expect(error?.kind == .invalidConfiguration)
+        let underlyingError = try #require(error?.errorUserInfo[NSUnderlyingErrorKey] as? NSError)
+        #expect(underlyingError.localizedDescription ==
+                "The operation couldn’t be completed. (com.firebase.appCheck error 2.)")
     }
     
     @Test("AppCheck vendor throws keychain access error from limitedUseToken")
     func testAppCheckKeychainAccessError() async throws {
         mockVendor.errorFromLimitedUseToken = NSError(domain: AppCheckErrorDomain, code: 3)
         
-        do {
+        let error = await #expect(throws: FirebaseAppCheckError.self) {
             _ = try await sut.clientAssertions
-        } catch let error as FirebaseAppCheckError {
-            #expect(error.kind == .keychainAccess)
-            #expect(error.errorUserInfo["originalError"] as? String ==
-                    "The operation couldn’t be completed. (com.firebase.appCheck error 3.)")
         }
+
+        #expect(error?.kind == .keychainAccess)
+        let underlyingError = try #require(error?.errorUserInfo[NSUnderlyingErrorKey] as? NSError)
+        #expect(underlyingError.localizedDescription ==
+                "The operation couldn’t be completed. (com.firebase.appCheck error 3.)")
     }
     
     @Test("AppCheck vendor throws not supported error from limitedUseToken")
     func testAppCheckNotSupportedError() async throws {
         mockVendor.errorFromLimitedUseToken = NSError(domain: AppCheckErrorDomain, code: 4)
         
-        do {
+        let error = await #expect(throws: FirebaseAppCheckError.self) {
             _ = try await sut.clientAssertions
-        } catch let error as FirebaseAppCheckError {
-            #expect(error.kind == .notSupported)
-            #expect(error.errorUserInfo["originalError"] as? String ==
-                    "The operation couldn’t be completed. (com.firebase.appCheck error 4.)")
         }
+
+        #expect(error?.kind == .notSupported)
+        let underlyingError = try #require(error?.errorUserInfo[NSUnderlyingErrorKey] as? NSError)
+        #expect(underlyingError.localizedDescription ==
+                "The operation couldn’t be completed. (com.firebase.appCheck error 4.)")
     }
     
     @Test("AppCheck vendor throws generic error from limitedUseToken")
     func testAppCheckGenericError() async throws {
         mockVendor.errorFromLimitedUseToken = NSError(domain: AppCheckErrorDomain, code: 5)
         
-        do {
+        let error = await #expect(throws: FirebaseAppCheckError.self) {
             _ = try await sut.clientAssertions
-        } catch let error as FirebaseAppCheckError {
-            #expect(error.kind == .generic)
-            #expect(error.errorUserInfo["originalError"] as? String ==
-                    "The operation couldn’t be completed. (com.firebase.appCheck error 5.)")
         }
+
+        #expect(error?.kind == .generic)
+        let underlyingError = try #require(error?.errorUserInfo[NSUnderlyingErrorKey] as? NSError)
+        #expect(underlyingError.localizedDescription ==
+                "The operation couldn’t be completed. (com.firebase.appCheck error 5.)")
     }
     
     @Test("Check that 400 throws invalid public key error")
@@ -227,13 +233,14 @@ struct FirebaseAppIntegrityServiceTests: ~Copyable {
             (Data(), HTTPURLResponse(statusCode: 400))
         }
         
-        do {
+        let error = await #expect(throws: ClientAssertionError.self) {
             _ = try await sut.clientAssertions
-        } catch let error as ClientAssertionError {
-            #expect(error.kind == .invalidPublicKey)
-            #expect(error.errorUserInfo["originalError"] as? String ==
-                    "The operation couldn’t be completed. (Networking.ServerError error 400.)")
         }
+
+        #expect(error?.kind == .invalidPublicKey)
+        let underlyingError = try #require(error?.errorUserInfo[NSUnderlyingErrorKey] as? NSError)
+        #expect(underlyingError.localizedDescription ==
+                "The operation couldn’t be completed. (Networking.ServerError error 400.)")
     }
     
     @Test("Check that 401 throws invalid token error")
@@ -242,13 +249,14 @@ struct FirebaseAppIntegrityServiceTests: ~Copyable {
             (Data(), HTTPURLResponse(statusCode: 401))
         }
         
-        do {
+        let error = await #expect(throws: ClientAssertionError.self) {
             _ = try await sut.clientAssertions
-        } catch let error as ClientAssertionError {
-            #expect(error.kind == .invalidToken)
-            #expect(error.errorUserInfo["originalError"] as? String ==
-                    "The operation couldn’t be completed. (Networking.ServerError error 401.)")
         }
+
+        #expect(error?.kind == .invalidToken)
+        let underlyingError = try #require(error?.errorUserInfo[NSUnderlyingErrorKey] as? NSError)
+        #expect(underlyingError.localizedDescription ==
+                "The operation couldn’t be completed. (Networking.ServerError error 401.)")
     }
     
     @Test("Check that 500 throws txma server error")
@@ -257,13 +265,14 @@ struct FirebaseAppIntegrityServiceTests: ~Copyable {
             (Data(), HTTPURLResponse(statusCode: 500))
         }
         
-        do {
+        let error = await #expect(throws: ClientAssertionError.self) {
             _ = try await sut.clientAssertions
-        } catch let error as ClientAssertionError {
-            #expect(error.kind == .serverError)
-            #expect(error.errorUserInfo["originalError"] as? String ==
-                    "The operation couldn’t be completed. (Networking.ServerError error 500.)")
         }
+
+        #expect(error?.kind == .serverError)
+        let underlyingError = try #require(error?.errorUserInfo[NSUnderlyingErrorKey] as? NSError)
+        #expect(underlyingError.localizedDescription ==
+                "The operation couldn’t be completed. (Networking.ServerError error 500.)")
     }
     
     @Test("Proof of possession token generator returns error cant create attestation proof of possession error")
@@ -280,13 +289,15 @@ struct FirebaseAppIntegrityServiceTests: ~Copyable {
         
         mockAttestationProofOfPossessionTokenGenerator.errorFromToken = NSError(domain: "test domain", code: 0)
         
-        do {
+        let error = await #expect(throws: ProofOfPossessionError.self) {
             _ = try await sut.clientAssertions
-        } catch let error as ProofOfPossessionError {
-            #expect(error.kind == .cantGenerateAttestationProofOfPossessionJWT)
-            #expect(error.errorUserInfo["originalError"] as? String ==
-                    "The operation couldn’t be completed. (test domain error 0.)")
         }
+
+
+        #expect(error?.kind == .cantGenerateAttestationProofOfPossessionJWT)
+        let underlyingError = try #require(error?.errorUserInfo[NSUnderlyingErrorKey] as? NSError)
+        #expect(underlyingError.localizedDescription ==
+                "The operation couldn’t be completed. (test domain error 0.)")
     }
     
     @Test("DPoP token generator returns error cant create attestation proof of possession error")
@@ -303,13 +314,14 @@ struct FirebaseAppIntegrityServiceTests: ~Copyable {
         
         mockDemonstratingProofOfPossessionTokenGenerator.errorFromToken = NSError(domain: "test domain", code: 0)
         
-        do {
-            _ = try await sut.clientAssertions
-        } catch let error as ProofOfPossessionError {
-            #expect(error.kind == .cantGenerateDemonstratingProofOfPossessionJWT)
-            #expect(error.errorUserInfo["originalError"] as? String ==
-                    "The operation couldn’t be completed. (test domain error 0.)")
+        let error = await #expect(throws: ProofOfPossessionError.self) {
+            _ = try await sut.dPoPAssertion
         }
+
+        #expect(error?.kind == .cantGenerateDemonstratingProofOfPossessionJWT)
+        let underlyingError = try #require(error?.errorUserInfo[NSUnderlyingErrorKey] as? NSError)
+        #expect(underlyingError.localizedDescription ==
+                "The operation couldn’t be completed. (test domain error 0.)")
     }
     
     @Test("Check that client attestation is decoded successfully")
@@ -361,13 +373,14 @@ struct FirebaseAppIntegrityServiceTests: ~Copyable {
             """.utf8), HTTPURLResponse(statusCode: 200))
         }
         
-        do {
+        let error = await #expect(throws: ClientAssertionError.self) {
             _ = try await sut.clientAssertions
-        } catch let error as ClientAssertionError {
-            #expect(error.kind == .cantDecodeClientAssertion)
-            #expect(error.errorUserInfo["originalError"] as? String ==
-                    "The data couldn’t be read because it isn’t in the correct format.")
         }
+
+        #expect(error?.kind == .cantDecodeClientAssertion)
+        let underlyingError = try #require(error?.errorUserInfo[NSUnderlyingErrorKey] as? NSError)
+        #expect(underlyingError.localizedDescription ==
+                "The data couldn’t be read because it isn’t in the correct format.")
     }
     
     @Test("Check that client attestation request public key error is caught")

--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -5532,7 +5532,7 @@
 			repositoryURL = "https://github.com/govuk-one-login/mobile-ios-networking";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.5.0;
+				minimumVersion = 4.6.0;
 			};
 		};
 		C8A13CA22AFBD07E00FCBD36 /* XCRemoteSwiftPackageReference "mobile-ios-authentication" */ = {
@@ -5540,7 +5540,7 @@
 			repositoryURL = "https://github.com/govuk-one-login/mobile-ios-authentication.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.0.0;
+				minimumVersion = 5.1.0;
 			};
 		};
 		C8A13CA72AFBD0CC00FCBD36 /* XCRemoteSwiftPackageReference "mobile-ios-logging" */ = {
@@ -5564,7 +5564,7 @@
 			repositoryURL = "https://github.com/govuk-one-login/mobile-ios-secure-store";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.3.0;
+				minimumVersion = 4.5.0;
 			};
 		};
 		D0BE243C2BEB7E5E00759529 /* XCRemoteSwiftPackageReference "jwt-kit" */ = {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -221,7 +221,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-utilities",
       "state" : {
-        "revision" : "cb53f220f3059bd7105caf97ff33cbd65801bf2c",
+        "revision" : "104ec765b1ac2a7ae79798a719296e65542395df",
         "branch" : "feat/DCMAW-21061-standardise-gdserror"
       }
     },

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -221,8 +221,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-utilities",
       "state" : {
-        "revision" : "a67b1c345e1ba39f71ef60d8c9faa7a8a7d55794",
-        "version" : "1.1.1"
+        "revision" : "cb53f220f3059bd7105caf97ff33cbd65801bf2c",
+        "branch" : "feat/DCMAW-21061-standardise-gdserror"
       }
     },
     {

--- a/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneLogin.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-authentication.git",
       "state" : {
-        "revision" : "ebce5326dc346fd26030429fe6e51a116212213e",
-        "version" : "5.0.0"
+        "revision" : "dbeef4f0d41c595be949552f52b0a38e056ddcf4",
+        "version" : "5.1.0"
       }
     },
     {
@@ -194,8 +194,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-networking",
       "state" : {
-        "revision" : "5336f9b3ddfed6875d83b4e4f19cc24ecafcd3c8",
-        "version" : "4.5.0"
+        "revision" : "c2ad32a7c6f88c678fbb3c88e1ce2b755603b87f",
+        "version" : "4.6.0"
       }
     },
     {
@@ -203,8 +203,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-secure-store",
       "state" : {
-        "revision" : "97bbc491d6121a2903f8622e0fce1eb779a64b44",
-        "version" : "4.3.0"
+        "revision" : "32d1b6e8e151a90b7d9937148779ec37b0c33297",
+        "version" : "4.5.0"
       }
     },
     {
@@ -221,8 +221,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-utilities",
       "state" : {
-        "revision" : "104ec765b1ac2a7ae79798a719296e65542395df",
-        "branch" : "feat/DCMAW-21061-standardise-gdserror"
+        "revision" : "53afbf17be3ebdbed1746108cec3d2833b18b6a8",
+        "version" : "2.0.0"
       }
     },
     {

--- a/Tests/UnitTests/Utilities/Session/PersistentSessionErrorTests.swift
+++ b/Tests/UnitTests/Utilities/Session/PersistentSessionErrorTests.swift
@@ -4,11 +4,11 @@ import Testing
 struct PersistentSessionErrorTests {
     // swiftlint:disable line_length
     static let allPersistentSessionError = [
-        (error: PersistentSessionError(.noSessionExists, reason: "there was no persistentID token saved in the encrypted store"), debugDescription: "there was no persistentID token saved in the encrypted store"),
-        (error: PersistentSessionError(.userRemovedLocalAuth, reason: "the user has removed all local auth from their device"), debugDescription: "the user has removed all local auth from their device"),
-        (error: PersistentSessionError(.sessionMismatch, reason: "the persistentID was cleared from the encrypted store because a different user logged in"), debugDescription: "the persistentID was cleared from the encrypted store because a different user logged in"),
-        (error: PersistentSessionError(.cannotDeleteData, reason: "there was an error while trying to delete all user data"), debugDescription: "there was an error while trying to delete all user data"),
-        (error: PersistentSessionError(.idTokenNotStored, reason: "there was no idToken found in the secure store"), debugDescription: "there was no idToken found in the secure store")
+        (error: PersistentSessionError(.noSessionExists), debugDescription: "Error Domain=PersistentSessionErrorKind Code=1001 \"there was no persistentID token saved in the encrypted store\""),
+        (error: PersistentSessionError(.userRemovedLocalAuth), debugDescription: "Error Domain=PersistentSessionErrorKind Code=1002 \"the user has removed all local auth from their device\""),
+        (error: PersistentSessionError(.sessionMismatch), debugDescription: "Error Domain=PersistentSessionErrorKind Code=1003 \"the persistentID was cleared from the encrypted store because a different user logged in\""),
+        (error: PersistentSessionError(.cannotDeleteData), debugDescription: "Error Domain=PersistentSessionErrorKind Code=1004 \"there was an error while trying to delete all user data\""),
+        (error: PersistentSessionError(.idTokenNotStored), debugDescription: "Error Domain=PersistentSessionErrorKind Code=1005 \"there was no idToken found in the secure store\"")
     ]
     // swiftlint:enable line_length
 

--- a/Tests/UnitTests/Utilities/Session/PersistentSessionErrorTests.swift
+++ b/Tests/UnitTests/Utilities/Session/PersistentSessionErrorTests.swift
@@ -2,18 +2,35 @@
 import Testing
 
 struct PersistentSessionErrorTests {
+    
+    struct Case: Sendable {
+        let error: PersistentSessionError
+        let debugDescription: String
+        let kind: String
+    }
+
     // swiftlint:disable line_length
     static let allPersistentSessionError = [
-        (error: PersistentSessionError(.noSessionExists), debugDescription: "Error Domain=PersistentSessionErrorKind Code=1001 \"there was no persistentID token saved in the encrypted store\""),
-        (error: PersistentSessionError(.userRemovedLocalAuth), debugDescription: "Error Domain=PersistentSessionErrorKind Code=1002 \"the user has removed all local auth from their device\""),
-        (error: PersistentSessionError(.sessionMismatch), debugDescription: "Error Domain=PersistentSessionErrorKind Code=1003 \"the persistentID was cleared from the encrypted store because a different user logged in\""),
-        (error: PersistentSessionError(.cannotDeleteData), debugDescription: "Error Domain=PersistentSessionErrorKind Code=1004 \"there was an error while trying to delete all user data\""),
-        (error: PersistentSessionError(.idTokenNotStored), debugDescription: "Error Domain=PersistentSessionErrorKind Code=1005 \"there was no idToken found in the secure store\"")
+        Case(error: PersistentSessionError(.noSessionExists), debugDescription: "Error Domain=PersistentSessionErrorKind Code=1001 \"there was no persistentID token saved in the encrypted store\"", kind: "noSessionExists"),
+        Case(error: PersistentSessionError(.userRemovedLocalAuth), debugDescription: "Error Domain=PersistentSessionErrorKind Code=1002 \"the user has removed all local auth from their device\"", kind: "userRemovedLocalAuth"),
+        Case(error: PersistentSessionError(.sessionMismatch), debugDescription: "Error Domain=PersistentSessionErrorKind Code=1003 \"the persistentID was cleared from the encrypted store because a different user logged in\"", kind: "sessionMismatch"),
+        Case(error: PersistentSessionError(.cannotDeleteData), debugDescription: "Error Domain=PersistentSessionErrorKind Code=1004 \"there was an error while trying to delete all user data\"", kind: "cannotDeleteData"),
+        Case(error: PersistentSessionError(.idTokenNotStored), debugDescription: "Error Domain=PersistentSessionErrorKind Code=1005 \"there was no idToken found in the secure store\"", kind: "idTokenNotStored")
     ]
     // swiftlint:enable line_length
 
-    @Test("assert debugDescription matches reason", arguments: PersistentSessionErrorTests.allPersistentSessionError)
-    func test_debugDescription(sut: PersistentSessionError, debugDescription: String) async throws {
-        #expect(sut.debugDescription == debugDescription)
+    @Test("assert debugDescription", arguments: PersistentSessionErrorTests.allPersistentSessionError)
+    func test_debugDescription(testCase: Case) async throws {
+        #expect(testCase.error.debugDescription == testCase.debugDescription)
     }
+    
+    /// // swiftlint:disable line_length
+    /// The `kind` found in the `userInfo` **must** hold a unique String identifier that describes the error as reported on analytics
+    /// - Seealso: https://govukverify.atlassian.net/wiki/x/OgS84Q
+    /// // swiftlint:enable line_length
+    @Test("assert kind", arguments: PersistentSessionErrorTests.allPersistentSessionError)
+    func test_kind(testCase: Case) async throws {
+        #expect(testCase.error.errorUserInfo["kind"] as? String == testCase.kind)
+    }
+
 }


### PR DESCRIPTION
# [Update tests](https://govukverify.atlassian.net/browse/DCMAW-21061)
> [!TIP]
> This PR does not modify source code 

Updates the tests to match the expected `debugDescription` with the changes made in `GDSUtilities`.

Updated test `FirebaseAppIntegrityServiceTests/testDPoPError` that was falsely succeeding. Previously, the test used a try catch block. Meaning, it still passed even if the error was not thrown.

Using #expect to assert that the error is indeed thrown, indicated that the test needed updating.

<img width="1750" height="1196" alt="Screenshot 2026-07-28 at 15 16 11" src="https://github.com/user-attachments/assets/fa4db758-8b7f-4595-a4ec-d4e0ba3adf51" />

# Updated depencies
* [mobile-ios-utilities/releases/tag/2.0.0](https://github.com/govuk-one-login/mobile-ios-utilities/releases/tag/2.0.0)
* * [1.0.0...2.0.0](https://github.com/govuk-one-login/mobile-ios-utilities/compare/1.0.0...2.0.0)
* [mobile-ios-secure-store/releases/tag/4.5.0](https://github.com/govuk-one-login/mobile-ios-secure-store/releases/tag/4.5.0)
* * [4.3.0...4.5.0](https://github.com/govuk-one-login/mobile-ios-secure-store/compare/4.3.0...4.5.0)
* [mobile-ios-authentication/releases/tag/5.1.0](https://github.com/govuk-one-login/mobile-ios-authentication/releases/tag/5.1.0)
* * [5.0.0...5.1.0](https://github.com/govuk-one-login/mobile-ios-authentication/compare/5.0.0...5.1.0)
*  [mobile-ios-networking/releases/tag/4.6.0](https://github.com/govuk-one-login/mobile-ios-networking/releases/tag/4.6.0)
* * [4.5.0...4.6.0](https://github.com/govuk-one-login/mobile-ios-networking/compare/4.5.0...4.6.0)

# Do not merge

This PR depends on:
* https://github.com/govuk-one-login/mobile-ios-authentication/pull/105
* https://github.com/govuk-one-login/mobile-ios-secure-store/pull/74
* https://github.com/govuk-one-login/mobile-ios-networking/pull/73

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
