### PR TITLE
fix: DCMAW-22002: Fix checkov error

### DIFF
--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -1,0 +1,2 @@
+skip-path:
+  - Tests/UnitTests/Mocks

--- a/.github/workflows/run_unit_tests_and_send_coverage_report.yml
+++ b/.github/workflows/run_unit_tests_and_send_coverage_report.yml
@@ -45,15 +45,18 @@ jobs:
           GIT_CONFIG_GLOBAL: '${{ github.workspace }}/scripts-configs/override-git-config'
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           TEST_PLAN: "OneLoginUnit"
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_WORKSPACE: ${{ github.workspace }}
         run: |
           xctestrun=$(find . -name "*.xctestrun" | grep -i "${TEST_PLAN}")
           pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
 
           bundle exec fastlane testWithoutBuilding scheme:"OneLoginBuild" \
             xctestrun:"${xctestrun}" \
-            workspace:${{ github.workspace }} \
-            source_branch:${{ github.head_ref }} \
-            target_branch:${{ github.base_ref }} \
+            workspace:"$GITHUB_WORKSPACE" \
+            source_branch:"$GITHUB_HEAD_REF" \
+            target_branch:"$GITHUB_BASE_REF" \
             pr_number:$pull_number
 
       # Check the Quality Gate status.

--- a/.github/workflows/run_unit_tests_and_send_coverage_report.yml
+++ b/.github/workflows/run_unit_tests_and_send_coverage_report.yml
@@ -54,9 +54,9 @@ jobs:
 
           bundle exec fastlane testWithoutBuilding scheme:"OneLoginBuild" \
             xctestrun:"${xctestrun}" \
-            workspace:"$GITHUB_WORKSPACE" \
-            source_branch:"$GITHUB_HEAD_REF" \
-            target_branch:"$GITHUB_BASE_REF" \
+            workspace:"${GITHUB_WORKSPACE}" \
+            source_branch:"${GITHUB_HEAD_REF}" \
+            target_branch:"${GITHUB_BASE_REF}" \
             pr_number:$pull_number
 
       # Check the Quality Gate status.


### PR DESCRIPTION
# Description

The failure CKV_GHA_2 occurs because GitHub Actions context expressions (like ${{ github.head_ref }}) are directly expanded into inline bash scripts before execution.

If a user creates a pull request from a maliciously named branch (e.g., main; rm -rf /), that string will be interpolated directly into the script line, causing arbitrary command execution.

By mapping ${{ github.head_ref }} to an environment variable (PULL_HEAD_REF), the shell treats the value strictly as a data string inside standard double quotes ("$PULL_HEAD_REF"), eliminating shell code execution risks.

Additionally, regarding the secret scan failures, these failures are occurring because Checkov's secret scanner is flagging mock token data inside the unit test fixtures.
As Tests/UnitTests/Mocks/ only contains test fixtures and will never contain real production credentials, I have configured Checkov to skip that entire directory.

Passing:
<img width="434" height="223" alt="Screenshot 2026-08-11 at 16 13 00" src="https://github.com/user-attachments/assets/b860cfc7-e26a-4b3b-926f-c0db998604fa" />


# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [ ] Ran the app locally ensuring it builds 
- [ ] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
