### PR TITLE
feat: DCMAW-21050 ensure delegate callback does not misrepresent state

### DIFF
--- a/Sources/Qualification/State/AppQualifyingService.swift
+++ b/Sources/Qualification/State/AppQualifyingService.swift
@@ -5,6 +5,7 @@ import MobilePlatformServices
 import Networking
 import SecureStore
 
+@MainActor
 protocol QualifyingService: AnyObject {
     var delegate: AppQualifyingServiceDelegate? { get set }
     func initiate()
@@ -18,6 +19,7 @@ protocol AppQualifyingServiceDelegate: AnyObject {
     func didChangeServiceState(state: RemoteServiceState)
 }
 
+@MainActor
 final class AppQualifyingService: QualifyingService {
     private let analyticsService: OneLoginAnalyticsService
     private let updateService: AppInformationProvider
@@ -26,27 +28,29 @@ final class AppQualifyingService: QualifyingService {
     
     private var appInfoState: AppInformationState = .notChecked {
         didSet {
-            Task {
-                await delegate?.didChangeAppInfoState(state: appInfoState)
+            Task { [appInfoState = appInfoState] in
+                delegate?.didChangeAppInfoState(state: appInfoState)
             }
         }
     }
     
     private var sessionState: AppSessionState = .notLoggedIn {
         didSet {
-            Task {
-                await delegate?.didChangeSessionState(state: sessionState)
+            Task { [sessionState = sessionState] in
+                delegate?.didChangeSessionState(state: sessionState)
             }
         }
     }
     
     private var serviceState: RemoteServiceState = .activeService {
         didSet {
-            Task {
-                await delegate?.didChangeServiceState(state: serviceState)
+            Task { [serviceState = serviceState] in
+                delegate?.didChangeServiceState(state: serviceState)
             }
         }
     }
+
+    let serialTaskQueue: SerialTaskQueue = SerialTaskQueue()
 
     init(
         analyticsService: OneLoginAnalyticsService,
@@ -60,8 +64,10 @@ final class AppQualifyingService: QualifyingService {
     
     public func initiate() {
         Task {
-            await qualifyAppVersion()
-            await evaluateUserSession()
+            try await serialTaskQueue.enqueue {
+                await self.qualifyAppVersion()
+                await self.evaluateUserSession()
+            }
         }
     }
     
@@ -95,7 +101,6 @@ final class AppQualifyingService: QualifyingService {
         }
     }
     
-    @MainActor
     func evaluateUserSession() async {
         guard appInfoState == .qualified else {
             // Do not continue with local auth unless app info qualifies

--- a/Tests/UnitTests/Mocks/Sessions+Services/MockAppInfoService.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/MockAppInfoService.swift
@@ -52,3 +52,51 @@ final class MockAppInformationServiceExpectation: AppInformationProvider {
         return try await mockAppInformationService.fetchAppInfo()
     }
 }
+
+
+final class MockAppInfoAppInformationProvider: AppInformationProvider {
+    
+    var currentVersion: Networking.Version = .init(1, 0, 0)
+
+    private var appInfoStates: [AppInformationState]
+    
+    init(appInfoStates: [AppInformationState]) {
+        self.appInfoStates = appInfoStates
+    }
+
+
+    func fetchAppInfo() async throws -> MobilePlatformServices.App {
+        let appInfoState = self.appInfoStates.removeFirst()
+        
+        switch appInfoState {
+        case .notChecked:
+            return App(minimumVersion: .init(1, 0, 0),
+                       allowAppUsage: true,
+                       releaseFlags: [:],
+                       featureFlags: [:])
+        case .outdated:
+            return App(minimumVersion: .init(2, 0, 0),
+                       allowAppUsage: true,
+                       releaseFlags: [:],
+                       featureFlags: [:])
+        case .qualified:
+            return App(minimumVersion: .init(1, 0, 0),
+                       allowAppUsage: true,
+                       releaseFlags: [:],
+                       featureFlags: [:])
+        case .unavailable:
+            return App(minimumVersion: .init(1, 1, 0),
+                       allowAppUsage: false,
+                       releaseFlags: [:],
+                       featureFlags: [:])
+        case .offline:
+            throw AppInfoError.notConnectedToInternet
+        case .error:
+            throw URLError(.badServerResponse)
+        }
+    }
+    
+    
+    
+    
+}

--- a/Tests/UnitTests/Mocks/Sessions+Services/MockAppInfoService.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/MockAppInfoService.swift
@@ -95,8 +95,4 @@ final class MockAppInfoAppInformationProvider: AppInformationProvider {
             throw URLError(.badServerResponse)
         }
     }
-    
-    
-    
-    
 }

--- a/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockSessionManager.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockSessionManager.swift
@@ -237,3 +237,76 @@ class MockSessionManagerExpectation: SessionManager {
         try await sessionManager.clearAppForLogin()
     }
 }
+
+/// A mock that emulates the fact that ``sessionState`` can change over time similar to the implementation of
+/// ``PersistentSessionManager``, including while waiting for``resumeSession`` to return.
+///
+/// Specifically, this mock:
+/// * Dispenses a new ``sessionState`` each time one is requested to emulate state changes over time
+/// * Adds a **random delay** on a call to ``resumeSession`` to emulate the variability and delay of a network response
+
+/// Use this mock to write a test that will fail **should the code under test detects an unexpected state transition that can arise
+/// when waiting for ``resumeSession``**, in adition to the test assertions.
+///
+/// You create an instance of this mock using ``init(sessionStates:)`` by passing a list of `sessionStates` that will
+/// be dispensed in order first in; first out.
+final class MockResumeSessionSessionManager: SessionManager {
+    private var sessionStates: [SessionState]
+    var sessionState: SessionState {
+        sessionStates.removeFirst()
+    }
+
+    var expiryDate: Date? = .distantFuture
+    var isReturningUser = true
+    var isEnrolling = false
+    var validTokensForRefreshExchange: (idToken: String, refreshToken: String)?
+    var tokenProvider = TokenHolder()
+    var localAuthentication: LocalAuthManaging = MockLocalAuthManager()
+    var persistentID: String? = UUID().uuidString
+    var walletStoreID: String?
+    var user = CurrentValueSubject<(any OneLogin.User)?, Never>(nil)
+
+    /// Creates a new ``MockResumeSessionSessionManager`` that will use the given ``sessionStates`` to return
+    /// one ``SessionState`` at a time when the call to ``sessionState`` is made.
+    ///
+    /// Each ``SessionState`` that follows the one previously is meant to represent a **valid transition** between states for the time span they represent.
+    /// e.g.
+    /// * `[.saved, .expired]
+    /// * `[.nonePresent, .saved, .expired]
+    ///
+    /// both represent valid states and transitions for their respective time span under test;
+    /// * a user has authenticated, their session has expired
+    /// * no user has not attempted to authenticate, a user has authenticated, their session has expired.
+    ///
+    /// respectively.
+    ///
+    /// - parameter sessionStates: The list of ``SessionState`` **you expect** to be dispensed in order, first in; first out.
+    init(sessionStates: [SessionState]) {
+        self.sessionStates = sessionStates
+    }
+
+    func startAuthSession(
+        _ session: any LoginSession,
+        using configuration: @Sendable (String?) async throws -> LoginSessionConfiguration
+    ) async throws { }
+
+    func saveAuthSession() throws { }
+
+    func saveLoginTokens(
+        idToken: String?,
+        refreshToken: String?,
+        accessToken: String?,
+        accessTokenExpiry: Date?
+    ) throws { }
+
+    func resumeSession() async throws {
+        // 100ms to 1 second
+        try await Task.sleep(nanoseconds: UInt64.random(in: 100_000_000...1_000_000_000))
+    }
+
+    func endCurrentSession() { }
+
+    func clearAllSessionData(presentSystemLogOut: Bool) async throws { }
+
+    func clearAppForLogin() async throws { }
+}

--- a/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
+++ b/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
@@ -370,6 +370,236 @@ extension AppQualifyingServiceTests {
         XCTAssert(sessionManager.didCallClearAllSessionData)
         XCTAssertEqual(sessionState, .failed(MockWalletError.cantDelete))
     }
+    
+    /// This test aims to reproduce the case of an app entering into the foreground
+    /// which results in a call to ``initiate`` every time.
+    ///
+    /// Test that multiple calls to ``initiate`` do not result in an invalid ``AppSessionState`` to be received
+    /// while waiting for ``PersistentSessionManager`` to resume the session.
+    ///
+    /// The ``initiate`` function asyncronously attempts to evaluate the user session (i.e. ``evaluateUserSession``).
+    /// In case of a `.saved` sessionState,  the  ``AppQualifyingService`` will attempt to call
+    ///  ``SessionManager/resumeSession`` in order to update the sessionState (in case its succesful, this will
+    ///  also result in a  `.saved` sessionState, which next time will will attempt to call
+    ///  ``SessionManager/resumeSession`` and so on and so forth).
+    ///
+    /// While waiting, a second ``evaluateUserSession`` arrives (potentially a third, a fourth etc.) that may now
+    /// resolve the user session to new application state (e.g. .expired) just as the ``resumeSession`` returns.
+    ///
+    /// Potentially resulting to either an unexpected application state or an invalid transition between states.
+    ///
+    /// This test aims to catch such a case of an invalid transition between states by using a mock ``SessionManager``
+    /// that dispenses each ``SessionState`` in the given order, as expected by the test, and adding
+    /// an artificial delay when resuming a session so as the next call to ``initiate`` will attempt to read
+    /// the session state while the previous one awaits.
+    ///
+    /// The test invokes the ``initiate`` function is quick succession so as to generate concurrent pressure
+    /// by **scheduling of tasks** since ``initiate`` merely creates a tak and there is no way to control/manage
+    /// Task execution.
+    ///
+    /// In other words, this test aims to emulate what would happen should a number of Task(s) have been scheduled
+    /// for execution over a short period of time. Creating lots of Tasks in a short period of time aims to *force* the
+    /// system to execute themconcurrently. As of today, 13 number of tasks appear to apply enough concurrent pressure.
+    /// *This may change in the future*
+    ///
+    /// - SeeAlso: ``SceneDelegate/sceneWillEnterForeground(_:)`
+    /// - SeeAlso: ``MockResumeSessionSessionManager``
+    func test_multiple_foreground_initiate_calls_do_not_lead_to_invalid_session_state_transition() async throws {
+        let sessionStates: [SessionState] = [
+            .nonePresent,
+            .enrolling,
+            .oneTime,
+            .saved,
+            .expired,
+            .saved,
+            .expired,
+            .saved,
+            .nonePresent,
+            .enrolling,
+            .saved,
+            .expired,
+            .saved
+        ]
+        let expectedAppSessionStateTransitions = sessionStates.map(\.expectedAppSessionState)
+        let sessionStatesReceivedExpectation = expectation(description: "expected session states received")
+        sessionStatesReceivedExpectation.assertForOverFulfill = false
+        let sessionManager = MockResumeSessionSessionManager(sessionStates: sessionStates)
+        let sut: AppQualifyingService = .make(sessionManager: sessionManager)
+        var receivedSessionStates = [AppSessionState]()
+        let appQualifyingServiceDelegateExpectation = AppQualifyingServiceDelegateExpectation(didChangeSessionStateAsFunction: { sessionState in
+            receivedSessionStates.append(sessionState)
+
+            let expectedSessionStateTransitions = Array(expectedAppSessionStateTransitions.prefix(receivedSessionStates.count))
+            guard receivedSessionStates == expectedSessionStateTransitions else {
+                let issue = XCTIssue(
+                    type: .assertionFailure,
+                    compactDescription: "Received a session state that was not expected",
+                    detailedDescription: "Sequence of received session states \(receivedSessionStates) does not match expected sequence: \(expectedSessionStateTransitions)."
+                )
+                self.record(issue)
+                sessionStatesReceivedExpectation.fulfill()
+                return
+            }
+
+            if receivedSessionStates.count == expectedAppSessionStateTransitions.count {
+                sessionStatesReceivedExpectation.fulfill()
+            }
+        })
+
+        sut.delegate = appQualifyingServiceDelegateExpectation
+
+        for _ in 0..<sessionStates.count {
+            sut.initiate()
+        }
+
+        await fulfillment(of: [sessionStatesReceivedExpectation], timeout: 5)
+
+        XCTAssertEqual(receivedSessionStates, expectedAppSessionStateTransitions)
+    }
+    
+    /// This test aims to reproduce the case of an app entering into the foreground
+    /// which results in a call to ``initiate`` every time.
+    ///
+    /// Test that multiple calls to ``qualifyAppVersion`` do not result in an invalid ``AppInformationState`` to be received.
+    ///
+    /// The ``initiate`` function asyncronously attempts to evaluate the app version (i.e. ``qualifyAppVersion``).
+    ///
+    /// Since the ``AppQualifyingService`` **schedules a Task** to perform a callback to the delegate, it's possible that
+    /// by the time the task runs and reads the value, the value has since change from another call to ``qualifyAppVersion``
+    ///
+    /// Potentially resulting to either an unexpected app information state or an invalid transition between states.
+    ///
+    /// This test aims to catch such a case of an invalid transition between states by using a mock ``AppInformationProvider``
+    /// that dispenses each ``AppInformationState`` in the given order, as expected by the test.
+    ///
+    /// The test invokes the ``initiate`` function is quick succession so as to generate concurrent pressure
+    /// by **scheduling of tasks** since ``qualifyAppVersion`` merely creates a task and there is no way to control/manage
+    /// Task execution.
+    ///
+    /// In other words, this test aims to emulate what would happen should a number of Task(s) have been scheduled
+    /// for execution over a short period of time. Creating lots of Tasks in a short period of time aims to *force* the
+    /// system to execute themconcurrently. As of today, 6 number of tasks appear to apply enough concurrent pressure.
+    /// *This may change in the future*
+    ///
+    /// - SeeAlso: ``SceneDelegate/sceneWillEnterForeground(_:)``
+    /// - SeeAlso: ``AppQualifyingService/appInfoState``
+    /// - SeeAlso: ``MockAppInfoAppInformationProvider``
+    func test_multiple_foreground_initiate_calls_do_not_lead_to_invalid_information_state_transition() async throws {
+        let appInformationStates: [AppInformationState] = [
+            .qualified,
+            .unavailable,
+            .offline,
+            .qualified,
+            .outdated,
+            .error
+        ]
+        let sessionStatesReceivedExpectation = expectation(description: "expected session states received")
+        sessionStatesReceivedExpectation.assertForOverFulfill = false
+        let sut: AppQualifyingService = .make(appInformationProvider: MockAppInfoAppInformationProvider(appInfoStates: appInformationStates))
+        var receivedSessionStates = [AppInformationState]()
+        let appQualifyingServiceDelegateExpectation = AppQualifyingServiceDelegateExpectation(didChangeAppInfoStateAsFunction: { sessionState in
+            receivedSessionStates.append(sessionState)
+
+            let expectedSessionStateTransitions = Array(appInformationStates.prefix(receivedSessionStates.count))
+            guard receivedSessionStates == expectedSessionStateTransitions else {
+                let issue = XCTIssue(
+                    type: .assertionFailure,
+                    compactDescription: "Received a app information state that was not expected",
+                    detailedDescription: "Sequence of app information states \(receivedSessionStates) does not match expected sequence: \(expectedSessionStateTransitions)."
+                )
+                self.record(issue)
+                sessionStatesReceivedExpectation.fulfill()
+                return
+            }
+
+            if receivedSessionStates.count == appInformationStates.count {
+                sessionStatesReceivedExpectation.fulfill()
+            }
+        })
+
+        sut.delegate = appQualifyingServiceDelegateExpectation
+
+        for _ in 0..<appInformationStates.count {
+            sut.initiate()
+        }
+
+        await fulfillment(of: [sessionStatesReceivedExpectation], timeout: 5)
+
+        XCTAssertEqual(receivedSessionStates, appInformationStates)
+    }
+    
+    /// This test aims to reproduce the case of a number of notification posting an update on ``RemoteServiceState``.
+    ///
+    /// Test that multiple calls to ````AppQualifyingService/serviceState`` do not
+    /// result in an invalid ``RemoteServiceState`` published.
+    ///
+    /// Since the ``AppQualifyingService`` **schedules a Task** to perform a callback to the delegate, it's possible that
+    /// by the time the task runs and reads the value, the value has since change from another call to ``serviceState``
+    ///
+    /// Potentially resulting to either an unexpected remote service information state or an invalid transition between states.
+    ///
+    /// This test aims to catch such a case of an invalid transition between states by posting a number of notifications
+    /// and expects them to arrive in the same order, as posted.
+    ///
+    /// The test posts notifications in  quick succession so as to generate concurrent pressure
+    /// by **scheduling of tasks** since ``serviceState`` merely creates a task and there is no way to control/manage
+    /// Task execution.
+    ///
+    /// In other words, this test aims to emulate what would happen should a number of Task(s) have been scheduled
+    /// for execution over a short period of time. Creating lots of Tasks in a short period of time aims to *force* the
+    /// system to execute themconcurrently. As of today, 2 number of tasks appear to apply enough concurrent pressure.
+    /// *This may change in the future*
+    ///
+    /// - SeeAlso: ``AppQualifyingService/subscribe``
+    func test_multiple_serviceState_notifications_do_not_lead_to_invalid_service_state_transition() async throws {
+        let serviceStates: [RemoteServiceState] = [
+            .accountIntervention,
+            .reauthenticationRequired
+        ]
+        let sessionStatesReceivedExpectation = expectation(description: "expected session states received")
+        sessionStatesReceivedExpectation.assertForOverFulfill = false
+        let sut: AppQualifyingService = .make()
+        var receivedSessionStates = [RemoteServiceState]()
+        let appQualifyingServiceDelegateExpectation = AppQualifyingServiceDelegateExpectation(didChangeServiceStateAsFunction: { sessionState in
+            receivedSessionStates.append(sessionState)
+
+            let expectedServiceStates = Array(serviceStates.prefix(receivedSessionStates.count))
+            guard receivedSessionStates == expectedServiceStates else {
+                let issue = XCTIssue(
+                    type: .assertionFailure,
+                    compactDescription: "Received a remove service state that was not expected",
+                    detailedDescription: "Sequence of received remote service states \(receivedSessionStates) does not match expected sequence: \(expectedServiceStates)."
+                )
+                self.record(issue)
+                sessionStatesReceivedExpectation.fulfill()
+                return
+            }
+
+            if receivedSessionStates.count == expectedServiceStates.count {
+                sessionStatesReceivedExpectation.fulfill()
+            }
+        })
+
+        sut.delegate = appQualifyingServiceDelegateExpectation
+
+        let notifications: [Notification.Name] = serviceStates.compactMap { remoteServiceState in
+            switch remoteServiceState {
+            case .accountIntervention:
+                return .accountIntervention
+            case .reauthenticationRequired:
+                return .reauthenticationRequired
+            default:
+                return nil
+            }
+        }
+        for notification in notifications {
+            NotificationCenter.default.post(name: notification)
+        }
+
+        await fulfillment(of: [sessionStatesReceivedExpectation], timeout: 5)
+
+        XCTAssertEqual(receivedSessionStates, serviceStates)
+    }
 }
 
 // MARK: - Subscription Tests
@@ -475,6 +705,7 @@ extension AppQualifyingServiceTests {
     }
 }
 
+@MainActor
 class AppQualifyingServiceDelegateExpectation: AppQualifyingServiceDelegate {
     
     typealias DidChangeAppInfoState = (AppInformationState) -> Void
@@ -503,5 +734,18 @@ class AppQualifyingServiceDelegateExpectation: AppQualifyingServiceDelegate {
     
     func didChangeServiceState(state: RemoteServiceState) {
         self.didChangeServiceStateAsFunction(state)
+    }
+}
+
+private extension SessionState {
+    var expectedAppSessionState: AppSessionState {
+        switch self {
+        case .expired:
+            return .expired
+        case .enrolling, .nonePresent:
+            return .notLoggedIn
+        case .oneTime, .saved:
+            return .loggedIn
+        }
     }
 }


### PR DESCRIPTION
# [iOS | Tech Debt | A delegate callback on the sessionState, appInfoState and (possibly) the serviceState is sensitive to timings and may report an unexpected/wrong state.](https://govukverify.atlassian.net/browse/DCMAW-21050)

The proposed code changes ensure `AppQualifyingService` reliably reports on `AppInformationState`, `AppSessionState` and `RemoteServiceState` state and transitions.

# Changes
The fix requires 2 changes:

1. Calls on `qualifyAppVersion` and `evaluateUserSession` across different scheduled Task(s) due to multiple calls to `initiate()` over time is serialised

2. The callback on to report on each state `AppInformationState`, `AppSessionState`, `RemoteServiceState` is done with the value that has just been written at the time the Task is created instead of the value it has when its executed.

# Testing
[One commit](https://github.com/govuk-one-login/mobile-ios-one-login-app/commit/f05094806535c623d11892d48e573a2a7f9a1097), adds a test to reproduce defect:

<img width="1728" height="1136" alt="Screenshot 2026-08-03 at 14 27 11" src="https://github.com/user-attachments/assets/3adb79dd-aa31-458e-9211-14647acca303" />
<img width="1728" height="1136" alt="Screenshot 2026-08-03 at 14 27 19" src="https://github.com/user-attachments/assets/e7b94534-03ee-4761-9c17-4a1d9a73fa40" />

[Second commit](https://github.com/govuk-one-login/mobile-ios-one-login-app/pull/892/changes/a102d8ba0faa5fca3d099e9b52f686b4bcdf04e1) with the code changes that fixes the issue. Each test run for 100 iterations to have high confidence there is no timing at play:

<img width="1728" height="1136" alt="Screenshot 2026-08-03 at 14 54 55" src="https://github.com/user-attachments/assets/2cb6c8c9-a5a2-4e97-83b6-c22e8fa937b6" />
<img width="1728" height="1136" alt="Screenshot 2026-08-03 at 14 55 17" src="https://github.com/user-attachments/assets/434b6ba6-aba9-4b01-bc5b-8688753abc0f" />


# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
