### PR TITLE
feat: DCMAW-21048 ensure user session is evaluated once before attempting to evaluate it a second time

### DIFF
--- a/Sources/Qualification/State/AppQualifyingService.swift
+++ b/Sources/Qualification/State/AppQualifyingService.swift
@@ -7,7 +7,35 @@ import SecureStore
 
 @MainActor
 protocol QualifyingService: AnyObject {
+    /// Assign a delegate to receive state updates on:
+    /// * ``AppInformationState``
+    /// * ``AppSessionState``
+    /// * ``RemoteServiceState``
+    ///
+    /// Assigning a delegate guarantees that any future state updates will be delivered.
+    /// Past state updates, including the current state are NOT expected to delivered at the time a delegate is assigned.
+    ///
+    /// An implementation of ``QualifyingService`` chooses how and when state updates are delivered,
+    /// including whether they are delivered as they arrive or scheduled to be delivered (e.g. at the next opportunity)
+    ///
+    /// - SeeAlso: ``AppQualifyingService``
+    /// - Remark: Your implementation of ``QualifyingService`` must provide strong guarantees that state updates
+    /// are delivered in the "correct" sequence and represent valid transitions.
     var delegate: AppQualifyingServiceDelegate? { get set }
+    
+    /// Schedules an evaluation to both the ``AppInformationState`` and ``AppSessionState``.
+    /// Assign a ``delegate`` prior to the call to ``initiate()`` to receive state updates as they arrive.
+    ///
+    /// Once an evaluation is in flight, no further evaluations can be scheduled. In other words, multiple calls
+    /// to ``initiate()`` in quick succession are effectively no-op.
+    ///
+    /// This is by design as it's meant to avoid excessive, unnecessary evaluations that can effectively keep the system
+    /// busy and starve it off its ability to execute any other work.
+    ///
+    /// A state update is guaranteed to be delivered in the correct sequence and represent valid transitions
+    /// between states over time. While multiple calls to ``initiate()`` in quick succession do not result in
+    /// an equal number of evaluations, you are guaranteed to receive a state update in the correct sequence and represent valid transitions between states over time.
+    ///
     func initiate()
     func evaluateUserSession() async
 }
@@ -49,8 +77,8 @@ final class AppQualifyingService: QualifyingService {
             }
         }
     }
