### PR TITLE
feat: DCMAW-20314 adopt WalletSDK/delete

### DIFF
--- a/OneLogin.xcodeproj/project.pbxproj
+++ b/OneLogin.xcodeproj/project.pbxproj
@@ -400,6 +400,7 @@
 		8E9587DA2F45E6E80073A475 /* AppIntegrityErrorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9587D92F45E6E80073A475 /* AppIntegrityErrorViewModelTests.swift */; };
 		8E9A51852FDAEA4500F4C93A /* LoginSessionConfiguration+OneLoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9A51842FDAEA4500F4C93A /* LoginSessionConfiguration+OneLoginTests.swift */; };
 		8EA9FDBB2F3CE17E00C52D4D /* AppIntegrityErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EA9FDBA2F3CE17E00C52D4D /* AppIntegrityErrorViewModel.swift */; };
+		997E16863041D48C006E9940 /* WalletSessionDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 997E16853041D488006E9940 /* WalletSessionDataTests.swift */; };
 		9996E02F30064DF900AB019B /* FirebaseAppIntegrityService+Mocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9996E02E30064DF400AB019B /* FirebaseAppIntegrityService+Mocks.swift */; };
 		99AEB1C52FFCFB2E00F834BB /* PersistentSessionManager+Mocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99AEB1C42FFCFB2E00F834BB /* PersistentSessionManager+Mocks.swift */; };
 		AB24C1132DB94A5F0080141C /* LocalAuthSettingsErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB24C1122DB948520080141C /* LocalAuthSettingsErrorViewModel.swift */; };
