### PR TITLE
feat: DCMAW-22079 persistent session id is missing for a returning user

### DIFF
--- a/Sources/Qualification/State/AppQualifyingService.swift
+++ b/Sources/Qualification/State/AppQualifyingService.swift
@@ -145,6 +145,18 @@ final class AppQualifyingService: QualifyingService {
             return
         }
         
+        do {
+            try await sessionManager.assertReturningUserCanLogin()
+        } catch let error as SecureStoreError where
+                    error.kind == .cantDecryptData {
+            analyticsService.logCrash(error)
+            return
+        } catch {
+            analyticsService.logCrash(error)
+            sessionState = .failed(error)
+            return
+        }
+        
         switch sessionManager.sessionState {
         case .expired:
             sessionState = .expired

--- a/Sources/Qualification/State/AppQualifyingService.swift
+++ b/Sources/Qualification/State/AppQualifyingService.swift
@@ -139,6 +139,7 @@ final class AppQualifyingService: QualifyingService {
         }
     }
     
+    // swiftlint: disable:next function_body_length
     func evaluateUserSession() async {
         guard appInfoState == .qualified else {
             // Do not continue with local auth unless app info qualifies
@@ -150,6 +151,11 @@ final class AppQualifyingService: QualifyingService {
         } catch let error as SecureStoreError where
                     error.kind == .cantDecryptData {
             analyticsService.logCrash(error)
+            return
+        } catch let error as PersistentSessionError where
+                    error.kind == .cannotDeleteData && error.isWalletUnsafeState {
+            analyticsService.logCrash(error)
+            sessionState = .notLoggedIn
             return
         } catch {
             analyticsService.logCrash(error)

--- a/Sources/Utilities/Storage/Session/PersistentSessionManager.swift
+++ b/Sources/Utilities/Storage/Session/PersistentSessionManager.swift
@@ -202,7 +202,7 @@ final class PersistentSessionManager: SessionManager {
     }
     
     /// - throws: ``PersistentSessionError(.cannotDeleteData)`` in case the user data was not succesfully deleted.
-    private func _clearAllSessionData(presentSystemLogOut: Bool = true) async throws {
+    private func clearAllSessionData() async throws {
         // I am a returning user
         // but cannot reauthenticate because I don't have a persistent session ID
         //
@@ -212,14 +212,14 @@ final class PersistentSessionManager: SessionManager {
                 analyticsService.logCrash(PersistentSessionError(.sessionMismatch,
                                                                  reason: "secure wallet data deleted"))
             }
-            try await clearAllSessionData(presentSystemLogOut: presentSystemLogOut)
+            try await clearAllSessionData(presentSystemLogOut: true)
         } catch {
             throw PersistentSessionError(.cannotDeleteData, originalError: error)
         }
     }
     
     /// - throws: ``PersistentSessionError(.cannotDeleteData)`` in case the user data was not succesfully deleted.
-    private func _clearAppForLogin() async throws {
+    private func prepareAppForLogin() async throws {
         // I am a first time user
         // I don't have a persistent session ID
         //
@@ -246,10 +246,10 @@ final class PersistentSessionManager: SessionManager {
     private func assertSession() async throws {
         if persistentID == nil {
             if isReturningUser {
-                try await _clearAllSessionData()
+                try await clearAllSessionData()
                 throw PersistentSessionError(.sessionMismatch)
             } else {
-                try await _clearAppForLogin()
+                try await prepareAppForLogin()
             }
         }
     }
@@ -269,7 +269,7 @@ final class PersistentSessionManager: SessionManager {
             
             if case .failure(let error as SecureStoreError) = persistentID, error.kind == .cantDecryptData,
                let originalError = error.originalError as? NSError, originalError.code == errSecParam {
-                try await self._clearAllSessionData()
+                try await self.clearAllSessionData()
                 throw error
             }
             

--- a/Sources/Utilities/Storage/Session/PersistentSessionManager.swift
+++ b/Sources/Utilities/Storage/Session/PersistentSessionManager.swift
@@ -201,43 +201,87 @@ final class PersistentSessionManager: SessionManager {
         (try? localAuthentication.canUseAnyLocalAuth) ?? false && isReturningUser
     }
     
+    /// - throws: ``PersistentSessionError(.cannotDeleteData)`` in case the user data was not succesfully deleted.
+    private func _clearAllSessionData(presentSystemLogOut: Bool = true) async throws {
+        // I am a returning user
+        // but cannot reauthenticate because I don't have a persistent session ID
+        //
+        // I need to delete my session & Wallet data before I can login
+        do {
+            if await !walletSDK.isEmpty() {
+                analyticsService.logCrash(PersistentSessionError(.sessionMismatch,
+                                                                 reason: "secure wallet data deleted"))
+            }
+            try await clearAllSessionData(presentSystemLogOut: presentSystemLogOut)
+        } catch {
+            throw PersistentSessionError(.cannotDeleteData, originalError: error)
+        }
+    }
+    
+    /// - throws: ``PersistentSessionError(.cannotDeleteData)`` in case the user data was not succesfully deleted.
+    private func _clearAppForLogin() async throws {
+        // I am a first time user
+        // I don't have a persistent session ID
+        //
+        // I need to delete my session (but not analytics permissions) & Wallet data before I can login
+        do {
+            if await !walletSDK.isEmpty() {
+                analyticsService.logCrash(PersistentSessionError(.noSessionExists,
+                                                                 reason: "secure wallet data deleted"))
+            }
+            try await clearAppForLogin()
+        } catch {
+            throw PersistentSessionError(.cannotDeleteData, originalError: error)
+        }
+    }
+    
+    /// Asserts that a ``persistentID`` is present and accessible for either a returning or a first time user.
+    ///
+    /// - throws: ``PersistentSessionError(.sessionMismatch)`` in case this is a returning user without a persistent session ID.
+    ///     All session data will be cleared and a ``.systemLogUserOut`` notification is posted.
+    /// - throws: ``PersistentSessionError(.cannotDeleteData)`` in case the user data was not succesfully deleted.
+    /// - Note: in case of a first time user, their "preferences" are not cleared.
+    /// - SeeAlso: ``clearAllSessionData(presentSystemLogOut:)`` for a returning user
+    /// - SeeAlso: ``clearAppForLogin()`` for a first time user
+    private func assertSession() async throws {
+        if persistentID == nil {
+            if isReturningUser {
+                try await _clearAllSessionData()
+                throw PersistentSessionError(.sessionMismatch)
+            } else {
+                try await _clearAppForLogin()
+            }
+        }
+    }
+    
+    private var assertReturningUserCanLoginEvaluated = false
+    
+    public func assertReturningUserCanLogin() async throws {
+        try await self.serialTaskQueue.enqueue {
+            guard self.isReturningUser, !self.assertReturningUserCanLoginEvaluated else {
+                return
+            }
+            
+            let persistentID = Result {
+                try self.encryptedStore
+                    .readItem(itemName: OLString.persistentSessionID)
+            }
+            
+            if case .failure(let error as SecureStoreError) = persistentID, error.kind == .cantDecryptData,
+               let originalError = error.originalError as? NSError, originalError.code == errSecParam {
+                try await self._clearAllSessionData()
+                throw error
+            }
+            
+            self.assertReturningUserCanLoginEvaluated = true
+        }
+    }
+    
     func startAuthSession(
         _ session: any LoginSession,
         using configuration: @Sendable (String?) async throws -> LoginSessionConfiguration
     ) async throws {
-        if persistentID == nil {
-            if isReturningUser {
-                // I am a returning user
-                // but cannot reauthenticate because I don't have a persistent session ID
-                //
-                // I need to delete my session & Wallet data before I can login
-                do {
-                    if await !walletSDK.isEmpty() {
-                        analyticsService.logCrash(PersistentSessionError(.sessionMismatch,
-                                                                         reason: "secure wallet data deleted"))
-                    }
-                    try await clearAllSessionData(presentSystemLogOut: true)
-                } catch {
-                    throw PersistentSessionError(.cannotDeleteData, originalError: error)
-                }
-                
-                throw PersistentSessionError(.sessionMismatch)
-            } else {
-                // I am a first time user
-                // I don't have a persistent session ID
-                //
-                // I need to delete my session (but not analytics permissions) & Wallet data before I can login
-                do {
-                    if await !walletSDK.isEmpty() {
-                        analyticsService.logCrash(PersistentSessionError(.noSessionExists,
-                                                                         reason: "secure wallet data deleted"))
-                    }
-                    try await clearAppForLogin()
-                } catch {
-                    throw PersistentSessionError(.cannotDeleteData, originalError: error)
-                }
-            }
-        }
+        try await assertSession()
         
         let response = try await session.performLoginFlow(
             configuration: configuration(persistentID)

--- a/Sources/Utilities/Storage/Session/PersistentSessionManager.swift
+++ b/Sources/Utilities/Storage/Session/PersistentSessionManager.swift
@@ -7,6 +7,7 @@ import GDSUtilities
 import LocalAuthenticationWrapper
 import Logging
 import SecureStore
+import WalletStore
 
 // swiftlint:disable:next type_body_length
 final class PersistentSessionManager: SessionManager {
@@ -486,6 +487,13 @@ public enum PersistentSessionErrorKind: Int, GDSErrorKind {
 }
 
 public typealias PersistentSessionError = OneLoginGDSError<PersistentSessionErrorKind>
+
+extension PersistentSessionError {
+    /// Returns true in case the underlying error is ``WalletStoreError(.walletUnsafeState)``.
+    var isWalletUnsafeState: Bool {
+        (originalError as? WalletStoreError)?.kind == .walletUnsafeState
+    }
+}
 
 protocol SessionBoundData {
     func clearSessionData() async throws

--- a/Sources/Utilities/Storage/Session/SessionManager.swift
+++ b/Sources/Utilities/Storage/Session/SessionManager.swift
@@ -55,4 +55,24 @@ protocol SessionManager: AnyObject, UserProvider {
     
     /// Completely removes all user session data (including the persistent session and Wallet data) except analytics preferences
     func clearAppForLogin() async throws
+    
+    /// Asserts that, for a returning user, the ``persistentID`` is accessible.
+    ///
+    /// In case the ``persistentID`` is not accessible (e.g. cannot be decrypted), then all session data
+    /// will be deleted for the user, a ``SecureStoreError(.cantDecryptData)`` is thrown and a
+    /// ``systemLogUserOut`` notification is posted.
+    ///
+    /// - Note: The assertion is evaluated once per ``SessionManager`` instance.
+    /// Any subsequent calls are effectively no-op. You need to create a ``SessionManager`` instance in order
+    /// to evaluate the assertion again.
+    /// - Postcondition: In case the assertion was evaluated succesfully, a follow-up call will not attempt
+    /// to evaluate it again.
+    /// - throws: ``SecureStoreError(.cantDecryptData)`` in case the ``persistentID`` was not accessible.
+    /// - throws: ``PersistentSessionError(.cannotDeleteData)`` in case the user data was not succesfully deleted.
+    /// - Remark: Since the ``SessionManager`` protocol does not constrain an implementation to an actor,
+    /// it is the responsibility of each implementation to communicate its concurrency requirements in order to meet
+    /// the postcondition.
+    /// - SeeAlso: ``clearAllSessionData(presentSystemLogOut:)``
+    ///
+    func assertReturningUserCanLogin() async throws
 }

--- a/Tests/UnitTests/Login/WebAuthenticationServiceTests.swift
+++ b/Tests/UnitTests/Login/WebAuthenticationServiceTests.swift
@@ -404,6 +404,42 @@ struct WebAuthenticationServiceTests {
 }
 
 struct WalletSessionBoundDataStub: SessionBoundData {
+    
+    final class UserSessionData {
+        fileprivate var storage: [AnyHashable: Sendable]
+        
+        var isEmpty: Bool {
+            self.storage.isEmpty
+        }
+
+        init(storage: [AnyHashable: Sendable] = [:]) {
+            self.storage = storage
+        }
+        
+        subscript(key: AnyHashable) -> Sendable? {
+            get {
+                storage[key]
+            }
+            set {
+                storage[key] = newValue
+            }
+        }
+    }
+
+    static func stubWalletData(_ walletData: [AnyHashable: Sendable]) -> (mockWalletSessionBound: WalletSessionBoundDataStub, walletData: UserSessionData) {
+        let walletData = UserSessionData(storage: walletData)
+        
+        return (mockWalletSessionBound: WalletSessionBoundDataStub(
+            clearSessionDataAsFunction: clearSessionData(walletData: walletData)),
+                walletData: walletData)
+    }
+    
+    static func clearSessionData(walletData: UserSessionData) -> ClearSessionDataAsFunction {
+        return {
+            walletData.storage = [:]
+        }
+    }
+
     typealias ClearSessionDataAsFunction = () async throws -> Void
     
     var clearSessionDataAsFunction: ClearSessionDataAsFunction = { }

--- a/Tests/UnitTests/Mocks/Sessions+Services/Analytics/MockAnalyticsPreferenceStore.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Analytics/MockAnalyticsPreferenceStore.swift
@@ -11,5 +11,7 @@ final class MockAnalyticsPreferenceStore: AnalyticsPreferenceStore, SessionBound
         }
     }
     
-    func clearSessionData() async throws {}
+    func clearSessionData() async throws {
+        hasAcceptedAnalytics = false
+    }
 }

--- a/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockDefaultsStore.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockDefaultsStore.swift
@@ -2,6 +2,19 @@ import Foundation
 @testable import OneLogin
 
 class MockDefaultsStore: DefaultsStoring, SessionBoundData {
+    
+    static func firstTimeUser() -> MockDefaultsStore {
+        let unprotectedStore = MockDefaultsStore()
+        unprotectedStore.set(false, forKey: OLString.returningUser)
+        return unprotectedStore
+    }
+
+    static func returningUser() -> MockDefaultsStore {
+        let unprotectedStore = MockDefaultsStore()
+        unprotectedStore.set(true, forKey: OLString.returningUser)
+        return unprotectedStore
+    }
+    
     var savedData = [String: Any]()
     
     func set(_ value: Any?, forKey defaultName: String) {

--- a/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockSecureStoreService.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockSecureStoreService.swift
@@ -10,7 +10,7 @@ final class MockSecureStoreService: SecureStorable, SessionBoundData {
         var count = 0
         
         func increment() {
-            self.count = +1
+            self.count += 1
         }
         
         /// Returns true if a function has been called at least once
@@ -52,7 +52,15 @@ final class MockSecureStoreService: SecureStorable, SessionBoundData {
             clearSessionDataAsFunction: clearSessionDataCount(counter: clearSessionDataCounter)), clearSessionDataCounter)
     }
 
-    /// Returns a Mock and a counter than can be used to assert the ``SecureStorable/delete`` has been called
+    /// Returns a Mock and a counter that can be used to assert how many times ``SecureStorable/readItem(itemName:)`` was called.
+    static func mockReadItemCounter() -> (mockSecureStoreService: MockSecureStoreService, readItemCounter: Counter) {
+        let readItemCounter = Counter()
+
+        return (MockSecureStoreService(
+            readItemAsFunction: readItemCount(counter: readItemCounter)), readItemCounter)
+    }
+
+    /// Returns a Mock and a counter than can be used to assert how many times the ``SecureStorable/delete`` was called
     static func mockDeleteCounter() -> (mockSecureStoreService: MockSecureStoreService, deleteCounter: Counter) {
         let deleteCounter = Counter()
         
@@ -80,6 +88,13 @@ final class MockSecureStoreService: SecureStorable, SessionBoundData {
         // swiftlint:enable redundant_void_return
         
         return saveItemAsFunction
+    }
+
+    static func readItemCount(counter: Counter) -> ReadItemAsFunction {
+        return { _ in
+            counter.increment()
+            return ""
+        }
     }
 
     static func deleteCount(counter: Counter) -> DeleteAsFunction {

--- a/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockSessionManager.swift
+++ b/Tests/UnitTests/Mocks/Sessions+Services/Storage/MockSessionManager.swift
@@ -27,6 +27,7 @@ final class MockSessionManager: SessionManager {
     var didCallEndCurrentSession = false
     var didCallClearAllSessionData = false
     var didCallClearAppForLogin = false
+    var didAssertReturningUserCanLogin = false
 
     var errorFromStartSession: Error?
     var errorFromSaveSession: Error?
@@ -34,6 +35,7 @@ final class MockSessionManager: SessionManager {
     var errorFromResumeSession: Error?
     var errorFromClearAllSessionData: Error?
     var errorFromClearAppForLogin: Error?
+    var errorFromAssertReturningUserCanLogin: Error?
 
     var localAuthentication: LocalAuthManaging = MockLocalAuthManager()
 
@@ -129,6 +131,15 @@ final class MockSessionManager: SessionManager {
         user.send(MockUser())
         isReturningUser = returningUser
         expiryDate = expired ? .distantPast : .distantFuture
+    }
+    
+    func assertReturningUserCanLogin() async throws {
+        defer {
+            didAssertReturningUserCanLogin = true
+        }
+        if let errorFromAssertReturningUserCanLogin {
+            throw errorFromAssertReturningUserCanLogin
+        }
     }
 }
 
@@ -236,6 +247,10 @@ class MockSessionManagerExpectation: SessionManager {
     func clearAppForLogin() async throws {
         try await sessionManager.clearAppForLogin()
     }
+    
+    func assertReturningUserCanLogin() async throws {
+        try await sessionManager.assertReturningUserCanLogin()
+    }
 }
 
 /// A mock that emulates the fact that ``sessionState`` can change over time similar to the implementation of
@@ -309,4 +324,6 @@ final class MockResumeSessionSessionManager: SessionManager {
     func clearAllSessionData(presentSystemLogOut: Bool) async throws { }
 
     func clearAppForLogin() async throws { }
+    
+    func assertReturningUserCanLogin() async throws { }
 }

--- a/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
+++ b/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
@@ -5,6 +5,8 @@ import MobilePlatformServices
 import Networking
 @testable import OneLogin
 import SecureStore
+import Testing
+import WalletStore
 import XCTest
 
 extension AppQualifyingService {
@@ -21,7 +23,7 @@ extension AppQualifyingService {
 
 // MARK: - App Info Requests
 @MainActor
-final class AppQualifyingServiceTests: XCTestCase {
+final class AppQualifyingServiceXCTests: XCTestCase {
     
     func test_appInfoIsRequested() {
         let expectation = expectation(description: #function)
@@ -130,9 +132,198 @@ final class AppQualifyingServiceTests: XCTestCase {
     }
 }
 
-// MARK: - User State Evaluation
-extension AppQualifyingServiceTests {
+@MainActor
+struct AppQualifyingServiceTests {
     
+    @Test(
+        """
+        ON THE CONDITION a call to SessionManager/assertReturningUserCanLogin
+            throws a SecureStoreError(.cantDecryptData)
+        GIVEN an AppQualifyingService with an `.expired` session state
+        WHEN the call to `AppQualifyingService/initiate` is finished
+        THEN SessionManager/assertReturningUserCanLogin is called
+        AND the session state remains `.expired`
+        """
+    )
+    func assertReturningUserCanLoginIsCalledAndStopsSessionEvaluation() async throws {
+        let analyticsService = MockAnalyticsService()
+        let sessionManager = MockSessionManager()
+        sessionManager.sessionState = .expired
+        sessionManager.errorFromAssertReturningUserCanLogin = SecureStoreError(.cantDecryptData)
+        let sut: AppQualifyingService = .make(
+            analyticsService: analyticsService,
+            sessionManager: sessionManager
+        )
+
+        var expectedAppSessionState: AppSessionState?
+        await confirmation(expectedCount: 0) { confirmation in
+            let delegate = MockAppQualifyingServiceDelegate(
+                didChangeSessionStateAsFunction: { sessionState in
+                    expectedAppSessionState = sessionState
+                    confirmation()
+                }
+            )
+            sut.delegate = delegate
+            sut.initiate()
+            let initiateTask = sut._initiateTask
+            await initiateTask?.value
+        }
+
+        #expect(sessionManager.didAssertReturningUserCanLogin)
+        #expect(expectedAppSessionState == nil)
+        #expect(sessionManager.sessionState == .expired)
+    }
+
+    @Test(
+        """
+        ON THE CONDITION a call to SessionManager/assertReturningUserCanLogin
+            throws a SecureStoreError(.cantDecryptData)
+        GIVEN an AppQualifyingService with an `.expired` session state
+        WHEN the call to `AppQualifyingService/initiate` is finished
+        THEN SessionManager/assertCantDecryptData is called
+        AND the session state remains `.expired`
+        """
+    )
+    func assertReturningUserCanLoginCleanupFailureSetsFailedStateAndStopsSessionEvaluation() async {
+        let cannotDeleteDataError = PersistentSessionError(.cannotDeleteData)
+        let sessionManager = MockSessionManager()
+        sessionManager.sessionState = .expired
+        sessionManager.errorFromAssertReturningUserCanLogin = cannotDeleteDataError
+        let sut: AppQualifyingService = .make(sessionManager: sessionManager)
+
+        var expectedAppSessionState: AppSessionState?
+        await confirmation { confirmation in
+            let delegate = MockAppQualifyingServiceDelegate(
+                didChangeSessionStateAsFunction: { sessionState in
+                    expectedAppSessionState = sessionState
+                    confirmation()
+                }
+            )
+            sut.delegate = delegate
+            sut.initiate()
+            let initiateTask = sut._initiateTask
+            await initiateTask?.value
+        }
+
+        #expect(sessionManager.didAssertReturningUserCanLogin)
+        #expect(!sessionManager.didCallResumeSession)
+        #expect(expectedAppSessionState == .failed(cannotDeleteDataError))
+    }
+
+    @Test(
+        """
+        ON THE CONDITION a SecureStoreService throws a SecureStoreError(.cantDecryptData)
+        AND a returning user
+        GIVEN a PersistentSessionManager
+        AND an AppQualifyingService
+        WHEN the call to `AppQualifyingService/initiate` is finished
+        THEN a SecureStoreError(.cantDecryptData) has been logged
+        AND A `systemLogUserOut` notification is posted
+        AND the session state is evaluated as `.systemLogOut`
+        """
+    )
+    func assertCrashesLoggedAndSessionStateOnSecureStoreErrorCantDecryptDataError() async throws {
+        let cantDecryptDataError = SecureStoreError(
+            .cantDecryptData,
+            originalError: NSError(domain: NSOSStatusErrorDomain, code: -50)
+        )
+        let encryptedStore = MockSecureStoreService(
+            readItemAsFunction: MockSecureStoreService.errorFromReadItem(cantDecryptDataError)
+        )
+
+        let analyticsService = MockAnalyticsService()
+        let sessionManager = try PersistentSessionManager.make(
+            mockEncryptedStore: encryptedStore,
+            mockUnprotectedStore: MockDefaultsStore.returningUser()
+        )
+        
+        let systemLogOutNotifications = NotificationCenter.default.notifications(named: .systemLogUserOut).makeAsyncIterator()
+        
+        var receivedSessionStates = [AppSessionState]()
+        
+        await confirmation { confirmation in
+            let mockAppQualifyingServiceDelegate = MockAppQualifyingServiceDelegate(didChangeSessionStateAsFunction: { sessionState in
+                receivedSessionStates.append(sessionState)
+                confirmation()
+            })
+            
+            let sut: AppQualifyingService = .make(
+                analyticsService: analyticsService,
+                sessionManager: sessionManager
+            )
+            
+            sut.delegate = mockAppQualifyingServiceDelegate
+            
+            sut.initiate()
+            let initiateTask = sut._initiateTask
+            await initiateTask?.value
+        }
+        
+        let error = try #require(analyticsService.crashesLogged.first as? SecureStoreError)
+        #expect(error.kind == .cantDecryptData)
+        
+        #expect(await systemLogOutNotifications.next() != nil)
+        #expect(receivedSessionStates == [.systemLogOut])
+    }
+    
+    @Test(
+        """
+        ON THE CONDITION a SecureStoreService throws a SecureStoreError(.cantDecryptData)
+        ON THE CONDITION a WalletSessionData throws a WalletStoreError(.walletUnsafeState)
+        AND a returning user
+        GIVEN a PersistentSessionManager
+        AND an AppQualifyingService
+        WHEN the call to `AppQualifyingService/initiate` is finished
+        THEN a PersistentSessionError(.cannotDeleteData) has been logged
+        AND the session state is evaluated as `.failed`
+        """
+    )
+    func assertCrashesLoggedAndSessionStateOnClearSessionDataError() async throws {
+        let cantDecryptDataError = SecureStoreError(
+            .cantDecryptData,
+            originalError: NSError(domain: NSOSStatusErrorDomain, code: -50)
+        )
+        let encryptedStore = MockSecureStoreService(
+            readItemAsFunction: MockSecureStoreService.errorFromReadItem(cantDecryptDataError)
+        )
+
+        let analyticsService = MockAnalyticsService()
+        let sessionManager = try PersistentSessionManager.make(
+            mockEncryptedStore: encryptedStore,
+            mockUnprotectedStore: MockDefaultsStore.returningUser(),
+            walletSessionData: WalletSessionBoundDataStub(clearSessionDataAsFunction: {
+                throw WalletStoreError(.walletUnsafeState)
+            })
+        )
+        
+        var expectedAppSessionState: AppSessionState?
+        await confirmation { confirmation in
+            let mockAppQualifyingServiceDelegate = MockAppQualifyingServiceDelegate(didChangeSessionStateAsFunction: { sessionState in
+                expectedAppSessionState = sessionState
+                confirmation()
+            })
+            
+            let sut: AppQualifyingService = .make(
+                analyticsService: analyticsService,
+                sessionManager: sessionManager
+            )
+            
+            sut.delegate = mockAppQualifyingServiceDelegate
+            
+            sut.initiate()
+            let initiateTask = sut._initiateTask
+            await initiateTask?.value
+        }
+        
+        let error = try #require(analyticsService.crashesLogged.first as? PersistentSessionError)
+        #expect(error.kind == .cannotDeleteData)
+        
+        #expect(expectedAppSessionState == .failed(PersistentSessionError(.cannotDeleteData)))
+    }
+}
+
+// MARK: - User State Evaluation
+extension AppQualifyingServiceXCTests {
     func test_oneTimeUser_userConfirmed() {
         let sessionManager = MockSessionManager()
         sessionManager.sessionState = .oneTime
@@ -392,7 +583,7 @@ extension AppQualifyingServiceTests {
         let sessionManager = MockResumeSessionSessionManager(sessionStates: sessionStates)
         let sut: AppQualifyingService = .make(sessionManager: sessionManager)
         var receivedSessionStates = [AppSessionState]()
-        let appQualifyingServiceDelegateExpectation = AppQualifyingServiceDelegateExpectation(didChangeSessionStateAsFunction: { sessionState in
+        let appQualifyingServiceDelegateExpectation = MockAppQualifyingServiceDelegate(didChangeSessionStateAsFunction: { sessionState in
             receivedSessionStates.append(sessionState)
 
             let expectedSessionStateTransitions = Array(expectedAppSessionStateTransitions.prefix(receivedSessionStates.count))
@@ -447,7 +638,7 @@ extension AppQualifyingServiceTests {
         let sessionManager = MockResumeSessionSessionManager(sessionStates: sessionStates)
         let sut: AppQualifyingService = .make(sessionManager: sessionManager)
         var receivedSessionStates = [AppSessionState]()
-        let appQualifyingServiceDelegateExpectation = AppQualifyingServiceDelegateExpectation(didChangeSessionStateAsFunction: { sessionState in
+        let appQualifyingServiceDelegateExpectation = MockAppQualifyingServiceDelegate(didChangeSessionStateAsFunction: { sessionState in
             receivedSessionStates.append(sessionState)
 
             let expectedSessionStateTransitions = Array(expectedAppSessionStateTransitions.prefix(receivedSessionStates.count))
@@ -515,7 +706,7 @@ extension AppQualifyingServiceTests {
         let sessionManager = MockResumeSessionSessionManager(sessionStates: sessionStates)
         let sut: AppQualifyingService = .make(sessionManager: sessionManager)
         var receivedSessionStates = [AppSessionState]()
-        let appQualifyingServiceDelegateExpectation = AppQualifyingServiceDelegateExpectation(didChangeSessionStateAsFunction: { sessionState in
+        let appQualifyingServiceDelegateExpectation = MockAppQualifyingServiceDelegate(didChangeSessionStateAsFunction: { sessionState in
             receivedSessionStates.append(sessionState)
 
             let expectedSessionStateTransitions = Array(expectedAppSessionStateTransitions.prefix(receivedSessionStates.count))
@@ -567,7 +758,7 @@ extension AppQualifyingServiceTests {
         appInformationStatesReceivedExpectation.assertForOverFulfill = false
         let sut: AppQualifyingService = .make(appInformationProvider: MockAppInfoAppInformationProvider(appInfoStates: appInformationStates))
         var receivedappInformationStates = [AppInformationState]()
-        let appQualifyingServiceDelegateExpectation = AppQualifyingServiceDelegateExpectation(didChangeAppInfoStateAsFunction: { appInformationState in
+        let appQualifyingServiceDelegateExpectation = MockAppQualifyingServiceDelegate(didChangeAppInfoStateAsFunction: { appInformationState in
             receivedappInformationStates.append(appInformationState)
 
             let expectedAppInformationStateTransitions = Array(appInformationStates.prefix(appInformationStates.count))
@@ -621,7 +812,7 @@ extension AppQualifyingServiceTests {
         appInformationStatesReceivedExpectation.assertForOverFulfill = false
         let sut: AppQualifyingService = .make(appInformationProvider: MockAppInfoAppInformationProvider(appInfoStates: appInformationStates))
         var receivedappInformationStates = [AppInformationState]()
-        let appQualifyingServiceDelegateExpectation = AppQualifyingServiceDelegateExpectation(didChangeAppInfoStateAsFunction: { appInformationState in
+        let appQualifyingServiceDelegateExpectation = MockAppQualifyingServiceDelegate(didChangeAppInfoStateAsFunction: { appInformationState in
             receivedappInformationStates.append(appInformationState)
 
             let expectedAppInformationStateTransitions = Array(appInformationStates.prefix(receivedappInformationStates.count))
@@ -681,7 +872,7 @@ extension AppQualifyingServiceTests {
         appInformationStatesReceivedExpectation.assertForOverFulfill = false
         let sut: AppQualifyingService = .make(appInformationProvider: MockAppInfoAppInformationProvider(appInfoStates: appInformationStates))
         var receivedappInformationStates = [AppInformationState]()
-        let appQualifyingServiceDelegateExpectation = AppQualifyingServiceDelegateExpectation(didChangeAppInfoStateAsFunction: { appInformationState in
+        let appQualifyingServiceDelegateExpectation = MockAppQualifyingServiceDelegate(didChangeAppInfoStateAsFunction: { appInformationState in
             receivedappInformationStates.append(appInformationState)
 
             let expectedAppInformationStateTransitions = Array(appInformationStates.prefix(receivedappInformationStates.count))
@@ -745,7 +936,7 @@ extension AppQualifyingServiceTests {
         sessionStatesReceivedExpectation.assertForOverFulfill = false
         let sut: AppQualifyingService = .make()
         var receivedSessionStates = [RemoteServiceState]()
-        let appQualifyingServiceDelegateExpectation = AppQualifyingServiceDelegateExpectation(didChangeServiceStateAsFunction: { sessionState in
+        let appQualifyingServiceDelegateExpectation = MockAppQualifyingServiceDelegate(didChangeServiceStateAsFunction: { sessionState in
             receivedSessionStates.append(sessionState)
 
             let expectedServiceStates = Array(serviceStates.prefix(receivedSessionStates.count))
@@ -788,7 +979,7 @@ extension AppQualifyingServiceTests {
 }
 
 // MARK: - Subscription Tests
-extension AppQualifyingServiceTests {
+extension AppQualifyingServiceXCTests {
     
     func test_enrolmentComplete_changesSessionState() {
         let appInformationProvider = MockAppInformationService()
@@ -851,7 +1042,7 @@ extension AppQualifyingServiceTests {
         var _appState: AppInformationState?
         var _sessionState: AppSessionState?
 
-        let appQualifyingServiceDelegateExpectation = AppQualifyingServiceDelegateExpectation(didChangeAppInfoStateAsFunction: { appState in
+        let appQualifyingServiceDelegateExpectation = MockAppQualifyingServiceDelegate(didChangeAppInfoStateAsFunction: { appState in
             _appState = appState
         }, didChangeSessionStateAsFunction: { sessionState in
             _sessionState = sessionState
@@ -874,7 +1065,7 @@ extension AppQualifyingServiceTests {
         var _appState: AppInformationState?
         var _sessionState: AppSessionState?
 
-        let appQualifyingServiceDelegateExpectation = AppQualifyingServiceDelegateExpectation(didChangeAppInfoStateAsFunction: { appState in
+        let appQualifyingServiceDelegateExpectation = MockAppQualifyingServiceDelegate(didChangeAppInfoStateAsFunction: { appState in
             _appState = appState
             expectation.fulfill()
         }, didChangeSessionStateAsFunction: { sessionState in
@@ -891,7 +1082,7 @@ extension AppQualifyingServiceTests {
 }
 
 @MainActor
-class AppQualifyingServiceDelegateExpectation: AppQualifyingServiceDelegate {
+class MockAppQualifyingServiceDelegate: AppQualifyingServiceDelegate {
     
     typealias DidChangeAppInfoState = (AppInformationState) -> Void
     typealias DidChangeSessionState = (AppSessionState) -> Void

--- a/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
+++ b/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
@@ -408,7 +408,7 @@ extension AppQualifyingServiceXCTests {
         XCTAssertEqual(sessionState, .appIntegrityCheckFailed)
     }
     
-    func test_resumeSession_accountIntervention() throws {
+    func test_resumeSession_accountIntervention() async throws {
         let analyticsService = MockAnalyticsService()
         let sessionManager = MockSessionManager()
         sessionManager.expiryDate = .distantFuture
@@ -416,14 +416,13 @@ extension AppQualifyingServiceXCTests {
         sessionManager.errorFromResumeSession = ServerError(endpoint: "test", errorCode: 400)
         let sut: AppQualifyingService = .make(analyticsService: analyticsService, sessionManager: sessionManager)
         
-        let (_, sessionState) = waitForAppInfoStateChange(sut: sut, when: { sut in
-            sut.initiate()
-        })
+        sut.initiate()
+        await sut._initiateTask?.value
         
         // THEN the original session state is maintained
         let error = try XCTUnwrap(analyticsService.crashesLogged.first as? ServerError)
         XCTAssert(error.errorCode == 400)
-        XCTAssertNil(sessionState)
+        XCTAssert(sessionManager.sessionState == .saved)
     }
     
     func test_resumeSession_secureStoreError_cantDecryptData() {
@@ -462,22 +461,7 @@ extension AppQualifyingServiceXCTests {
         XCTAssertFalse(sessionManager.didCallClearAllSessionData)
         XCTAssertEqual(sessionState, .localAuthCancelled)
     }
-    
-    func test_resumeSession_secureStoreError_keepsSessionData() {
-        let sessionManager = MockSessionManager()
-        sessionManager.expiryDate = .distantFuture
-        sessionManager.sessionState = .saved
-        sessionManager.errorFromResumeSession = SecureStoreError(.cantDecryptData)
-        let sut: AppQualifyingService = .make(sessionManager: sessionManager)
         
-        let (appState, sessionState) = waitForAppInfoStateChange(sut: sut, when: { sut in
-            sut.initiate()
-        })
-        
-        XCTAssertEqual(appState, .qualified)
-        XCTAssertNotEqual(sessionState, .failed(MockWalletError.cantDelete))
-    }
-    
     func test_resumeSession_userRemovedLocalAuth_clearSessionData() {
         let analyticsService = MockAnalyticsService()
         

--- a/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
+++ b/Tests/UnitTests/Qualification/AppQualifyingServiceTests.swift
@@ -181,7 +181,7 @@ struct AppQualifyingServiceTests {
         GIVEN an AppQualifyingService with an `.expired` session state
         WHEN the call to `AppQualifyingService/initiate` is finished
         THEN SessionManager/assertCantDecryptData is called
-        AND the session state remains `.expired`
+        AND the session state is `.failed`
         """
     )
     func assertReturningUserCanLoginCleanupFailureSetsFailedStateAndStopsSessionEvaluation() async {
@@ -208,6 +208,44 @@ struct AppQualifyingServiceTests {
         #expect(sessionManager.didAssertReturningUserCanLogin)
         #expect(!sessionManager.didCallResumeSession)
         #expect(expectedAppSessionState == .failed(cannotDeleteDataError))
+    }
+    
+    @Test(
+        """
+        ON THE CONDITION a call to SessionManager/assertReturningUserCanLogin
+            throws a SecureStoreError(.cantDecryptData)
+        AND `originalError` is WalletStoreError(.walletUnsafeState)
+        GIVEN an AppQualifyingService with an `.expired` session state
+        WHEN the call to `AppQualifyingService/initiate` is finished
+        THEN SessionManager/assertCantDecryptData is called
+        AND the session state is `.notLoggedIn`
+        """
+    )
+    func assertReturningUserCanLoginCleanupFailureSetsSystemLogoutStateAndStopsSessionEvaluation() async {
+        let walletSessionDataClearSessionDataError = WalletStoreError(.walletUnsafeState)
+        let cannotDeleteDataError = PersistentSessionError(.cannotDeleteData, originalError: walletSessionDataClearSessionDataError)
+        let sessionManager = MockSessionManager()
+        sessionManager.sessionState = .expired
+        sessionManager.errorFromAssertReturningUserCanLogin = cannotDeleteDataError
+        let sut: AppQualifyingService = .make(sessionManager: sessionManager)
+
+        var expectedAppSessionState: AppSessionState?
+        await confirmation { confirmation in
+            let delegate = MockAppQualifyingServiceDelegate(
+                didChangeSessionStateAsFunction: { sessionState in
+                    expectedAppSessionState = sessionState
+                    confirmation()
+                }
+            )
+            sut.delegate = delegate
+            sut.initiate()
+            let initiateTask = sut._initiateTask
+            await initiateTask?.value
+        }
+
+        #expect(sessionManager.didAssertReturningUserCanLogin)
+        #expect(!sessionManager.didCallResumeSession)
+        #expect(expectedAppSessionState == .notLoggedIn)
     }
 
     @Test(
@@ -275,7 +313,7 @@ struct AppQualifyingServiceTests {
         AND an AppQualifyingService
         WHEN the call to `AppQualifyingService/initiate` is finished
         THEN a PersistentSessionError(.cannotDeleteData) has been logged
-        AND the session state is evaluated as `.failed`
+        AND the session state is evaluated as `.notLoggedIn`
         """
     )
     func assertCrashesLoggedAndSessionStateOnClearSessionDataError() async throws {
@@ -318,7 +356,7 @@ struct AppQualifyingServiceTests {
         let error = try #require(analyticsService.crashesLogged.first as? PersistentSessionError)
         #expect(error.kind == .cannotDeleteData)
         
-        #expect(expectedAppSessionState == .failed(PersistentSessionError(.cannotDeleteData)))
+        #expect(expectedAppSessionState == .notLoggedIn)
     }
 }
 

--- a/Tests/UnitTests/Utilities/Session/PersistentSessionErrorTests.swift
+++ b/Tests/UnitTests/Utilities/Session/PersistentSessionErrorTests.swift
@@ -1,5 +1,6 @@
 @testable import OneLogin
 import Testing
+import WalletStore
 
 struct PersistentSessionErrorTests {
     
@@ -31,6 +32,20 @@ struct PersistentSessionErrorTests {
     @Test("assert kind", arguments: PersistentSessionErrorTests.allPersistentSessionError)
     func test_kind(testCase: Case) async throws {
         #expect(testCase.error.errorUserInfo["kind"] as? String == testCase.kind)
+    }
+
+    @Test
+    func isWalletUnsafeState() {
+        let error = PersistentSessionError(.cannotDeleteData,
+                                           originalError: WalletStoreError(.walletUnsafeState))
+        #expect(error.isWalletUnsafeState)
+    }
+
+    @Test
+    func noOriginalErrorIsNotWalletUnsafeState() {
+        let cannotDeleteDataError = PersistentSessionError(.cannotDeleteData)
+
+        #expect(!cannotDeleteDataError.isWalletUnsafeState)
     }
 
 }

--- a/Tests/UnitTests/Utilities/Session/PersistentSessionManagerXCTests.swift
+++ b/Tests/UnitTests/Utilities/Session/PersistentSessionManagerXCTests.swift
@@ -7,6 +7,7 @@ import MockNetworking
 @testable import Networking
 @testable @preconcurrency import OneLogin
 import SecureStore
+import Security
 import Testing
 import WalletStore
 import XCTest
@@ -1010,6 +1011,88 @@ extension PersistentSessionManagerXCTests {
 }
 
 struct PersistentSessionManagerTests {
+
+    @Test(
+        """
+        ON THE CONDITION a SecureStoreService throws a SecureStoreError(.cantDecryptData)
+        AND a returning user
+        GIVEN a PersistentSessionManager
+        WHEN calling `assertReturningUserCanLogin()`
+        THEN a SecureStoreError(.cantDecryptData) is thrown
+        AND the user session data is cleared
+        AND a `.systemLogUserOut` notification has been posted
+        """
+    )
+    func assertReturningUserCanLoginClearsReturningUserAndThrowsOriginalError() async throws {
+        let cantDecryptDataError = SecureStoreError(
+            .cantDecryptData,
+            originalError: NSError(domain: NSOSStatusErrorDomain, code: -50)
+        )
+        let encryptedStore = MockSecureStoreService(
+            readItemAsFunction: MockSecureStoreService.errorFromReadItem(cantDecryptDataError)
+        )
+        let systemLogOutNotifications = NotificationCenter.default.notifications(named: .systemLogUserOut)
+        let systemLogOutIterator = systemLogOutNotifications.makeAsyncIterator()
+        
+        let mockUnprotectedStore = MockDefaultsStore.returningUser()
+        let mockAnalyticsPreferenceStore = MockAnalyticsPreferenceStore()
+        let (mockWalletSessionBound, walletData) = WalletSessionBoundDataStub.stubWalletData(["any": "value"])
+        mockAnalyticsPreferenceStore.hasAcceptedAnalytics = true
+        let sut = try PersistentSessionManager.make(
+            mockEncryptedStore: encryptedStore,
+            mockUnprotectedStore: mockUnprotectedStore,
+            walletSessionData: mockWalletSessionBound,
+            analyticsPreferenceStore: mockAnalyticsPreferenceStore
+        )
+
+        let error = await #expect(throws: SecureStoreError.self) {
+            try await sut.assertReturningUserCanLogin()
+        }
+
+        #expect(error?.kind == .cantDecryptData)
+
+        #expect(encryptedStore.savedItems.isEmpty)
+        #expect(mockUnprotectedStore.savedData.isEmpty)
+        #expect(walletData.isEmpty)
+        #expect(mockAnalyticsPreferenceStore.hasAcceptedAnalytics == false)
+        
+        #expect(!sut.isReturningUser)
+        #expect(await systemLogOutIterator.next() == Notification(name: .systemLogUserOut))
+    }
+
+    @Test
+    func assertReturningUserCanLoginIsEvaluatedOnlyOnce() async throws {
+        let (mockEncryptedStore, mockEncryptedStoreReadItem) = MockSecureStoreService.mockReadItemCounter()
+        try mockEncryptedStore.saveItem(
+            item: UUID().uuidString,
+            itemName: OLString.persistentSessionID
+        )
+        
+        let sut = try PersistentSessionManager.make(
+            mockEncryptedStore: mockEncryptedStore,
+            mockUnprotectedStore: MockDefaultsStore.returningUser()
+        )
+
+        try await sut.assertReturningUserCanLogin()
+        try await sut.assertReturningUserCanLogin()
+
+        #expect(mockEncryptedStoreReadItem.count == 1)
+    }
+
+    @Test
+    func assertfirstTimeUserDoesNotReadEncryptedStore() async throws {
+        let (mockEncryptedStore, mockEncryptedStoreReadItem) = MockSecureStoreService.mockReadItemCounter()
+        
+        let mockUnprotectedStore = MockDefaultsStore.firstTimeUser()
+        let sut = try PersistentSessionManager.make(
+            mockEncryptedStore: mockEncryptedStore,
+            mockUnprotectedStore: mockUnprotectedStore
+        )
+
+        try await sut.assertReturningUserCanLogin()
+
+        #expect(!mockEncryptedStoreReadItem.called())
+    }
 
     @Test("Wallet deletion warnings are logged")
     func clearAllSessionDataLogsWalletDeletionWarnings() async throws {


### PR DESCRIPTION
# [iOS | Tech Debt | SecureStoreError(.cantDecryptData) | NSOStatusErrorDomain (-50) | PersistentSessionID is missing for a returning user](https://govukverify.atlassian.net/browse/DCMAW-22079)

  This is case where attempting to start an auth session, throws a `PersistentSessionError(.sessionMismatch)` error.
  In this case, the user has restored from a backup and the `persistentID` is not accessible (e.g. cannot be decrypted)
  due to the fact that the private key backed by the SE is not exportable.

  This code change adds an assertion to verify that a returning user can indeed login,
  without encountering a `PersistentSessionError(.sessionMismatch)` **in case they have restored from a backup**.
  The `PersistentSessionError(.sessionMismatch)` may still be thrown in other cases[1].

  In case the assertion fails, due to a `SecureStoreError(.cantDecryptData)` error,
  all of user data is deleted and the user is presented with the login screen as normal, which is expected to succeed.

  In case the assertion fails due to any other error, the session is considered to have failed.

  The assertion happens while the loading screen is shown, before attempting to evaluate the
  user session so that the user is either shown the login or an unrecoverable screen in case an error is thrown.

  [1]: At this moment, there are no other known cases. The `PersistentSessionError(.sessionMismatch)`
  aka `PersistentSessionErrorKind (1003)` has been [seen in our logs in the thousands](https://console.firebase.google.com/project/mobile-one-login-prod/crashlytics/app/ios:uk.gov.onelogin/issues/338a4fb1d5b8d1951e3cb2abf61e2bbd?time=90d&sessionEventKey=d2f8c23e103945fda177a843791c802d_2259759493317190388).
  This code change aims to draw a distinction between a “legitimate” `PersistentSessionError(.sessionMismatch)`
  which may indicate a programmatic error and a `PersistentSessionError(.sessionMismatch)` due to a `SecureStoreError(.cantDecryptData)` error (e.g. [as seen on staging](https://console.firebase.google.com/project/mobile-one-login-staging/crashlytics/app/ios:uk.gov.onelogin.staging/issues/5843b557308416b1e186ba18b1556b59?time=7d&sessionEventKey=9ceb4799bb4f45799e65e1d46ea0f591_2259808495129907350) while testing the change in this PR).

# Changes


## Product

**In case of a restore**
Previously, once a returning user has restored from a backup, two scenarios were possible:

## Before

<img width="304" height="596" alt="before" src="https://github.com/user-attachments/assets/f9f72713-8120-40de-930c-22e070e60523" />


1. The access token has expired. In which case the user would be asked to sign in again. This attempts to [clear all user data](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.29.0/Sources/Utilities/Storage/Session/PersistentSessionManager.swift#L218) and [it throws a](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.29.0/Sources/Utilities/Storage/Session/PersistentSessionManager.swift#L223) `PersistentSessionError(.sessionMismatch)`. The `PersistentSessionError` [is handled](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/develop/Sources/Login/LoginCoordinator.swift#L99), by showing a [data delete warning screen](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/develop/Sources/Login/LoginCoordinator.swift#L231), allowing the user to login again.

<img width="304" height="596" alt="login before" src="https://github.com/user-attachments/assets/4b03a430-b4f2-4d0e-8935-6931b45f9302" />


https://github.com/user-attachments/assets/24eb5bd9-b2db-4b07-ba18-598a83b66362


2. The access token is valid. In which case the user would be asked to resume their session. Since `persistentId` is inaccessible, a `PersistentSessionError(.noSessionExists)` [is thrown](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.29.0/Sources/Utilities/Storage/Session/PersistentSessionManager.swift#L298). That attempts to [clear all the user session data](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/develop/Sources/Qualification/State/AppQualifyingService.swift#L189). A `.systemLogOut` notification is posted, which [publishes an update to the sessionState](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/develop/Sources/Qualification/State/AppQualifyingService.swift#L239), [which displays the login coordinator](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/develop/Sources/Qualification/QualifyingCoordinator.swift#L101) which [already exists](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/develop/Sources/Qualification/QualifyingCoordinator.swift#L134) hence it displays its "root", without the data deleted warning screen, which is the "You need to sign in again" screen.

<img width="283" height="574" alt="resume before" src="https://github.com/user-attachments/assets/641d01d6-c13f-459e-902b-3d762b3160c7" />

https://github.com/user-attachments/assets/91e3a69e-67c5-4a53-af8e-4b8df619194d

With these changes, before attempting to evaluate the session, [a call is made to assertReturningUserCanLogin](https://github.com/govuk-one-login/mobile-ios-one-login-app/pull/914/changes#diff-2b8361fc4b906f97e8fc9aed97a2b0f429b06eccfaf9ea47a6c33fbb7adb0a91R149). [In case the data cannot be decrypted](https://github.com/govuk-one-login/mobile-ios-one-login-app/pull/914/changes#diff-d9e901b931fb93a0c3733e4284970bf1a470ddf02ad8e7985adf02e7cbd03299R270), the user session data is deleted and the `SecureStoreError(.cantDecryptData)` error [is thrown](https://github.com/govuk-one-login/mobile-ios-one-login-app/pull/914/changes#diff-d9e901b931fb93a0c3733e4284970bf1a470ddf02ad8e7985adf02e7cbd03299R273). A `.systemLogOut` notification is posted, which [publishes an update to the sessionState](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/741c1b95a29466a60ec6843cede67c0907de85eb/Sources/Qualification/State/AppQualifyingService.swift#L251), [which launches the login coordinator](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/741c1b95a29466a60ec6843cede67c0907de85eb/Sources/Qualification/QualifyingCoordinator.swift#L101) and [presents the data deleted warning screen.](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/741c1b95a29466a60ec6843cede67c0907de85eb/Sources/Login/LoginCoordinator.swift#L158).

## After
<img width="304" height="596" alt="after" src="https://github.com/user-attachments/assets/ef4d0046-9b7a-4b43-8556-92209ac079f3" />

https://github.com/user-attachments/assets/1361c6f8-15b6-4a9a-88c3-3b8ecaad1b76

# Do not merge

This PR depends on:
* https://github.com/govuk-one-login/mobile-ios-one-login-app/pull/912

# Testing

https://github.com/user-attachments/assets/c47a1e6d-32a4-4307-b329-3452e7bec542


# Discussion

1. The access token has expired. In which case the user would be asked to sign in again.

Previously, [an attempt to login](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.29.0/Sources/Login/LoginCoordinator.swift#L97) that throws a `PersistentSessionError(.cannotDeleteData)` (i.e. [in case clear all session data failed](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/develop/Sources/Utilities/Storage/Session/PersistentSessionManager.swift#L221)), would show [the recoverable screen](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/1.29.0/Sources/Login/LoginCoordinator.swift#L233). This was [a case of user stuck in a login loop](https://github.com/govuk-one-login/mobile-ios-one-login-app/pull/833). In this case, this was a permanent state where the user had to delete the app to recover.

This behaviour is preserved. See https://github.com/govuk-one-login/mobile-ios-one-login-app/pull/914/changes/398682a2d1c9d2b42c4c30c088e069e96f918f5f for details.

~With this code change, that will be treated as an unrecoverable error. AFAIK, out of all the session data, calling `clearSessionData` only the `WalletSessionData` [can throw](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/feat/DCMAW-22079-persistentSessionID-is-missing-for-a-returning-user/Sources/Service/WalletSessionData%2BOneLogin.swift#L117). In case it does, [the error is considered "critical"](https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/feat/DCMAW-22079-persistentSessionID-is-missing-for-a-returning-user/Sources/Service/WalletSessionData%2BOneLogin.swift#L111). Is it safe to assume that the `PersistentSessionError(.cannotDeleteData)` is permanent/unrecoverable? If not, maintaining the existing behaviour of showing the recoverable screen, will put the user in a loop. On a **future note**, should there be a screen that lets the user know the only way to recover is to delete the app? Something to discuss with the wider team. 🤔~

<img width="304" height="596" alt="before" src="https://github.com/govuk-one-login/mobile-ios-one-login-app/blob/feat/DCMAW-22079-persistentSessionID-is-missing-for-a-returning-user/Tests/SnapshotTests/__Snapshots__/ErrorScreenSnapshotTests/test_unrecoverableLoginError.1.png?raw=true" />


# Related

* [Slack Thread](https://gds.slack.com/archives/C06UQBUJGP8/p1783681987773749?thread_ts=1783523501.298529&cid=C06UQBUJGP8)
* `PersistentSessionError(.noSessionExists)` (aka PersistentSessionErrorKind (1001) since the error code was standardised) [on Firebase, last 90 days.](https://console.firebase.google.com/project/mobile-one-login-prod/crashlytics/app/ios:uk.gov.onelogin/issues/5c252923926783abbb3598f7c33e57fc?time=90d&types=error&customKeys=kind%E2%87%92noSessionExists&sessionEventKey=a104c13135964dc891f8389fb0118dab_2260082873340820357)
* _Any_ PersistentSessionError(.noSessionExists), before the error was was standardised on [Firebase, last 90 days.](https://console.firebase.google.com/project/mobile-one-login-prod/crashlytics/app/ios:uk.gov.onelogin/issues?time=90d&state=all&tag=all&sort=eventCount&issuesQuery=key:kind%20value:OneLogin.PersistentSessionErrorKind.noSessionExists&types=error)

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
