### PR TITLE
fix: DCMAW-22784 navigation bar button tintColor not applied for iOS 26

### DIFF
--- a/Sources/Application/SceneDelegate.swift
+++ b/Sources/Application/SceneDelegate.swift
@@ -90,7 +90,11 @@ final class SceneDelegate: UIResponder,
         )
         UITabBar.appearance().backgroundColor = .systemBackground
         
-        // Bar button items color
-        UIBarButtonItem.appearance(whenContainedInInstancesOf: [UINavigationBar.self]).tintColor = .accent
+        if #available(iOS 26.0, *) {
+            // No color applied to navigation bar items for iOS 26 and higher
+        } else {
+            // Apply navigation bar button item color to iOS lower than 26
+            UIBarButtonItem.appearance(whenContainedInInstancesOf: [UINavigationBar.self]).tintColor = .accent
+        }
     }
 }

--- a/Sources/Application/SceneDelegate.swift
+++ b/Sources/Application/SceneDelegate.swift
@@ -90,9 +90,7 @@ final class SceneDelegate: UIResponder,
         )
         UITabBar.appearance().backgroundColor = .systemBackground
         
-        if #available(iOS 26.0, *) {
-            // No color applied to navigation bar items for iOS 26 and higher
-        } else {
+        if #unavailable(iOS 26.0) {
             // Apply navigation bar button item color to iOS lower than 26
             UIBarButtonItem.appearance(whenContainedInInstancesOf: [UINavigationBar.self]).tintColor = .accent
         }

--- a/Tests/UnitTests/Application/SceneDelegateTests.swift
+++ b/Tests/UnitTests/Application/SceneDelegateTests.swift
@@ -30,6 +30,10 @@ final class SceneDelegateTests: XCTestCase {
     func test_setUpBasicUI_barButtonItemTintColor() {
         sut.setUpBasicUI()
         let appearance = UIBarButtonItem.appearance(whenContainedInInstancesOf: [UINavigationBar.self])
-        XCTAssertEqual(appearance.tintColor, .accent)
+        if #available(iOS 26.0, *) {
+            XCTAssertNil(appearance.tintColor)
+        } else {
+            XCTAssertEqual(appearance.tintColor, .accent)
+        }
     }
 }


### PR DESCRIPTION
# fix: DCMAW-22784 navigation bar button tintColor not applied for iOS 26
 

**iOS 26.0 and higher - Navigation bar buttons have no color**

https://github.com/user-attachments/assets/c62b38f6-cf3f-4dbd-8fb3-113cc4a6ed68


https://github.com/user-attachments/assets/e2f9387d-32a7-4ddb-8269-16f84d7190b4


**iOS 18.6 (all iOS before 26.0)**

https://github.com/user-attachments/assets/0617ba7b-e693-4df6-b0e1-e2b16cf517e0


https://github.com/user-attachments/assets/cba1ee6d-0f55-4f94-86fd-5e93e989c1e9


# Checklist

## Before raising your pull request:
- [ ] Commit messages that conform to conventional commit messages
- [ ] Ran the app locally ensuring it builds 
- [ ] Ran the tests locally ensuring they pass on Build
- [ ] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