@@ -1051,6 +1052,7 @@
 		8E9587D92F45E6E80073A475 /* AppIntegrityErrorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntegrityErrorViewModelTests.swift; sourceTree = "<group>"; };
 		8E9A51842FDAEA4500F4C93A /* LoginSessionConfiguration+OneLoginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoginSessionConfiguration+OneLoginTests.swift"; sourceTree = "<group>"; };
 		8EA9FDBA2F3CE17E00C52D4D /* AppIntegrityErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntegrityErrorViewModel.swift; sourceTree = "<group>"; };
+		997E16853041D488006E9940 /* WalletSessionDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSessionDataTests.swift; sourceTree = "<group>"; };
 		9996E02E30064DF400AB019B /* FirebaseAppIntegrityService+Mocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FirebaseAppIntegrityService+Mocks.swift"; sourceTree = "<group>"; };
 		99AEB1C42FFCFB2E00F834BB /* PersistentSessionManager+Mocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistentSessionManager+Mocks.swift"; sourceTree = "<group>"; };
 		AB24C1122DB948520080141C /* LocalAuthSettingsErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAuthSettingsErrorViewModel.swift; sourceTree = "<group>"; };
@@ -1866,6 +1868,7 @@
 		7C7A763C2C9433A900EE85CB /* Service */ = {
 			isa = PBXGroup;
 			children = (
+				997E16853041D488006E9940 /* WalletSessionDataTests.swift */,
 				1E69F8722EF08A4100D8A292 /* NetworkingServiceTests.swift */,
 			);
 			path = Service;
@@ -3864,6 +3867,7 @@
 				ABC6B3D72E141A3900B41C6E /* UnrecoverableLoginErrorViewModelTests.swift in Sources */,
 				41CCE1362C77657600FFBE64 /* UpdateAppViewModelTests.swift in Sources */,
 				7CA719682C846E7600973585 /* URLRequest+OneLoginTests.swift in Sources */,
+				997E16863041D48C006E9940 /* WalletSessionDataTests.swift in Sources */,
 				C8AA3B352BF4CF500093A220 /* WalletCoordinatorTests.swift in Sources */,
 				C84960012EBDFC6F0065CA40 /* UserDefaults+OneLoginTests.swift in Sources */,
 				41279DD72BFF46DB00E16537 /* SignOutConfirmationViewModelTests.swift in Sources */,

--- a/Sources/Service/WalletSessionData+OneLogin.swift
+++ b/Sources/Service/WalletSessionData+OneLogin.swift
@@ -1,16 +1,152 @@
 import Wallet
+import WalletStore
 
-struct WalletSessionData: SessionBoundData {
+/// Use to clear session data related to Wallet.
+///
+/// - SeeAlso: ``clearSessionData()`` for how to clear the session data.
+/// - SeeAlso: ``streamClearSessionDataWarnings`` on how to best consume a stream of warnings.
+actor WalletSessionData: SessionBoundData {
+    
+    /// Use to stream warnings emitted by each call to ``clearSessionData()``.
+    ///
+    /// To receive the warnings emitted by a call to ``clearSessionData()``, obtain the warning stream first
+    /// followed by a call to ``clearSessionData()``.
+    ///
+    /// There are two recommended ways to consume the stream, in order of preference:
+    /// 1. As a structured task, using `async let`.
+    /// 2. As a `Task` scoped to observing the warnings.
+    ///
+    /// For example, using a structured task.
+    ///
+    /// ```
+    /// func clearSessionData(
+    ///     walletSessionData: WalletSessionData
+    /// ) async throws {
+    ///     let warnings = await walletSessionData.streamClearSessionDataWarnings
+    ///
+    ///     async let logWarnings: Void = {
+    ///         for await warning in warnings {
+    ///             analyticsService.logCrash(warning)
+    ///         }
+    ///     }()
+    ///
+    ///     try await walletSessionData.clearSessionData()
+    ///     await logWarnings
+    /// }
+    /// ```
+    ///
+    /// Alternatively, using a `Task`.
+    /// You should ensure that the task is cancelled irrespective of how ``clearSessionData`` completes;
+    /// either succesfully or by throwing an error.
+    ///
+    /// ```
+    /// func clearSessionData(
+    ///     walletSessionData: WalletSessionData
+    /// ) async throws {
+    ///     let warnings = await walletSessionData.streamClearSessionDataWarnings
+    ///
+    ///     let logWarnings = Task {
+    ///         for await warning in warnings {
+    ///             analyticsService.logCrash(warning)
+    ///         }
+    ///     }
+    ///
+    ///     defer {
+    ///         logWarnings.cancel()
+    ///     }
+    ///
+    ///     try await walletSessionData.clearSessionData()
+    ///     await logWarnings.value
+    /// }
+    /// ```
+    ///
+    /// You **must** wait for ``clearSessionData()`` to complete before obtaining another stream;
+    /// overlapping calls are not supported and may result in warnings being lost.
+    ///
+    /// - SeeAlso: ``clearSessionData()`` for how warnings are produced.
+    ///
+    /// - Note: If a ``WalletSessionData`` instance is unexpectedly retained, a consumer waiting
+    /// on a stream will remain suspended in the case of either omitting a call to ``clearSessionData()``
+    /// or the observation task is not cancelled.
+    private(set) var streamClearSessionDataWarnings: AsyncStream<WalletStoreError>
+    private var clearSessionDataWarnings: AsyncStream<WalletStoreError>.Continuation
+
+    private let walletSDK: WalletServiceProtocol
+    
+    public init(walletSDK: WalletServiceProtocol = WalletSDKWrapper.instance) {
+        self.walletSDK = walletSDK
+        (streamClearSessionDataWarnings, clearSessionDataWarnings) = AsyncStream<WalletStoreError>.makeStream()
+    }
+    
+    deinit {
+        clearSessionDataWarnings.finish()
+    }
+    
+    /// Clears session data related to Wallet.
+    ///
+    /// Optionally, you can receive "warnings" via the ``streamClearSessionDataWarnings`` stream.
+    /// "Warnings" conform to Error type that are NOT thrown thus not available to `catch`.
+    ///
+    /// Should you wish to observe any warnings when attempting to clear session data, make sure you subscribe to
+    /// the ``streamClearSessionDataWarnings``  before making the call to ``clearSessionData()``
+    ///
+    /// e.g.
+    ///
+    /// ```
+    /// var oneWarningsStream = walletSessionData.streamClearSessionDataWarnings.makeAsyncIterator()
+    /// try await walletSessionData.clearSessionData()
+    ///
+    /// await oneWarningsStream.next() // to receive warnings from **one** call to clearSessionData
+    ///
+    /// var anotherWarningsStream = walletSessionData.streamClearSessionDataWarnings.makeAsyncIterator()
+    /// try await walletSessionData.clearSessionData()
+    ///
+    /// await anotherWarningsStream.next() // to receive warnings from **another** call to clearSessionData
+    /// ```
+    ///
+    /// The ``streamClearSessionDataWarnings`` stream, produces warnings by making a call to  ``clearSessionData()``.
+    /// Once the function returns, the stream closes. Any warnings already emitted by the
+    /// last call to ``clearSessionData()`` remain available until they are consumed.
+    ///
+    /// - throws: all errors thrown by ``WalletSDK/delete()`` that are considered "critical".
+    /// - SeeAlso: ``WalletSDKWrapper/delete()``
+    /// - Remark: You should not make calls to `clearSessionData()` that overlap. This is a misuse of the API and
+    ///     may lead to missing and/or unexpected warnings.
+    /// - Note: For any errors that are not "critical" the ``WalletSDK`` classifies them as
+    /// "warnings" and are intented to be "informatonal" only (e.g. loggged for observability)
     func clearSessionData() async throws {
-        try await WalletSDK.deleteData()
+        let continuation = clearSessionDataWarnings
+        
+        defer {
+            continuation.finish()
+            (streamClearSessionDataWarnings, clearSessionDataWarnings) = AsyncStream<WalletStoreError>.makeStream()
+        }
+        
+        for error in try await walletSDK.delete() {
+            continuation.yield(error)
+        }
     }
 }
 
 protocol WalletServiceProtocol {
+    func delete() async throws(WalletStoreError) -> [WalletStoreError]
     func isEmpty() async -> Bool
 }
 
 struct WalletSDKWrapper: WalletServiceProtocol {
+    
+    static let instance = WalletSDKWrapper()
+    
+    /// Use ``instance`` to obtain a reference.
+    private init() {
+        // the `WalletSDKWrapper` is meant to represent an instance of the WalletSDK
+        // when using its static function. Thus, using a `init` is moot.
+    }
+    
+    func delete() async throws(WalletStoreError) -> [WalletStoreError] {
+        try await WalletSDK.delete()
+    }
+    
     func isEmpty() async -> Bool {
         return await WalletSDK.isEmpty()
     }

--- a/Sources/Utilities/Storage/Session/PersistentSessionManager.swift
+++ b/Sources/Utilities/Storage/Session/PersistentSessionManager.swift
@@ -14,8 +14,9 @@ final class PersistentSessionManager: SessionManager {
         accessControlEncryptedSecureStoreMigrator: (any SecureStorable & SessionBoundData)? = nil,
         encryptedStore: (any SecureStorable & SessionBoundData)? = nil,
         unprotectedStore: (any DefaultsStoring & SessionBoundData) = UserDefaults.standard,
+        localAuthentication: LocalAuthManaging = LocalAuthenticationWrapper(localAuthStrings: .oneLogin),
         analyticsService: OneLoginAnalyticsService,
-        walletSDK: WalletServiceProtocol = WalletSDKWrapper(),
+        walletSDK: WalletServiceProtocol = WalletSDKWrapper.instance,
         walletSessionData: SessionBoundData = WalletSessionData(),
         refreshTokenExchangeManager: TokenExchangeManaging,
         serialTaskQueue: SerialTaskQueue,
@@ -32,7 +33,7 @@ final class PersistentSessionManager: SessionManager {
                 accessControlEncryptedStore: accessControlEncryptedSecureStoreMigrator
             ),
             unprotectedStore: unprotectedStore,
-            localAuthentication: LocalAuthenticationWrapper(localAuthStrings: .oneLogin),
+            localAuthentication: localAuthentication,
             analyticsService: analyticsService,
             walletSDK: walletSDK,
             tokenExchangeManager: refreshTokenExchangeManager,
@@ -94,7 +95,7 @@ final class PersistentSessionManager: SessionManager {
         unprotectedStore: DefaultsStoring,
         localAuthentication: LocalAuthManaging,
         analyticsService: OneLoginAnalyticsService,
-        walletSDK: WalletServiceProtocol = WalletSDKWrapper(),
+        walletSDK: WalletServiceProtocol = WalletSDKWrapper.instance,
         tokenExchangeManager: TokenExchangeManaging,
         serialTaskQueue: SerialTaskQueue = SerialTaskQueue()
     ) {
@@ -380,25 +381,38 @@ final class PersistentSessionManager: SessionManager {
     }
     
     func clearAppForLogin() async throws {
-        for each in sessionBoundData where type(of: each) != UserDefaultsPreferenceStore.self {
-            try await each.clearSessionData()
-        }
-        
-        endCurrentSession()
+        let excludingUserDefaultsPreferenceStore = sessionBoundData.filter { type(of: $0 ) != UserDefaultsPreferenceStore.self }
+        try await self.clearSessionData(in: excludingUserDefaultsPreferenceStore, presentSystemLogOut: false)
     }
 
     func clearAllSessionData(presentSystemLogOut: Bool) async throws {
-        for each in sessionBoundData {
-            try await each.clearSessionData()
+        try await self.clearSessionData(in: sessionBoundData, presentSystemLogOut: presentSystemLogOut)
+    }
+    
+    private func clearSessionData(in sessionData: [SessionBoundData], presentSystemLogOut: Bool) async throws {
+        for each in sessionData {
+            if case let walletSessionData? = each as? WalletSessionData {
+                let streamClearSessionDataWarnings = await walletSessionData.streamClearSessionDataWarnings
+                async let logWarnings = { [analyticsService = self.analyticsService] in
+                    for await warning in streamClearSessionDataWarnings {
+                        analyticsService.logCrash(warning)
+                    }
+                }()
+                
+                try await walletSessionData.clearSessionData()
+                await logWarnings
+            } else {
+                try await each.clearSessionData()
+            }
         }
-        
+
         endCurrentSession()
-        
+
         if presentSystemLogOut {
             NotificationCenter.default.post(name: .systemLogUserOut)
         }
     }
-    
+
     func registerSessionBoundData(_ data: [SessionBoundData]) {
         sessionBoundData = data
     }

--- a/Tests/UnitTests/Login/WebAuthenticationServiceTests.swift
+++ b/Tests/UnitTests/Login/WebAuthenticationServiceTests.swift
@@ -274,7 +274,7 @@ struct WebAuthenticationServiceTests {
     
     @Test
     func test_startWebSession_success() async throws {
-        let sessionManager: PersistentSessionManager = .make()
+        let sessionManager: PersistentSessionManager = try .make()
         let sut: WebAuthenticationService = await .make(sessionManager: sessionManager)
         
         await #expect(throws: Never.self) {
@@ -375,7 +375,7 @@ struct WebAuthenticationServiceTests {
     func test_errorFromAttestationJWT_onNewUser() async throws {
         let mockAnalyticsService = MockAnalyticsService()
 
-        let sessionManager: PersistentSessionManager = .make()
+        let sessionManager: PersistentSessionManager = try .make()
 
         let sut: WebAuthenticationService = await .make(
             sessionManager: sessionManager,

--- a/Tests/UnitTests/Mocks/Sessions+Services/Wallet/MockWalletSDKWrapper.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Wallet/MockWalletSDKWrapper.swift
@@ -1,9 +1,22 @@
 @testable import OneLogin
 import Wallet
+import WalletStore
 
 final class MockWalletSDKWrapper: WalletServiceProtocol {
+    typealias DeleteAsFunction = () async throws(WalletStoreError) -> [WalletStoreError]
+
+    var deleteAsFunction: DeleteAsFunction
+
     var isEmpty: Bool = true
-    
+
+    init(deleteAsFunction: @escaping DeleteAsFunction = { return [] }) {
+        self.deleteAsFunction = deleteAsFunction
+    }
+
+    func delete() async throws(WalletStoreError) -> [WalletStoreError] {
+        try await self.deleteAsFunction()
+    }
+
     func isEmpty() async -> Bool {
         return isEmpty
     }

--- a/Tests/UnitTests/Service/WalletSessionDataTests.swift
+++ b/Tests/UnitTests/Service/WalletSessionDataTests.swift
@@ -1,0 +1,271 @@
+@testable import OneLogin
+import Testing
+import WalletStore
+
+struct WalletSessionDataTests {
+    
+    @Test func assertWalletUnsafeStateThrown() async throws {
+        func deleteThrowsWalletUnsafeState() async throws(WalletStoreError) -> [WalletStoreError] {
+            throw WalletStoreError(.walletUnsafeState)
+        }
+        
+        let mockWalletSDK = MockWalletSDKWrapper(deleteAsFunction: deleteThrowsWalletUnsafeState)
+        
+        let walletSessionData = WalletSessionData(walletSDK: mockWalletSDK)
+        
+        let error = await #expect(throws: WalletStoreError.self) {
+            try await walletSessionData.clearSessionData()
+        }
+        
+        #expect(error?.kind == .walletUnsafeState)
+    }
+    
+    @Test func assertErrorsNotThrown() async throws {
+        func deleteReturnsErrors() async throws(WalletStoreError) -> [WalletStoreError] {
+            let anyOtherThanWalletUnsafeStateErrors = [
+                WalletStoreError(.updateDocumentExpiryDate),
+                WalletStoreError(.updateValid)
+            ]
+            
+            return anyOtherThanWalletUnsafeStateErrors
+        }
+        
+        let mockWalletSDK = MockWalletSDKWrapper(deleteAsFunction: deleteReturnsErrors)
+        
+        let walletSessionData = WalletSessionData(walletSDK: mockWalletSDK)
+        
+        await #expect(throws: Never.self) {
+            try await walletSessionData.clearSessionData()
+        }
+    }
+    
+    @Test func assertWarningsStream() async throws {
+        let first: WalletStoreError = WalletStoreError(.updateDocumentExpiryDate)
+        let second: WalletStoreError = WalletStoreError(.updateValid)
+        
+        func deleteReturnsErrors() async throws(WalletStoreError) -> [WalletStoreError] {
+            let anyOtherThanWalletUnsafeStateErrors = [
+                first,
+                second
+            ]
+            
+            return anyOtherThanWalletUnsafeStateErrors
+        }
+        
+        let mockWalletSDK = MockWalletSDKWrapper(deleteAsFunction: deleteReturnsErrors)
+        
+        let walletSessionData = WalletSessionData(walletSDK: mockWalletSDK)
+        var warningsStream = await walletSessionData.streamClearSessionDataWarnings.makeAsyncIterator()
+        
+        try await walletSessionData.clearSessionData()
+        
+        #expect(await warningsStream.next() == first)
+        #expect(await warningsStream.next() == second)
+    }
+    
+    @Test func assertNoWarningsStream() async throws {
+        func deleteNoErrors() async throws(WalletStoreError) -> [WalletStoreError] {
+            return []
+        }
+        
+        let mockWalletSDK = MockWalletSDKWrapper(deleteAsFunction: deleteNoErrors)
+        
+        let walletSessionData = WalletSessionData(walletSDK: mockWalletSDK)
+        var warningsStream = await walletSessionData.streamClearSessionDataWarnings.makeAsyncIterator()
+        
+        try await walletSessionData.clearSessionData()
+        
+        #expect(await warningsStream.next() == nil)
+    }
+    
+    @Test func assertWarningsStreamOnSecondSessionData() async throws {
+        let error: WalletStoreError = WalletStoreError(.updateValid)
+        
+        var called = false
+        func deleteReturnsErrors() async throws(WalletStoreError) -> [WalletStoreError] {
+            defer {
+                called = true
+            }
+            
+            if !called {
+                return []
+            } else {
+                return [error]
+            }
+        }
+        
+        let mockWalletSDK = MockWalletSDKWrapper(deleteAsFunction: deleteReturnsErrors)
+        
+        let walletSessionData = WalletSessionData(walletSDK: mockWalletSDK)
+        
+        try await walletSessionData.clearSessionData()
+        
+        var warningsStream = await walletSessionData.streamClearSessionDataWarnings.makeAsyncIterator()
+        try await walletSessionData.clearSessionData()
+    
+        #expect(await warningsStream.next() == error)
+    }
+    
+    @Test func assertWarningsStreamPerClearSessionData() async throws {
+        let one: WalletStoreError = WalletStoreError(.updateDocumentExpiryDate)
+        let another: WalletStoreError = WalletStoreError(.updateValid)
+
+        var called = false
+        func deleteReturnsErrors() async throws(WalletStoreError) -> [WalletStoreError] {
+            defer {
+                called = true
+            }
+            
+            if !called {
+                return [one]
+            } else {
+                return [another]
+            }
+        }
+        
+        let mockWalletSDK = MockWalletSDKWrapper(deleteAsFunction: deleteReturnsErrors)
+        
+        let walletSessionData = WalletSessionData(walletSDK: mockWalletSDK)
+        
+        var oneWarningsStream = await walletSessionData.streamClearSessionDataWarnings.makeAsyncIterator()
+        try await walletSessionData.clearSessionData()
+
+        #expect(await oneWarningsStream.next() == one)
+        #expect(await oneWarningsStream.next() == nil)
+
+        var anotherWarningsStream = await walletSessionData.streamClearSessionDataWarnings.makeAsyncIterator()
+        try await walletSessionData.clearSessionData()
+    
+        #expect(await anotherWarningsStream.next() == another)
+        #expect(await anotherWarningsStream.next() == nil)
+    }
+    
+    @Test func assertWarningsStreamNotMissedAfterWalletSessionDataGoesAway() async throws {
+        let error: WalletStoreError = WalletStoreError(.updateDocumentExpiryDate)
+
+        func deleteReturnsErrors() async throws(WalletStoreError) -> [WalletStoreError] {
+            let anyOtherThanWalletUnsafeStateErrors = [
+                error
+            ]
+            
+            return anyOtherThanWalletUnsafeStateErrors
+        }
+        
+        let mockWalletSDK = MockWalletSDKWrapper(deleteAsFunction: deleteReturnsErrors)
+        
+        var walletSessionData: Optional = WalletSessionData(walletSDK: mockWalletSDK)
+        var warningsStream = await walletSessionData?.streamClearSessionDataWarnings.makeAsyncIterator()
+        
+        try await walletSessionData?.clearSessionData()
+        
+        walletSessionData = nil
+        
+        #expect(await warningsStream?.next() == error)
+    }
+    
+    @Test func assertWarningsStreamAfterClearSessionDataCalledDeinit() async throws {
+        let error: WalletStoreError = WalletStoreError(.updateDocumentExpiryDate)
+
+        func deleteReturnsErrors() async throws(WalletStoreError) -> [WalletStoreError] {
+            let anyOtherThanWalletUnsafeStateErrors = [
+                error
+            ]
+            
+            return anyOtherThanWalletUnsafeStateErrors
+        }
+        
+        let mockWalletSDK = MockWalletSDKWrapper(deleteAsFunction: deleteReturnsErrors)
+        
+        var walletSessionData: Optional = WalletSessionData(walletSDK: mockWalletSDK)
+        
+        try await walletSessionData?.clearSessionData()
+        
+        var warningsStream = await walletSessionData?.streamClearSessionDataWarnings.makeAsyncIterator()
+
+        walletSessionData = nil
+        
+        #expect(await warningsStream?.next() == nil)
+    }
+    
+    @Test func assertWarningsStreamTaskCancellation() async throws {
+        let error: WalletStoreError = WalletStoreError(.updateDocumentExpiryDate)
+
+        func deleteReturnsErrors() async throws(WalletStoreError) -> [WalletStoreError] {
+            let anyOtherThanWalletUnsafeStateErrors = [
+                error
+            ]
+            
+            return anyOtherThanWalletUnsafeStateErrors
+        }
+        
+        let mockWalletSDK = MockWalletSDKWrapper(deleteAsFunction: deleteReturnsErrors)
+        
+        let walletSessionData = WalletSessionData(walletSDK: mockWalletSDK)
+        
+        let streamClearSessionDataWarnings = await walletSessionData.streamClearSessionDataWarnings
+        try await walletSessionData.clearSessionData()
+        
+        let observeWarnings = Task {
+            var warningsStream = streamClearSessionDataWarnings.makeAsyncIterator()
+            return await warningsStream.next()
+        }
+        
+        observeWarnings.cancel()
+        
+        #expect(await observeWarnings.value == error)
+    }
+    
+    @Test func assertWarningsStreamTaskCancellationOnStreamWithoutClearSessionDataCall() async throws {
+        let error: WalletStoreError = WalletStoreError(.updateDocumentExpiryDate)
+
+        func deleteReturnsErrors() async throws(WalletStoreError) -> [WalletStoreError] {
+            let anyOtherThanWalletUnsafeStateErrors = [
+                error
+            ]
+            
+            return anyOtherThanWalletUnsafeStateErrors
+        }
+        
+        let mockWalletSDK = MockWalletSDKWrapper(deleteAsFunction: deleteReturnsErrors)
+        
+        let walletSessionData = WalletSessionData(walletSDK: mockWalletSDK)
+        
+        try await walletSessionData.clearSessionData()
+        let streamClearSessionDataWarnings = await walletSessionData.streamClearSessionDataWarnings
+        
+        let observeWarnings = Task {
+            var warningsStream = streamClearSessionDataWarnings.makeAsyncIterator()
+            return await warningsStream.next()
+        }
+        
+        observeWarnings.cancel()
+        
+        #expect(await observeWarnings.value == nil)
+    }
+    
+    @Test func assertWarningsStreamUsingStructuredTask() async throws {
+        let error: WalletStoreError = WalletStoreError(.updateDocumentExpiryDate)
+
+        func deleteReturnsErrors() async throws(WalletStoreError) -> [WalletStoreError] {
+            let anyOtherThanWalletUnsafeStateErrors = [
+                error
+            ]
+            
+            return anyOtherThanWalletUnsafeStateErrors
+        }
+        
+        let mockWalletSDK = MockWalletSDKWrapper(deleteAsFunction: deleteReturnsErrors)
+        
+        let walletSessionData = WalletSessionData(walletSDK: mockWalletSDK)
+        
+        let streamClearSessionDataWarnings = await walletSessionData.streamClearSessionDataWarnings
+        try await walletSessionData.clearSessionData()
+        
+        async let observeWarnings = {
+            var warningsStream = streamClearSessionDataWarnings.makeAsyncIterator()
+            return await warningsStream.next()
+        }()
+        
+        #expect(await observeWarnings == error)
+    }
+}

--- a/Tests/UnitTests/Utilities/Session/PersistentSessionManagerXCTests.swift
+++ b/Tests/UnitTests/Utilities/Session/PersistentSessionManagerXCTests.swift
@@ -8,6 +8,7 @@ import MockNetworking
 @testable @preconcurrency import OneLogin
 import SecureStore
 import Testing
+import WalletStore
 import XCTest
 
 struct SessionBoundDataExpectation: SessionBoundData {
@@ -33,17 +34,21 @@ extension PersistentSessionManager {
                      mockUnprotectedStore: MockDefaultsStore = MockDefaultsStore(),
                      mockAnalyticsService: OneLoginAnalyticsService = MockAnalyticsService(),
                      mockWalletSDK: MockWalletSDKWrapper = MockWalletSDKWrapper(),
-                     refreshTokenExchangeManager: TokenExchangeManaging = MockRefreshTokenExchangeManager()) -> PersistentSessionManager {
+                     walletSessionData: SessionBoundData = WalletSessionData(),
+                     refreshTokenExchangeManager: TokenExchangeManaging = MockRefreshTokenExchangeManager(),
+                     analyticsPreferenceStore: (any AnalyticsPreferenceStore & SessionBoundData) = MockAnalyticsPreferenceStore()) throws -> PersistentSessionManager {
                 
-        return PersistentSessionManager(
+        return try .make(
+            accessControlEncryptedSecureStoreMigrator: mockAccessControlEncryptedStore,
             encryptedStore: mockEncryptedStore,
-            storeKeyService: SecureTokenStore(accessControlEncryptedStore: mockAccessControlEncryptedStore),
             unprotectedStore: mockUnprotectedStore,
             localAuthentication: mockLocalAuthentication,
             analyticsService: mockAnalyticsService,
             walletSDK: mockWalletSDK,
-            tokenExchangeManager: refreshTokenExchangeManager
-        )
+            walletSessionData: walletSessionData,
+            refreshTokenExchangeManager: refreshTokenExchangeManager,
+            serialTaskQueue: SerialTaskQueue(),
+            analyticsPreferenceStore: analyticsPreferenceStore)
     }
 }
 
@@ -425,7 +430,7 @@ extension PersistentSessionManagerXCTests {
         // AND the wallet is not empty
         let mockWalletSDK = MockWalletSDKWrapper()
         mockWalletSDK.isEmpty = false
-        let sut: PersistentSessionManager = .make(mockEncryptedStore: mockEncryptedStore,
+        let sut: PersistentSessionManager = try .make(mockEncryptedStore: mockEncryptedStore,
                                                   mockAnalyticsService: mockAnalyticsService,
                                                   mockWalletSDK: mockWalletSDK)
         
@@ -460,7 +465,7 @@ extension PersistentSessionManagerXCTests {
         let mockAnalyticsPrefernceStore = UserDefaultsPreferenceStore()
         mockAnalyticsPrefernceStore.hasAcceptedAnalytics = true
         
-        let sut: PersistentSessionManager = .make(mockEncryptedStore: mockEncryptedStore,
+        let sut: PersistentSessionManager = try .make(mockEncryptedStore: mockEncryptedStore,
                                                   mockUnprotectedStore: mockUnprotectedStore,
                                                   mockAnalyticsService: mockAnalyticsService,
                                                   mockWalletSDK: mockWalletSDK)
@@ -581,9 +586,15 @@ extension PersistentSessionManagerXCTests {
         )
         
         let (mockEncryptedStore, mockEncryptedStoreClearSessionData) = MockSecureStoreService.mockClearSessionDataCounter()
+        try mockEncryptedStore.saveItem(
+            item: UUID().uuidString,
+            itemName: OLString.persistentSessionID
+        )
+
         let mockUnprotectedStore = MockDefaultsStore()
+        
         // GIVEN I am a new user
-        let sut: PersistentSessionManager = .make(mockAccessControlEncryptedStore: mockAccessControlEncryptedStore,
+        let sut: PersistentSessionManager = try .make(mockAccessControlEncryptedStore: mockAccessControlEncryptedStore,
                                                   mockEncryptedStore: mockEncryptedStore,
                                                   mockUnprotectedStore: mockUnprotectedStore)
         
@@ -702,7 +713,7 @@ extension PersistentSessionManagerXCTests {
         }
         
         let refreshTokenExchangeManager = RefreshTokenExchangeManager(networkClient: client)
-        let sut: PersistentSessionManager = .make(mockAccessControlEncryptedStore: mockAccessControlEncryptedStore,
+        let sut: PersistentSessionManager = try .make(mockAccessControlEncryptedStore: mockAccessControlEncryptedStore,
                                                   mockLocalAuthentication: mockLocalAuthentication,
                                                   mockEncryptedStore: mockEncryptedStore,
                                                   mockUnprotectedStore: mockUnprotectedStore,
@@ -734,7 +745,7 @@ extension PersistentSessionManagerXCTests {
         }
         
         let refreshTokenExchangeManager = RefreshTokenExchangeManager(networkClient: client)
-        let sut: PersistentSessionManager = .make(mockAccessControlEncryptedStore: mockAccessControlEncryptedStore,
+        let sut: PersistentSessionManager = try .make(mockAccessControlEncryptedStore: mockAccessControlEncryptedStore,
                                                   mockLocalAuthentication: mockLocalAuthentication,
                                                   mockEncryptedStore: mockEncryptedStore,
                                                   mockUnprotectedStore: mockUnprotectedStore,
@@ -765,7 +776,7 @@ extension PersistentSessionManagerXCTests {
         client.dPoPProvider = mockAppIntegrityProvider
         
         let refreshTokenExchangeManager = RefreshTokenExchangeManager(networkClient: client)
-        let sut: PersistentSessionManager = .make(mockAccessControlEncryptedStore: mockAccessControlEncryptedStore,
+        let sut: PersistentSessionManager = try .make(mockAccessControlEncryptedStore: mockAccessControlEncryptedStore,
                                                   mockLocalAuthentication: mockLocalAuthentication,
                                                   mockEncryptedStore: mockEncryptedStore,
                                                   mockUnprotectedStore: mockUnprotectedStore,
@@ -921,7 +932,7 @@ extension PersistentSessionManagerXCTests {
         XCTAssertFalse(sut.isSessionValid)
         XCTAssertEqual(sut.sessionState, .expired)
         
-        let sut: PersistentSessionManager = .make(mockAccessControlEncryptedStore: mockAccessControlEncryptedStore,
+        let sut: PersistentSessionManager = try .make(mockAccessControlEncryptedStore: mockAccessControlEncryptedStore,
                                                   mockLocalAuthentication: mockLocalAuthentication,
                                                   mockEncryptedStore: mockEncryptedStore,
                                                   mockUnprotectedStore: mockUnprotectedStore,
@@ -969,7 +980,7 @@ extension PersistentSessionManagerXCTests {
 
         let mockRefreshTokenExchangeManager = MockRefreshTokenExchangeManagerGuarantor()
         
-        let sut: PersistentSessionManager = .make(mockAccessControlEncryptedStore: mockAccessControlEncryptedStore,
+        let sut: PersistentSessionManager = try .make(mockAccessControlEncryptedStore: mockAccessControlEncryptedStore,
                                                   mockLocalAuthentication: mockLocalAuthentication,
                                                   mockEncryptedStore: mockEncryptedStore,
                                                   mockUnprotectedStore: mockUnprotectedStore,
@@ -999,6 +1010,74 @@ extension PersistentSessionManagerXCTests {
 }
 
 struct PersistentSessionManagerTests {
+
+    @Test("Wallet deletion warnings are logged")
+    func clearAllSessionDataLogsWalletDeletionWarnings() async throws {
+        let warnings = [
+            WalletStoreError(.updateDocumentExpiryDate),
+            WalletStoreError(.updateValid)
+        ]
+
+        func deleteReturnsErrors() async throws(WalletStoreError) -> [WalletStoreError] {
+            return warnings
+        }
+
+        let analyticsService = MockAnalyticsService()
+        let walletSessionData = WalletSessionData(
+            walletSDK: MockWalletSDKWrapper(deleteAsFunction: deleteReturnsErrors)
+        )
+        let sut = try PersistentSessionManager.make(
+            mockAnalyticsService: analyticsService,
+            walletSessionData: walletSessionData
+        )
+
+        try await sut.clearAllSessionData(presentSystemLogOut: false)
+
+        #expect(analyticsService.crashesLogged == warnings.map { $0 as NSError })
+    }
+
+    @Test("No crash logs for no wallet deletion warnings")
+    func clearAllSessionDataWithNoWalletDeletionWarnings() async throws {
+        let analyticsService = MockAnalyticsService()
+        let walletSessionData = WalletSessionData(
+            walletSDK: MockWalletSDKWrapper(deleteAsFunction: {
+                return []
+            })
+        )
+        let sut = try PersistentSessionManager.make(
+            mockAnalyticsService: analyticsService,
+            walletSessionData: walletSessionData
+        )
+
+        try await sut.clearAllSessionData(presentSystemLogOut: false)
+
+        #expect(analyticsService.crashesLogged.isEmpty)
+    }
+
+    @Test("Critical wallet deletion error is propagated")
+    func clearAllSessionDataPropagatesCriticalWalletDeletionError() async throws {
+        let expectedError = WalletStoreError(.walletUnsafeState)
+        
+        func deleteThrowsWalletUnsafeState() async throws(WalletStoreError) -> [WalletStoreError] {
+            throw expectedError
+        }
+
+        let analyticsService = MockAnalyticsService()
+        let walletSessionData = WalletSessionData(
+            walletSDK: MockWalletSDKWrapper(deleteAsFunction: deleteThrowsWalletUnsafeState)
+        )
+        let sut = try PersistentSessionManager.make(
+            mockAnalyticsService: analyticsService,
+            walletSessionData: walletSessionData
+        )
+
+        let error = await #expect(throws: WalletStoreError.self) {
+            try await sut.clearAllSessionData(presentSystemLogOut: false)
+        }
+
+        #expect(error?.kind == expectedError.kind)
+        #expect(analyticsService.crashesLogged.isEmpty)
+    }
     
     /// GIVEN I am "a returning user" with stored tokens, who is "NOT enrolling" and "NOT authenticated" due to a `nil` `expiryDate`
     /// AND `SecureStoreService` throws `SecureStoreError(.systemCancel, originalError: LAError(.systemCancel))`


### PR DESCRIPTION
# [DCMAW-20314 adopt WalletSDK/delete](https://govukverify.atlassian.net/browse/DCMAW-20314)

This code change migrates away from the deprecated `WalletSDK/deleteData()` to the suggested `WalletSDK/delete`.

It also changes the `WalletSessionData` type so that it's possible to stream warnings emitted by the `WalletSDK/delete` and are intended to be "informational" only (e.g. logged for observability)

# Testing


https://github.com/user-attachments/assets/fa9fb62e-8a2c-4f46-9429-6452a3568809



# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