-
-    let serialTaskQueue: SerialTaskQueue = SerialTaskQueue()
+    
+    private var task: Task<Void, Never>?
 
     init(
         analyticsService: OneLoginAnalyticsService,
@@ -63,11 +91,16 @@ final class AppQualifyingService: QualifyingService {
     }
     
     public func initiate() {
-        Task {
-            try await serialTaskQueue.enqueue {
-                await self.qualifyAppVersion()
-                await self.evaluateUserSession()
+        guard task == nil else {
+            return
+        }
+
+        self.task = Task(name: #function) {
+            defer {
+                self.task = nil
             }
+            await qualifyAppVersion()
+            await evaluateUserSession()
         }
     }
     

--- a/Sources/Qualification/State/AppQualifyingService.swift
+++ b/Sources/Qualification/State/AppQualifyingService.swift
@@ -56,12 +56,10 @@ final class AppQualifyingService: QualifyingService {
     
     private var initiateTask: Task<Void, Never>?
     
-    /** used for testing only */
-    // swiftlint:disable identifier_name
+    /// used for testing only
     var _initiateTask: Task<Void, Never>? {
         initiateTask
     }
-    // swiftlint:enable identifier_name
 
     private var appInfoState: AppInformationState = .notChecked {
         didSet {

--- a/Sources/Qualification/State/AppQualifyingService.swift
+++ b/Sources/Qualification/State/AppQualifyingService.swift
@@ -54,6 +54,8 @@ final class AppQualifyingService: QualifyingService {
     private let sessionManager: SessionManager
     weak var delegate: AppQualifyingServiceDelegate?
     
+    private var initiateTask: Task<Void, Never>?
+
     private var appInfoState: AppInformationState = .notChecked {
         didSet {
             Task { [appInfoState = appInfoState] in
@@ -78,8 +80,6 @@ final class AppQualifyingService: QualifyingService {
         }
     }
     
-    private var task: Task<Void, Never>?
-
     init(
         analyticsService: OneLoginAnalyticsService,
         updateService: AppInformationProvider = AppInformationService(baseURL: AppEnvironment.appInfoURL),
@@ -91,13 +91,13 @@ final class AppQualifyingService: QualifyingService {
     }
     
     public func initiate() {
-        guard task == nil else {
+        guard initiateTask == nil else {
             return
         }
 
-        self.task = Task(name: #function) {
+        self.initiateTask = Task(name: #function) {
             defer {
-                self.task = nil
+                self.initiateTask = nil
             }
             await qualifyAppVersion()
             await evaluateUserSession()

--- a/Sources/Qualification/State/AppQualifyingService.swift
+++ b/Sources/Qualification/State/AppQualifyingService.swift
@@ -57,9 +57,11 @@ final class AppQualifyingService: QualifyingService {
     private var initiateTask: Task<Void, Never>?
     
     /** used for testing only */
+    // swiftlint:disable identifier_name
     var _initiateTask: Task<Void, Never>? {
         initiateTask
     }
+    // swiftlint:enable identifier_name
 
     private var appInfoState: AppInformationState = .notChecked {
         didSet {

--- a/Sources/Qualification/State/AppQualifyingService.swift
+++ b/Sources/Qualification/State/AppQualifyingService.swift
@@ -55,6 +55,11 @@ final class AppQualifyingService: QualifyingService {
     weak var delegate: AppQualifyingServiceDelegate?
     
     private var initiateTask: Task<Void, Never>?
+    
+    /** used for testing only */
+    var _initiateTask: Task<Void, Never>? {
+        initiateTask
+    }
 
     private var appInfoState: AppInformationState = .notChecked {
         didSet {

--- a/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
+++ b/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
@@ -563,27 +563,27 @@ extension AppQualifyingServiceTests {
         let appInformationStates: [AppInformationState] = [
             .qualified
         ]
-        let sessionStatesReceivedExpectation = expectation(description: "expected session states received")
-        sessionStatesReceivedExpectation.assertForOverFulfill = false
+        let appInformationStatesReceivedExpectation = expectation(description: "expected app information states received")
+        appInformationStatesReceivedExpectation.assertForOverFulfill = false
         let sut: AppQualifyingService = .make(appInformationProvider: MockAppInfoAppInformationProvider(appInfoStates: appInformationStates))
-        var receivedSessionStates = [AppInformationState]()
-        let appQualifyingServiceDelegateExpectation = AppQualifyingServiceDelegateExpectation(didChangeAppInfoStateAsFunction: { sessionState in
-            receivedSessionStates.append(sessionState)
+        var receivedappInformationStates = [AppInformationState]()
+        let appQualifyingServiceDelegateExpectation = AppQualifyingServiceDelegateExpectation(didChangeAppInfoStateAsFunction: { appInformationState in
+            receivedappInformationStates.append(appInformationState)
 
-            let expectedSessionStateTransitions = Array(appInformationStates.prefix(receivedSessionStates.count))
-            guard receivedSessionStates == expectedSessionStateTransitions else {
+            let expectedAppInformationStateTransitions = Array(appInformationStates.prefix(appInformationStates.count))
+            guard receivedappInformationStates == expectedAppInformationStateTransitions else {
                 let issue = XCTIssue(
                     type: .assertionFailure,
                     compactDescription: "Received a app information state that was not expected",
-                    detailedDescription: "Sequence of app information states \(receivedSessionStates) does not match expected sequence: \(expectedSessionStateTransitions)."
+                    detailedDescription: "Sequence of app information states \(appInformationStates) does not match expected sequence: \(expectedAppInformationStateTransitions)."
                 )
                 self.record(issue)
-                sessionStatesReceivedExpectation.fulfill()
+                appInformationStatesReceivedExpectation.fulfill()
                 return
             }
 
-            if receivedSessionStates.count == appInformationStates.count {
-                sessionStatesReceivedExpectation.fulfill()
+            if receivedappInformationStates.count == appInformationStates.count {
+                appInformationStatesReceivedExpectation.fulfill()
             }
         })
 
@@ -595,11 +595,11 @@ extension AppQualifyingServiceTests {
 
         await sut._initiateTask?.value
 
-        await fulfillment(of: [sessionStatesReceivedExpectation], timeout: 5)
+        await fulfillment(of: [appInformationStatesReceivedExpectation], timeout: 5)
 
-        XCTAssertEqual(receivedSessionStates, appInformationStates)
+        XCTAssertEqual(appInformationStates, appInformationStates)
     }
-    
+
     /// This test aims to reproduce the case of an app entering into the foreground
     /// which results in a call to ``initiate`` every time.
     ///
@@ -607,7 +607,7 @@ extension AppQualifyingServiceTests {
     /// has been completed.
     ///
     /// The test aims to emulate how a follow up call to ``initiate`` once the last one has finished evaluating
-    /// the information state, via ``qualifyAppVersion``, will result in another session state evaluation.
+    /// the information state, via ``qualifyAppVersion``, will result in another app information state evaluation.
     ///
     /// - SeeAlso: ``SceneDelegate/sceneWillEnterForeground(_:)``
     /// - SeeAlso: ``AppQualifyingService/appInfoState``
@@ -617,27 +617,27 @@ extension AppQualifyingServiceTests {
             .qualified,
             .unavailable
         ]
-        let sessionStatesReceivedExpectation = expectation(description: "expected session states received")
-        sessionStatesReceivedExpectation.assertForOverFulfill = false
+        let appInformationStatesReceivedExpectation = expectation(description: "expected app information states received")
+        appInformationStatesReceivedExpectation.assertForOverFulfill = false
         let sut: AppQualifyingService = .make(appInformationProvider: MockAppInfoAppInformationProvider(appInfoStates: appInformationStates))
-        var receivedSessionStates = [AppInformationState]()
-        let appQualifyingServiceDelegateExpectation = AppQualifyingServiceDelegateExpectation(didChangeAppInfoStateAsFunction: { sessionState in
-            receivedSessionStates.append(sessionState)
+        var receivedappInformationStates = [AppInformationState]()
+        let appQualifyingServiceDelegateExpectation = AppQualifyingServiceDelegateExpectation(didChangeAppInfoStateAsFunction: { appInformationState in
+            receivedappInformationStates.append(appInformationState)
 
-            let expectedSessionStateTransitions = Array(appInformationStates.prefix(receivedSessionStates.count))
-            guard receivedSessionStates == expectedSessionStateTransitions else {
+            let expectedAppInformationStateTransitions = Array(appInformationStates.prefix(receivedappInformationStates.count))
+            guard receivedappInformationStates == expectedAppInformationStateTransitions else {
                 let issue = XCTIssue(
                     type: .assertionFailure,
                     compactDescription: "Received a app information state that was not expected",
-                    detailedDescription: "Sequence of app information states \(receivedSessionStates) does not match expected sequence: \(expectedSessionStateTransitions)."
+                    detailedDescription: "Sequence of app information states \(receivedappInformationStates) does not match expected sequence: \(expectedAppInformationStateTransitions)."
                 )
                 self.record(issue)
-                sessionStatesReceivedExpectation.fulfill()
+                appInformationStatesReceivedExpectation.fulfill()
                 return
             }
 
-            if receivedSessionStates.count == appInformationStates.count {
-                sessionStatesReceivedExpectation.fulfill()
+            if receivedappInformationStates.count == appInformationStates.count {
+                appInformationStatesReceivedExpectation.fulfill()
             }
         })
 
@@ -649,9 +649,9 @@ extension AppQualifyingServiceTests {
         sut.initiate()
         await sut._initiateTask?.value
 
-        await fulfillment(of: [sessionStatesReceivedExpectation], timeout: 5)
+        await fulfillment(of: [appInformationStatesReceivedExpectation], timeout: 5)
 
-        XCTAssertEqual(receivedSessionStates, appInformationStates)
+        XCTAssertEqual(receivedappInformationStates, appInformationStates)
     }
 
     /// This test aims to reproduce the case of an app entering into the foreground
@@ -677,27 +677,27 @@ extension AppQualifyingServiceTests {
             .outdated,
             .error
         ]
-        let sessionStatesReceivedExpectation = expectation(description: "expected session states received")
-        sessionStatesReceivedExpectation.assertForOverFulfill = false
+        let appInformationStatesReceivedExpectation = expectation(description: "expected app information states received")
+        appInformationStatesReceivedExpectation.assertForOverFulfill = false
         let sut: AppQualifyingService = .make(appInformationProvider: MockAppInfoAppInformationProvider(appInfoStates: appInformationStates))
-        var receivedSessionStates = [AppInformationState]()
-        let appQualifyingServiceDelegateExpectation = AppQualifyingServiceDelegateExpectation(didChangeAppInfoStateAsFunction: { sessionState in
-            receivedSessionStates.append(sessionState)
+        var receivedappInformationStates = [AppInformationState]()
+        let appQualifyingServiceDelegateExpectation = AppQualifyingServiceDelegateExpectation(didChangeAppInfoStateAsFunction: { appInformationState in
+            receivedappInformationStates.append(appInformationState)
 
-            let expectedSessionStateTransitions = Array(appInformationStates.prefix(receivedSessionStates.count))
-            guard receivedSessionStates == expectedSessionStateTransitions else {
+            let expectedAppInformationStateTransitions = Array(appInformationStates.prefix(receivedappInformationStates.count))
+            guard receivedappInformationStates == expectedAppInformationStateTransitions else {
                 let issue = XCTIssue(
                     type: .assertionFailure,
                     compactDescription: "Received a app information state that was not expected",
-                    detailedDescription: "Sequence of app information states \(receivedSessionStates) does not match expected sequence: \(expectedSessionStateTransitions)."
+                    detailedDescription: "Sequence of app information states \(appInformationStates) does not match expected sequence: \(expectedAppInformationStateTransitions)."
                 )
                 self.record(issue)
-                sessionStatesReceivedExpectation.fulfill()
+                appInformationStatesReceivedExpectation.fulfill()
                 return
             }
 
-            if receivedSessionStates.count == appInformationStates.count {
-                sessionStatesReceivedExpectation.fulfill()
+            if receivedappInformationStates.count == appInformationStates.count {
+                appInformationStatesReceivedExpectation.fulfill()
             }
         })
 
@@ -708,9 +708,9 @@ extension AppQualifyingServiceTests {
             await sut._initiateTask?.value
         }
 
-        await fulfillment(of: [sessionStatesReceivedExpectation], timeout: 5)
+        await fulfillment(of: [appInformationStatesReceivedExpectation], timeout: 5)
 
-        XCTAssertEqual(receivedSessionStates, appInformationStates)
+        XCTAssertEqual(appInformationStates, appInformationStates)
     }
 
     /// This test aims to reproduce the case of a number of notification posting an update on ``RemoteServiceState``.

--- a/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
+++ b/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
@@ -384,7 +384,7 @@ extension AppQualifyingServiceTests {
     /// - SeeAlso: ``MockResumeSessionSessionManager``
     func test_multiple_foreground_initiate_calls_only_evaluate_session_state_once() async throws {
         let sessionStates: [SessionState] = [
-            .saved,
+            .saved
         ]
         let expectedAppSessionStateTransitions = sessionStates.map(\.expectedAppSessionState)
         let sessionStatesReceivedExpectation = expectation(description: "expected session states received")
@@ -439,7 +439,7 @@ extension AppQualifyingServiceTests {
     func test_foreground_initiate_in_sequence_evaluate_every_session_state() async throws {
         let sessionStates: [SessionState] = [
             .nonePresent,
-            .saved,
+            .saved
         ]
         let expectedAppSessionStateTransitions = sessionStates.map(\.expectedAppSessionState)
         let sessionStatesReceivedExpectation = expectation(description: "expected session states received")
@@ -561,7 +561,7 @@ extension AppQualifyingServiceTests {
     /// - SeeAlso: ``MockAppInfoAppInformationProvider``
     func test_multiple_foreground_initiate_calls_only_evaluate_information_state_once() async throws {
         let appInformationStates: [AppInformationState] = [
-            .qualified,
+            .qualified
         ]
         let sessionStatesReceivedExpectation = expectation(description: "expected session states received")
         sessionStatesReceivedExpectation.assertForOverFulfill = false
@@ -615,7 +615,7 @@ extension AppQualifyingServiceTests {
     func test_foreground_initiate_in_sequence_evaluate_every_information_state() async throws {
         let appInformationStates: [AppInformationState] = [
             .qualified,
-            .unavailable,
+            .unavailable
         ]
         let sessionStatesReceivedExpectation = expectation(description: "expected session states received")
         sessionStatesReceivedExpectation.assertForOverFulfill = false

--- a/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
+++ b/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
@@ -374,37 +374,126 @@ extension AppQualifyingServiceTests {
     /// This test aims to reproduce the case of an app entering into the foreground
     /// which results in a call to ``initiate`` every time.
     ///
-    /// Test that multiple calls to ``initiate`` do not result in an invalid ``AppSessionState`` to be received
-    /// while waiting for ``PersistentSessionManager`` to resume the session.
+    /// Tests that multiple calls to ``initiate`` in quick succession, result in only
+    /// a single evaluation of an ``AppSessionState``.
     ///
-    /// The ``initiate`` function asyncronously attempts to evaluate the user session (i.e. ``evaluateUserSession``).
-    /// In case of a `.saved` sessionState,  the  ``AppQualifyingService`` will attempt to call
-    ///  ``SessionManager/resumeSession`` in order to update the sessionState (in case its succesful, this will
-    ///  also result in a  `.saved` sessionState, which next time will will attempt to call
-    ///  ``SessionManager/resumeSession`` and so on and so forth).
-    ///
-    /// While waiting, a second ``evaluateUserSession`` arrives (potentially a third, a fourth etc.) that may now
-    /// resolve the user session to new application state (e.g. .expired) just as the ``resumeSession`` returns.
-    ///
-    /// Potentially resulting to either an unexpected application state or an invalid transition between states.
-    ///
-    /// This test aims to catch such a case of an invalid transition between states by using a mock ``SessionManager``
-    /// that dispenses each ``SessionState`` in the given order, as expected by the test, and adding
-    /// an artificial delay when resuming a session so as the next call to ``initiate`` will attempt to read
-    /// the session state while the previous one awaits.
-    ///
-    /// The test invokes the ``initiate`` function is quick succession so as to generate concurrent pressure
-    /// by **scheduling of tasks** since ``initiate`` merely creates a tak and there is no way to control/manage
-    /// Task execution.
-    ///
-    /// In other words, this test aims to emulate what would happen should a number of Task(s) have been scheduled
-    /// for execution over a short period of time. Creating lots of Tasks in a short period of time aims to *force* the
-    /// system to execute themconcurrently. As of today, 13 number of tasks appear to apply enough concurrent pressure.
-    /// *This may change in the future*
+    /// The test invokes the ``initiate`` function is quick succession to assert that multiple calls
+    /// are effectively no-op.
     ///
     /// - SeeAlso: ``SceneDelegate/sceneWillEnterForeground(_:)`
     /// - SeeAlso: ``MockResumeSessionSessionManager``
-    func test_multiple_foreground_initiate_calls_do_not_lead_to_invalid_session_state_transition() async throws {
+    func test_multiple_foreground_initiate_calls_only_evaluate_session_state_once() async throws {
+        let sessionStates: [SessionState] = [
+            .saved,
+        ]
+        let expectedAppSessionStateTransitions = sessionStates.map(\.expectedAppSessionState)
+        let sessionStatesReceivedExpectation = expectation(description: "expected session states received")
+        sessionStatesReceivedExpectation.assertForOverFulfill = false
+        let sessionManager = MockResumeSessionSessionManager(sessionStates: sessionStates)
+        let sut: AppQualifyingService = .make(sessionManager: sessionManager)
+        var receivedSessionStates = [AppSessionState]()
+        let appQualifyingServiceDelegateExpectation = AppQualifyingServiceDelegateExpectation(didChangeSessionStateAsFunction: { sessionState in
+            receivedSessionStates.append(sessionState)
+
+            let expectedSessionStateTransitions = Array(expectedAppSessionStateTransitions.prefix(receivedSessionStates.count))
+            guard receivedSessionStates == expectedSessionStateTransitions else {
+                let issue = XCTIssue(
+                    type: .assertionFailure,
+                    compactDescription: "Received a session state that was not expected",
+                    detailedDescription: "Sequence of received session states \(receivedSessionStates) does not match expected sequence: \(expectedSessionStateTransitions)."
+                )
+                self.record(issue)
+                sessionStatesReceivedExpectation.fulfill()
+                return
+            }
+
+            if receivedSessionStates.count == expectedAppSessionStateTransitions.count {
+                sessionStatesReceivedExpectation.fulfill()
+            }
+        })
+
+        sut.delegate = appQualifyingServiceDelegateExpectation
+
+        for _ in 0..<10 {
+            sut.initiate()
+        }
+        
+        await sut._initiateTask?.value
+
+        await fulfillment(of: [sessionStatesReceivedExpectation], timeout: 5)
+
+        XCTAssertEqual(receivedSessionStates, expectedAppSessionStateTransitions)
+    }
+    
+    /// This test aims to reproduce the case of an app entering into the foreground
+    /// which results in a call to ``initiate`` every time.
+    ///
+    /// It asserts that the session state will be evaluated over time as long as the last evaluation
+    /// has been completed.
+    ///
+    /// The test aims to emulate how a follow up call to ``initiate`` once the last one has finished evaluating
+    /// the session state, via ``evaluateUserSession``, will result in another session state evaluation.
+    ///
+    /// - SeeAlso: ``SceneDelegate/sceneWillEnterForeground(_:)`
+    /// - SeeAlso: ``MockResumeSessionSessionManager``
+    func test_foreground_initiate_in_sequence_evaluate_every_session_state() async throws {
+        let sessionStates: [SessionState] = [
+            .nonePresent,
+            .saved,
+        ]
+        let expectedAppSessionStateTransitions = sessionStates.map(\.expectedAppSessionState)
+        let sessionStatesReceivedExpectation = expectation(description: "expected session states received")
+        sessionStatesReceivedExpectation.assertForOverFulfill = false
+        let sessionManager = MockResumeSessionSessionManager(sessionStates: sessionStates)
+        let sut: AppQualifyingService = .make(sessionManager: sessionManager)
+        var receivedSessionStates = [AppSessionState]()
+        let appQualifyingServiceDelegateExpectation = AppQualifyingServiceDelegateExpectation(didChangeSessionStateAsFunction: { sessionState in
+            receivedSessionStates.append(sessionState)
+
+            let expectedSessionStateTransitions = Array(expectedAppSessionStateTransitions.prefix(receivedSessionStates.count))
+            guard receivedSessionStates == expectedSessionStateTransitions else {
+                let issue = XCTIssue(
+                    type: .assertionFailure,
+                    compactDescription: "Received a session state that was not expected",
+                    detailedDescription: "Sequence of received session states \(receivedSessionStates) does not match expected sequence: \(expectedSessionStateTransitions)."
+                )
+                self.record(issue)
+                sessionStatesReceivedExpectation.fulfill()
+                return
+            }
+
+            if receivedSessionStates.count == expectedAppSessionStateTransitions.count {
+                sessionStatesReceivedExpectation.fulfill()
+            }
+        })
+
+        sut.delegate = appQualifyingServiceDelegateExpectation
+        
+        sut.initiate()
+        await sut._initiateTask?.value
+        
+        sut.initiate()
+        await sut._initiateTask?.value
+
+        await fulfillment(of: [sessionStatesReceivedExpectation], timeout: 5)
+
+        XCTAssertEqual(receivedSessionStates, expectedAppSessionStateTransitions)
+    }
+    
+    /// This test aims to reproduce the case of an app entering into the foreground
+    /// which results in a call to ``initiate`` every time.
+    ///
+    /// It asserts that calls to ``evaluateUserSession`` over time, as long as the last
+    /// ``AppSessionState`` has been evaluated, will correctly transition to the
+    /// next session state.
+    ///
+    /// The test awaits for the evaluation to complete before attempting to initiate a new one. This way
+    /// it aims to emulate how ``initiate`` will create a new task to evaluate the session state
+    /// and how the state will transition over time.
+    ///
+    /// - SeeAlso: ``SceneDelegate/sceneWillEnterForeground(_:)`
+    /// - SeeAlso: ``MockResumeSessionSessionManager``
+    func test_multiple_foreground_initiate_calls_over_time_transition_sessions_state() async throws {
         let sessionStates: [SessionState] = [
             .nonePresent,
             .enrolling,
@@ -447,9 +536,10 @@ extension AppQualifyingServiceTests {
         })
 
         sut.delegate = appQualifyingServiceDelegateExpectation
-
+        
         for _ in 0..<sessionStates.count {
             sut.initiate()
+            await sut._initiateTask?.value
         }
 
         await fulfillment(of: [sessionStatesReceivedExpectation], timeout: 5)
@@ -460,31 +550,125 @@ extension AppQualifyingServiceTests {
     /// This test aims to reproduce the case of an app entering into the foreground
     /// which results in a call to ``initiate`` every time.
     ///
-    /// Test that multiple calls to ``qualifyAppVersion`` do not result in an invalid ``AppInformationState`` to be received.
+    /// Tests that multiple calls to ``qualifyAppVersion`` in quick succession, result in only
+    /// a single evaluation of an ``AppInformationState``.
     ///
-    /// The ``initiate`` function asyncronously attempts to evaluate the app version (i.e. ``qualifyAppVersion``).
-    ///
-    /// Since the ``AppQualifyingService`` **schedules a Task** to perform a callback to the delegate, it's possible that
-    /// by the time the task runs and reads the value, the value has since change from another call to ``qualifyAppVersion``
-    ///
-    /// Potentially resulting to either an unexpected app information state or an invalid transition between states.
-    ///
-    /// This test aims to catch such a case of an invalid transition between states by using a mock ``AppInformationProvider``
-    /// that dispenses each ``AppInformationState`` in the given order, as expected by the test.
-    ///
-    /// The test invokes the ``initiate`` function is quick succession so as to generate concurrent pressure
-    /// by **scheduling of tasks** since ``qualifyAppVersion`` merely creates a task and there is no way to control/manage
-    /// Task execution.
-    ///
-    /// In other words, this test aims to emulate what would happen should a number of Task(s) have been scheduled
-    /// for execution over a short period of time. Creating lots of Tasks in a short period of time aims to *force* the
-    /// system to execute themconcurrently. As of today, 6 number of tasks appear to apply enough concurrent pressure.
-    /// *This may change in the future*
+    /// The test invokes the ``initiate`` function is quick succession to assert that multiple calls
+    /// are effectively no-op.
     ///
     /// - SeeAlso: ``SceneDelegate/sceneWillEnterForeground(_:)``
     /// - SeeAlso: ``AppQualifyingService/appInfoState``
     /// - SeeAlso: ``MockAppInfoAppInformationProvider``
-    func test_multiple_foreground_initiate_calls_do_not_lead_to_invalid_information_state_transition() async throws {
+    func test_multiple_foreground_initiate_calls_only_evaluate_information_state_once() async throws {
+        let appInformationStates: [AppInformationState] = [
+            .qualified,
+        ]
+        let sessionStatesReceivedExpectation = expectation(description: "expected session states received")
+        sessionStatesReceivedExpectation.assertForOverFulfill = false
+        let sut: AppQualifyingService = .make(appInformationProvider: MockAppInfoAppInformationProvider(appInfoStates: appInformationStates))
+        var receivedSessionStates = [AppInformationState]()
+        let appQualifyingServiceDelegateExpectation = AppQualifyingServiceDelegateExpectation(didChangeAppInfoStateAsFunction: { sessionState in
+            receivedSessionStates.append(sessionState)
+
+            let expectedSessionStateTransitions = Array(appInformationStates.prefix(receivedSessionStates.count))
+            guard receivedSessionStates == expectedSessionStateTransitions else {
+                let issue = XCTIssue(
+                    type: .assertionFailure,
+                    compactDescription: "Received a app information state that was not expected",
+                    detailedDescription: "Sequence of app information states \(receivedSessionStates) does not match expected sequence: \(expectedSessionStateTransitions)."
+                )
+                self.record(issue)
+                sessionStatesReceivedExpectation.fulfill()
+                return
+            }
+
+            if receivedSessionStates.count == appInformationStates.count {
+                sessionStatesReceivedExpectation.fulfill()
+            }
+        })
+
+        sut.delegate = appQualifyingServiceDelegateExpectation
+
+        for _ in 0..<appInformationStates.count {
+            sut.initiate()
+        }
+
+        await sut._initiateTask?.value
+
+        await fulfillment(of: [sessionStatesReceivedExpectation], timeout: 5)
+
+        XCTAssertEqual(receivedSessionStates, appInformationStates)
+    }
+    
+    /// This test aims to reproduce the case of an app entering into the foreground
+    /// which results in a call to ``initiate`` every time.
+    ///
+    /// It asserts that the information state will be evaluated over time as long as the last evaluation
+    /// has been completed.
+    ///
+    /// The test aims to emulate how a follow up call to ``initiate`` once the last one has finished evaluating
+    /// the information state, via ``qualifyAppVersion``, will result in another session state evaluation.
+    ///
+    /// - SeeAlso: ``SceneDelegate/sceneWillEnterForeground(_:)``
+    /// - SeeAlso: ``AppQualifyingService/appInfoState``
+    /// - SeeAlso: ``MockAppInfoAppInformationProvider``
+    func test_foreground_initiate_in_sequence_evaluate_every_information_state() async throws {
+        let appInformationStates: [AppInformationState] = [
+            .qualified,
+            .unavailable,
+        ]
+        let sessionStatesReceivedExpectation = expectation(description: "expected session states received")
+        sessionStatesReceivedExpectation.assertForOverFulfill = false
+        let sut: AppQualifyingService = .make(appInformationProvider: MockAppInfoAppInformationProvider(appInfoStates: appInformationStates))
+        var receivedSessionStates = [AppInformationState]()
+        let appQualifyingServiceDelegateExpectation = AppQualifyingServiceDelegateExpectation(didChangeAppInfoStateAsFunction: { sessionState in
+            receivedSessionStates.append(sessionState)
+
+            let expectedSessionStateTransitions = Array(appInformationStates.prefix(receivedSessionStates.count))
+            guard receivedSessionStates == expectedSessionStateTransitions else {
+                let issue = XCTIssue(
+                    type: .assertionFailure,
+                    compactDescription: "Received a app information state that was not expected",
+                    detailedDescription: "Sequence of app information states \(receivedSessionStates) does not match expected sequence: \(expectedSessionStateTransitions)."
+                )
+                self.record(issue)
+                sessionStatesReceivedExpectation.fulfill()
+                return
+            }
+
+            if receivedSessionStates.count == appInformationStates.count {
+                sessionStatesReceivedExpectation.fulfill()
+            }
+        })
+
+        sut.delegate = appQualifyingServiceDelegateExpectation
+
+        sut.initiate()
+        await sut._initiateTask?.value
+        
+        sut.initiate()
+        await sut._initiateTask?.value
+
+        await fulfillment(of: [sessionStatesReceivedExpectation], timeout: 5)
+
+        XCTAssertEqual(receivedSessionStates, appInformationStates)
+    }
+
+    /// This test aims to reproduce the case of an app entering into the foreground
+    /// which results in a call to ``initiate`` every time.
+    ///
+    /// It asserts that calls to ``qualifyAppVersion`` over time, as long as the last
+    /// ``AppInformationState`` has been evaluated, will correctly transition to the
+    /// next information state.
+    ///
+    /// The test awaits for the evaluation to complete before attempting to initiate a new one. This way
+    /// it aims to emulate how ``initiate`` will create a new task to evaluate the information state
+    /// and how the state will transition over time.
+    ///
+    /// - SeeAlso: ``SceneDelegate/sceneWillEnterForeground(_:)``
+    /// - SeeAlso: ``AppQualifyingService/appInfoState``
+    /// - SeeAlso: ``MockAppInfoAppInformationProvider``
+    func test_multiple_foreground_initiate_calls_over_time_transition_information_state() async throws {
         let appInformationStates: [AppInformationState] = [
             .qualified,
             .unavailable,
@@ -521,13 +705,14 @@ extension AppQualifyingServiceTests {
 
         for _ in 0..<appInformationStates.count {
             sut.initiate()
+            await sut._initiateTask?.value
         }
 
         await fulfillment(of: [sessionStatesReceivedExpectation], timeout: 5)
 
         XCTAssertEqual(receivedSessionStates, appInformationStates)
     }
-    
+
     /// This test aims to reproduce the case of a number of notification posting an update on ``RemoteServiceState``.
     ///
     /// Test that multiple calls to ````AppQualifyingService/serviceState`` do not

--- a/scripts-configs/sonar-project.properties
+++ b/scripts-configs/sonar-project.properties
@@ -9,6 +9,10 @@ sonar.tests=Tests,AppIntegrity/Tests,LocalAuthenticationWrapper/Tests,MobilePlat
 sonar.coverage.exclusions=Sources/Application/TestAppDelegate.swift,Sources/Application/TestingSceneDelegate.swift
 sonar.exclusions=Sources/Application/main.swift,Sources/Application/TestAppDelegate.swift,Sources/Application/TestingSceneDelegate.swift
 
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=swift:S116
+sonar.issue.ignore.multicriteria.e1.resourceKey=Sources/Qualification/State/AppQualifyingService.swift
+
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8
 sonar.pullrequest.provider=github


### PR DESCRIPTION
# [Ensure user session is evaluated once before attempting to evaluate it a second time](https://govukverify.atlassian.net/browse/DCMAW-21048)

The proposed code changes ensure that user session is evaluated once before attempting to evaluate it a second time. In practice this code change guarantees that:
1. ~~Evaluating a user session is done **serially**~~ (This work was done as part of https://github.com/govuk-one-login/mobile-ios-one-login-app/pull/892 which this PR is based on)
2. The number of requests to resume a session are **throttled**

# Discussion
To better demonstrate the issue as described in the ticket, there are a number of commits that lead up to the proposed code changes in this PR. These commits are not part of the code changes. They are merely there for future reference and to provide a step-by-step guide on how to reproduce the issue as well as proof of the underlying cause before finally proposing a fix that provides a remedy to the risks listed in the ticket.

Therefore, it's important that the code changes are reviewed in the sequence the commit arrive before reviewing the proposed code changes described by this PR. In order:

1. [add test to reproduce defect](https://github.com/govuk-one-login/mobile-ios-one-login-app/pull/892/changes/f05094806535c623d11892d48e573a2a7f9a1097)

This test was written first to reproduce and demonstrate the issue as identified in the ticket. When the test is run in this commit, it indeed fails.

<img width="1728" height="1136" alt="failure" src="https://github.com/user-attachments/assets/3c785456-f8bb-4439-bfe3-6f9c4aa73efc" />

2. [proof that serialisation fixes the defect as described in the test](https://github.com/govuk-one-login/mobile-ios-one-login-app/pull/892/changes/a102d8ba0faa5fca3d099e9b52f686b4bcdf04e1)

The changes in this commit are meant to demonstrate that the underlying cause is indeed fixed by serialising execution. When the test is run in this commit, it passes [^1].

<img width="1728" height="1136" alt="serialised" src="https://github.com/user-attachments/assets/4c07a25d-2170-4196-bfe7-334717a5817c" />

[^1]: There is a caveat as described in the **Important Note** found in the commit message.

3. [throttle user session evaluation](https://github.com/govuk-one-login/mobile-ios-one-login-app/commit/ba6f04264c0aee778825de7cb6742845dbb17ae5)

This commit, in addition to serialising also throttles the user evaluation. Thus the test changes to now assert that in case multiple Task(s) are scheduled in quick succession, only 1 app session state will be reported.

The comments in each commit provide more context. Each commit can be independently checked out and verified.

# Testing

While the above test **demonstrates the issue** and asserts the proposed fix, it is not proof that the code has not regressed in any other way in relation to the user evaluation.

In order to test that, the following user scenario was exercised. 

> A user who is already authenticated (i.e. their user session is evaluated as `.saved`) is able to bring the app into the foreground over a period of time and see the home screen

That scenario must satisfy the following product requirements:
* A user will land on the home screen without encountering any errors
* The user session is evaluated as timely as possibly

While exercising the scenario, Instruments was used to monitor the creation, scheduling an execution of tasks while simultaneously a recording of the actual network calls made was captured to confirm the number of requests made as part of resuming a session (and by extension refreshing a token).

Below you can find a video that demonstrates the user behaviour, a timeline of the outbound network calls as well as a screenshot from Instruments of the Swift Tasks, both before and after the proposed code changes in this PR.

## Before

https://github.com/user-attachments/assets/bb8b1855-71ee-4c9b-8711-49361def1c55
<img width="1728" height="1084" alt="Screenshot 2026-07-31 at 17 14 34" src="https://github.com/user-attachments/assets/8fd04e37-6ce8-4fc8-80f6-5f54900f3040" />

## After

https://github.com/user-attachments/assets/e72488c8-1686-49d1-bf56-874a989f555b
<img width="1728" height="1084" alt="Screenshot 2026-07-31 at 17 14 44" src="https://github.com/user-attachments/assets/16b19516-fe61-44da-9fc5-0aefed3ec0c2" />

# Where to focus the review

* Is the issue correctly identified in the ticket?
* Does the test correctly reproduce the issue? Is the test driving the code in an invalid way, makes the wrong assumptions or is misconstructed?
* Does the solution fix the issue without any side effects? Does the test coverage need to be expanded, how?

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
